### PR TITLE
demo: single-source-of-truth mode + XR_EXT_display_info v13 consume + HUD lock indicator

### DIFF
--- a/common/input_handler.cpp
+++ b/common/input_handler.cpp
@@ -220,11 +220,10 @@ bool UpdateInputState(InputState& state, UINT msg, WPARAM wParam, LPARAM lParam)
             state.hudVisible = !state.hudVisible;
             break;
         case 'V':
-            // Cycle through all rendering modes
-            if (state.renderingModeCount > 0) {
-                state.currentRenderingMode = (state.currentRenderingMode + 1) % state.renderingModeCount;
-            }
-            state.renderingModeChangeRequested = true;
+            // Request a cycle to the next mode. Main loop reads the runtime's
+            // current mode index (xr.currentModeIndex) to compute the target
+            // and calls xrRequestDisplayRenderingModeEXT.
+            state.cycleRenderingModeRequested = true;
             break;
         case 'I':
             // Snapshot the multi-view atlas to a PNG. Render thread
@@ -232,40 +231,31 @@ bool UpdateInputState(InputState& state, UINT msg, WPARAM wParam, LPARAM lParam)
             state.captureAtlasRequested = true;
             break;
         case '0':
-            state.currentRenderingMode = 0; // 2D mode
-            state.renderingModeChangeRequested = true;
+            state.absoluteRenderingModeRequested = 0; // 2D mode
             break;
         case '1':
-            if (state.renderingModeCount > 1) state.currentRenderingMode = 1;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 1) state.absoluteRenderingModeRequested = 1;
             break;
         case '2':
-            if (state.renderingModeCount > 2) state.currentRenderingMode = 2;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 2) state.absoluteRenderingModeRequested = 2;
             break;
         case '3':
-            if (state.renderingModeCount > 3) state.currentRenderingMode = 3;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 3) state.absoluteRenderingModeRequested = 3;
             break;
         case '4':
-            if (state.renderingModeCount > 4) state.currentRenderingMode = 4;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 4) state.absoluteRenderingModeRequested = 4;
             break;
         case '5':
-            if (state.renderingModeCount > 5) state.currentRenderingMode = 5;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 5) state.absoluteRenderingModeRequested = 5;
             break;
         case '6':
-            if (state.renderingModeCount > 6) state.currentRenderingMode = 6;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 6) state.absoluteRenderingModeRequested = 6;
             break;
         case '7':
-            if (state.renderingModeCount > 7) state.currentRenderingMode = 7;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 7) state.absoluteRenderingModeRequested = 7;
             break;
         case '8':
-            if (state.renderingModeCount > 8) state.currentRenderingMode = 8;
-            state.renderingModeChangeRequested = true;
+            if (state.renderingModeCount > 8) state.absoluteRenderingModeRequested = 8;
             break;
         case 'T':
             state.eyeTrackingModeToggleRequested = true;

--- a/common/input_handler.h
+++ b/common/input_handler.h
@@ -74,10 +74,15 @@ struct InputState {
     // HUD visibility toggle (TAB key)
     bool hudVisible = true;
 
-    // Unified rendering mode (V key cycles, 0-8 keys select directly)
-    uint32_t currentRenderingMode = 1;   // Default: mode 1 (first 3D mode)
-    uint32_t renderingModeCount = 0;     // Set from xrEnumerateDisplayRenderingModesEXT
-    bool renderingModeChangeRequested = false;
+    // Rendering mode REQUESTS (single source of truth lives on the runtime
+    // side — read back as `xr.currentModeIndex` after the runtime's
+    // XrEventDataRenderingModeChangedEXT lands). The keyboard handler emits
+    // transient requests that the main loop translates into
+    // xrRequestDisplayRenderingModeEXT calls; the actual current mode is
+    // never mirrored here.
+    uint32_t renderingModeCount = 0;            // Set from xrEnumerateDisplayRenderingModesEXT
+    bool cycleRenderingModeRequested = false;   // V key / mode button: cycle to next mode
+    int32_t absoluteRenderingModeRequested = -1; // 0-8 keys / config: jump to this mode (-1 = none)
 
     // Camera vs display mode toggle (C key)
     bool cameraMode = false;

--- a/common/text_overlay.cpp
+++ b/common/text_overlay.cpp
@@ -347,7 +347,7 @@ std::wstring FormatParallaxInfo(bool parallaxEnabled, float eyePosX, float eyePo
     return oss.str();
 }
 
-std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName, uint32_t modeCount, bool display3D) {
+std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName, uint32_t modeCount, bool display3D, bool isRequestable) {
     if (!simDisplayAvailable) {
         return L"Mode: Weaved";
     }
@@ -363,6 +363,10 @@ std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* mo
     oss << L" (" << (display3D ? L"3D" : L"2D") << L")";
     if (modeCount > 1) {
         oss << L" [1-" << modeCount << L"]";
+    }
+    // XR_EXT_display_info v13: surface workspace mode lock.
+    if (!isRequestable) {
+        oss << L" [locked by workspace]";
     }
     return oss.str();
 }

