### PR TITLE
windows: enable timelineSemaphore feature on VkDevice

### DIFF
--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -385,6 +385,12 @@ bool CreateVulkanDevice(VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
     // 64-bit atomics are optional — sort.comp uses CAS fallback when unavailable
     features12.shaderBufferInt64Atomics = supported12.shaderBufferInt64Atomics;
     features12.shaderSharedInt64Atomics = supported12.shaderSharedInt64Atomics;
+    // Required for the DisplayXR shell IPC path: the runtime imports the
+    // service's per-client cross-process workspace_sync_fence as a VK
+    // timeline semaphore so the service can ID3D11DeviceContext4::Wait on
+    // our render completion. Without this, every view ships with a stale
+    // fence value and the service skips the blit (manifest: black window).
+    features12.timelineSemaphore = supported12.timelineSemaphore;
 
     VkDeviceCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;


### PR DESCRIPTION
## Summary

Required for the DisplayXR shell IPC path. The runtime imports the service's per-client cross-process `workspace_sync_fence` as a VK timeline semaphore so the service can `ID3D11DeviceContext4::Wait` on our render completion. Without `timelineSemaphore` enabled in `features12`, the runtime's import fails and every view ships with a stale fence value — the service skips the blit and our window renders black in shell mode.

Companion to [displayxr-runtime#201](https://github.com/DisplayXR/displayxr-runtime/pull/201).

## Test plan
- [x] Build: `scripts\build-with-deps.bat`
- [x] Standalone (no shell, `DISPLAYXR_WORKSPACE_SESSION` unset) — renders correctly (regression check; existing path unchanged)
- [x] In shell (`DISPLAYXR_WORKSPACE_SESSION=1`, with companion runtime PR) — 4× gauss splat windows now render content (was black)
- [x] Mixed: 2 cubes + 2 gauss splats in shell — both APIs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)