--- a/common/text_overlay.h
+++ b/common/text_overlay.h
@@ -80,7 +80,7 @@ std::wstring FormatDisplayInfo(float widthM, float heightM, float nomX, float no
 std::wstring FormatEyeTrackingInfo(const float eyePositions[][3], uint32_t eyeCount,
     bool active, bool isTracking, uint32_t activeMode, uint32_t supportedModes);
 std::wstring FormatParallaxInfo(bool parallaxEnabled, float eyePosX, float eyePosY);
-std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName = nullptr, uint32_t modeCount = 0, bool display3D = true);
+std::wstring FormatMode(int outputMode, bool simDisplayAvailable, const char* modeName = nullptr, uint32_t modeCount = 0, bool display3D = true, bool isRequestable = true);
 std::wstring FormatCameraInfo(float cameraPosX, float cameraPosY, float cameraPosZ,
     float forwardX, float forwardY, float forwardZ, bool cameraMode = false);
 std::wstring FormatViewParams(float ipdFactor, float parallaxFactor,

--- a/common/xr_session_common.h
+++ b/common/xr_session_common.h
@@ -112,8 +112,11 @@ struct XrSessionManager {
     // Canvas sub-rect (XR_EXT_win32_window_binding / XR_EXT_cocoa_window_binding)
     PFN_xrSetSharedTextureOutputRectEXT pfnSetSharedTextureOutputRectEXT = nullptr;
 
-    // Enumerated rendering mode info
-    uint32_t currentModeIndex = 1;  // Default: mode 1 (first 3D mode, matches runtime default)
+    // Enumerated rendering mode info. `currentModeIndex` is initialized to
+    // mode 1 as a fallback for runtimes that don't expose `isActive`; on
+    // runtimes with XR_EXT_display_info v13+ the enumerate step replaces
+    // this with the runtime-reported active mode (initial-mode-sync, #234).
+    uint32_t currentModeIndex = 1;
     uint32_t renderingModeCount = 0;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE] = {};
     uint32_t renderingModeViewCounts[8] = {};
@@ -122,6 +125,10 @@ struct XrSessionManager {
     float renderingModeScaleX[8] = {};
     float renderingModeScaleY[8] = {};
     bool renderingModeDisplay3D[8] = {};
+    // v13: per-mode isRequestable flag. False when this session is a
+    // non-controller workspace client (runtime drops requests). Apps use
+    // this to gate mode-toggle UI / show "Mode locked by workspace".
+    bool renderingModeIsRequestable[8] = {};
 
     // Window handle for session target (used by ext app, ignored by non-ext app)
     HWND windowHandle = nullptr;

--- a/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/openxr_includes/openxr/XR_EXT_display_info.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_display_info 1
-#define XR_EXT_display_info_SPEC_VERSION 12
+#define XR_EXT_display_info_SPEC_VERSION 13
 #define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -239,6 +239,27 @@ typedef struct XrDisplayRenderingModeInfoEXT {
     uint32_t                    tileRows;        //!< Tile rows in atlas layout (v12)
     uint32_t                    viewWidthPixels; //!< Per-view width in pixels (v12)
     uint32_t                    viewHeightPixels;//!< Per-view height in pixels (v12)
+    /*!
+     * (v13) True for the mode that is currently active for this session.
+     *
+     * Apps can read this at startup (after xrCreateSession + first
+     * xrEnumerateDisplayRenderingModesEXT call) to learn the current mode
+     * without waiting for an XrEventDataRenderingModeChangedEXT — useful
+     * when the session begins under a workspace that already chose a mode.
+     * Re-enumerating after a mode change reflects the new active mode.
+     */
+    XrBool32                    isActive;
+    /*!
+     * (v13) True iff this session may request this mode via
+     * xrRequestDisplayRenderingModeEXT.
+     *
+     * False for non-controller sessions running under a workspace — the
+     * workspace controller is the sole mode authority and app requests are
+     * dropped by the runtime. Apps can use this to gate their UI (e.g.
+     * disable the V toggle and show "Mode locked by workspace"). Always
+     * true for standalone sessions and for workspace-controller sessions.
+     */
+    XrBool32                    isRequestable;
 } XrDisplayRenderingModeInfoEXT;
 
 /*!

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -1133,7 +1133,8 @@ static void RenderThreadFunc(
                                 dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
                                     (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true,
+                                    xr->renderingModeCount > 0 ? xr->renderingModeIsRequestable[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,
@@ -1192,6 +1193,13 @@ static void RenderThreadFunc(
                                         xr->renderingModeNames[xr->currentModeIndex]) {
                                         const char* nm = xr->renderingModeNames[xr->currentModeIndex];
                                         modeLabel = L"Mode: " + std::wstring(nm, nm + strlen(nm));
+                                    }
+                                    // v13: surface workspace mode-lock so user
+                                    // knows clicking the Mode button is a no-op.
+                                    if (xr->renderingModeCount > 0 &&
+                                        xr->currentModeIndex < xr->renderingModeCount &&
+                                        !xr->renderingModeIsRequestable[xr->currentModeIndex]) {
+                                        modeLabel += L" [locked]";
                                     }
                                     buttons.push_back(toHudPx(
                                         MODE_BTN_X_FRACTION, MODE_BTN_Y_FRACTION,

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -326,11 +326,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             std::lock_guard<std::mutex> lock(g_inputMutex);
             g_inputState.leftButton = false;
             g_inputState.dragging = false;
-            if (g_inputState.renderingModeCount > 0) {
-                g_inputState.currentRenderingMode =
-                    (g_inputState.currentRenderingMode + 1) % g_inputState.renderingModeCount;
-            }
-            g_inputState.renderingModeChangeRequested = true;
+            // Mode button = cycle request (V-key equivalent). Main loop
+            // reads runtime's current mode and computes the target.
+            g_inputState.cycleRenderingModeRequested = true;
             return 0;
         }
         SetCapture(hwnd);
@@ -555,6 +553,8 @@ static void RenderThreadFunc(
         bool resetRequested = false;
         bool animateToggle = false;
         bool loadReq = false;
+        bool cycleModeRequested = false;
+        int32_t absoluteModeRequest = -1;
         uint32_t windowW, windowH;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
@@ -577,7 +577,10 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.teleportRequested = false;
             g_inputState.fullscreenToggleRequested = false;
-            g_inputState.renderingModeChangeRequested = false;
+            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            g_inputState.cycleRenderingModeRequested = false;
+            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
+            g_inputState.absoluteRenderingModeRequested = -1;
             g_inputState.eyeTrackingModeToggleRequested = false;
             if (g_inputState.transparentBgToggleRequested) {
                 g_inputState.transparentBgToggleRequested = false;
@@ -627,11 +630,17 @@ static void RenderThreadFunc(
             }
         }
 
-        // Handle rendering mode change (V=cycle, 0-8=direct)
-        if (inputSnapshot.renderingModeChangeRequested) {
-            if (xr->pfnRequestDisplayRenderingModeEXT && xr->session != XR_NULL_HANDLE) {
-                xr->pfnRequestDisplayRenderingModeEXT(xr->session, inputSnapshot.currentRenderingMode);
-            }
+        // Rendering mode requests (V/mode-button=cycle, 0-8=absolute). Single
+        // source of truth: runtime owns current mode via xr->currentModeIndex.
+        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
+            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
+        }
+        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
+            xr->session != XR_NULL_HANDLE &&
+            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
+            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
         }
 
         // Handle eye tracking mode toggle (T key)
@@ -712,14 +721,14 @@ static void RenderThreadFunc(
                         for (uint32_t i = 0; i < 8; i++) rawViews[i] = {XR_TYPE_VIEW};
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
-                        bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode]);
+                        bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
 
                         // View count for the active rendering mode (1=mono, 2=stereo, 4=quad).
                         // Sized off the runtime's per-mode advertisement so the eye-loop and
                         // per-view buffers (rawEyes / stereoViews / viewMat / projectionViews)
                         // all line up with what xrEndFrame expects.
                         uint32_t activeViewCount = (xr->renderingModeCount > 0)
-                            ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2u;
+                            ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2u;
                         if (activeViewCount == 0) activeViewCount = 1u;
                         if (activeViewCount > 8) activeViewCount = 8u;
                         const int eyeCount = monoMode ? 1 : (int)activeViewCount;
@@ -734,7 +743,7 @@ static void RenderThreadFunc(
                         float scaleX, scaleY;
                         uint32_t cols, rows;
                         if (xr->renderingModeCount > 0) {
-                            uint32_t mode = inputSnapshot.currentRenderingMode;
+                            uint32_t mode = xr->currentModeIndex;
                             scaleX = xr->renderingModeScaleX[mode];
                             scaleY = xr->renderingModeScaleY[mode];
                             cols   = xr->renderingModeTileColumns[mode] ? xr->renderingModeTileColumns[mode] : 1u;
@@ -1105,7 +1114,7 @@ static void RenderThreadFunc(
                                 // render path (window × view_scale of the current mode).
                                 float dispScaleX, dispScaleY;
                                 if (xr->renderingModeCount > 0) {
-                                    uint32_t mode = inputSnapshot.currentRenderingMode;
+                                    uint32_t mode = xr->currentModeIndex;
                                     dispScaleX = xr->renderingModeScaleX[mode];
                                     dispScaleY = xr->renderingModeScaleY[mode];
                                 } else {
@@ -1121,10 +1130,10 @@ static void RenderThreadFunc(
                                 std::wstring dispText = FormatDisplayInfo(xr->displayWidthM, xr->displayHeightM,
                                     xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ);
                                 dispText += L"\n" + FormatScaleInfo(xr->recommendedViewScaleX, xr->recommendedViewScaleY);
-                                dispText += L"\n" + FormatMode(inputSnapshot.currentRenderingMode, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
-                                    (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeNames[inputSnapshot.currentRenderingMode] : nullptr,
+                                dispText += L"\n" + FormatMode(xr->currentModeIndex, xr->pfnRequestDisplayRenderingModeEXT != nullptr,
+                                    (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeNames[xr->currentModeIndex] : nullptr,
                                     xr->renderingModeCount,
-                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[inputSnapshot.currentRenderingMode] : true);
+                                    xr->renderingModeCount > 0 ? xr->renderingModeDisplay3D[xr->currentModeIndex] : true);
                                 std::wstring eyeText = FormatEyeTrackingInfo(
                                     xr->eyePositions, (uint32_t)eyeCount,
                                     xr->eyeTrackingActive, xr->isEyeTracking,
@@ -1179,9 +1188,9 @@ static void RenderThreadFunc(
                                         L"Open…"));
                                     std::wstring modeLabel = L"Mode";
                                     if (xr->renderingModeCount > 0 &&
-                                        inputSnapshot.currentRenderingMode < xr->renderingModeCount &&
-                                        xr->renderingModeNames[inputSnapshot.currentRenderingMode]) {
-                                        const char* nm = xr->renderingModeNames[inputSnapshot.currentRenderingMode];
+                                        xr->currentModeIndex < xr->renderingModeCount &&
+                                        xr->renderingModeNames[xr->currentModeIndex]) {
+                                        const char* nm = xr->renderingModeNames[xr->currentModeIndex];
                                         modeLabel = L"Mode: " + std::wstring(nm, nm + strlen(nm));
                                     }
                                     buttons.push_back(toHudPx(
@@ -1269,7 +1278,7 @@ static void RenderThreadFunc(
                 }
 
                 // Submit frame
-                uint32_t submitViewCount = (xr->renderingModeCount > 0 && inputSnapshot.currentRenderingMode < xr->renderingModeCount) ? xr->renderingModeViewCounts[inputSnapshot.currentRenderingMode] : 2;
+                uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 if (submitViewCount == 0) submitViewCount = 1;
                 if (submitViewCount > 8) submitViewCount = 8;  // matches projectionViews[8] sizing
                 if (rendered && hudSubmitted) {
@@ -1591,10 +1600,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     g_inputState.viewParams.virtualDisplayHeight = kFallbackVirtualDisplayHeightM;
     g_inputState.renderingModeCount = xr.renderingModeCount;
-    // Align runtime active rendering mode with app's default (currentRenderingMode=1).
-    // Without this, app UI labels show mode 1 (Anaglyph) but the runtime stays at its
-    // own default (mode 0 Passthrough on sim_display) until the user presses V.
-    g_inputState.renderingModeChangeRequested = true;
+    // Align runtime active rendering mode with app's default (mode 1 = first 3D mode).
+    // The main loop's dispatch picks this up on the first frame and calls
+    // xrRequestDisplayRenderingModeEXT(1); the runtime event drives xr.currentModeIndex.
+    g_inputState.absoluteRenderingModeRequested = 1;
     g_inputState.hudVisible = false;     // hidden by default; toggle with Tab
     g_inputState.animateEnabled = true;  // auto-orbit always on after 10 s idle
     {

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -470,6 +470,11 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
                     xr.renderingModeScaleX[i] = modes[i].viewScaleX;
                     xr.renderingModeScaleY[i] = modes[i].viewScaleY;
                     xr.renderingModeDisplay3D[i] = (modes[i].hardwareDisplay3D == XR_TRUE);
+                    xr.renderingModeIsRequestable[i] = modes[i].isRequestable ? true : false;
+                    // v13 initial-mode-sync: trust runtime-reported active mode.
+                    if (modes[i].isActive) {
+                        xr.currentModeIndex = modes[i].modeIndex;
+                    }
                     xr.renderingModeTileColumns[i] = modes[i].tileColumns ? modes[i].tileColumns : 1;
                     xr.renderingModeTileRows[i] = modes[i].tileRows ? modes[i].tileRows : 1;
                     LOG_INFO("  [%u] %s (views=%u, scale=%.2fx%.2f, tiles=%ux%u, 3D=%d)",


### PR DESCRIPTION
## Summary

Mirrors the displayxr-runtime test-app refactor for the gauss demo:

- `495a97d` — Single-source-of-truth for rendering mode (drop the two-field anti-pattern; V/0-8/mode-button become *requests* that go through the public API).
- `a5c2864` — Consume XR_EXT_display_info v13 (`isActive` for initial-mode-sync; capture `isRequestable` per mode).
- `ea983b1` — HUD Mode line and on-screen Mode button append "[locked]" / "[locked by workspace]" when `isRequestable=false` so users know clicking is a no-op under workspace.

ABI note: bumps the local `openxr_includes/openxr/XR_EXT_display_info.h` to v13. Must land with DisplayXR/displayxr-runtime#240 to avoid `modes[i+1]` misaligned reads.

macOS path (`macos/main.mm`) NOT in this PR — deferred per same reasoning as the runtime side (no Mac in the dev loop). Track separately.

## Test plan

- [x] Windows: shell V (now Ctrl+V) flips workspace, gauss HUD + Mode button track the change.
- [x] Mode label correctly shows "[locked]" under workspace; not shown standalone.
- [x] User-verified on Leia SR.

Refs DisplayXR/displayxr-runtime#234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)