### PR TITLE
demo: opt into XR_EXT_workspace_file_dialog (#228 Tier 1)

### DIFF
--- a/common/xr_session_common.cpp
+++ b/common/xr_session_common.cpp
@@ -336,6 +336,27 @@ bool PollEvents(XrSessionManager& xr) {
             xr.currentModeIndex = modeEvent->currentModeIndex;
             break;
         }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT: {
+            // #228 Tier 1: spatial file picker delivered a result. Store on
+            // the session manager; the main loop consumes filePickerHasResult
+            // and routes the path through the same g_pendingLoadPath queue
+            // the Win32 GetOpenFileNameA path uses.
+            auto* pe = (XrEventDataFilePickerCompleteEXT*)&event;
+            if (pe->requestId == xr.filePickerRequestId) {
+                xr.filePickerLastResult = pe->result;
+                strncpy(xr.filePickerLastPath, pe->path, sizeof(xr.filePickerLastPath) - 1);
+                xr.filePickerLastPath[sizeof(xr.filePickerLastPath) - 1] = '\0';
+                xr.filePickerInFlight = false;
+                xr.filePickerHasResult = true;
+                LOG_INFO("[#228] File picker complete: requestId=%llu result=%d path=\"%s\"",
+                    (unsigned long long)pe->requestId, (int)pe->result, pe->path);
+            } else {
+                LOG_WARN("[#228] Ignoring file picker event for stale requestId=%llu (current=%llu)",
+                    (unsigned long long)pe->requestId,
+                    (unsigned long long)xr.filePickerRequestId);
+            }
+            break;
+        }
         default:
             LOG_DEBUG("Received event type: %d", event.type);
             break;

--- a/common/xr_session_common.h
+++ b/common/xr_session_common.h
@@ -27,6 +27,7 @@
 #include <openxr/openxr_platform.h>
 #include <openxr/XR_EXT_win32_window_binding.h>
 #include <openxr/XR_EXT_display_info.h>
+#include <openxr/XR_EXT_workspace_file_dialog.h>
 #include <DirectXMath.h>
 #include <vector>
 #include <string>
@@ -81,6 +82,20 @@ struct XrSessionManager {
     // Extension support (used by ext app, ignored by non-ext app)
     bool hasWin32WindowBindingExt = false;
     bool hasDisplayInfoExt = false;
+    // XR_EXT_workspace_file_dialog (#228 Tier 1 spatial file picker). When
+    // the runtime + active workspace controller advertise this, we route
+    // the demo's "Load .ply/.spz" button through xrRequestFilePickerEXT
+    // and let a spatial picker UI appear in the workspace. Falls back to
+    // GetOpenFileNameA otherwise (workspace mode without a Tier 1 picker,
+    // or any non-DisplayXR runtime). See PollEvents for the completion
+    // path that fills filePickerLast* below.
+    bool hasFileDialogExt = false;
+    PFN_xrRequestFilePickerEXT pfnRequestFilePickerEXT = nullptr;
+    bool filePickerInFlight = false;             //!< Set when xrRequestFilePickerEXT returned SUCCESS; cleared on event arrival.
+    bool filePickerHasResult = false;            //!< Set by PollEvents when the completion event arrives; consumed + cleared by the main loop.
+    XrAsyncRequestIdEXT filePickerRequestId = 0;
+    XrFilePickerResultEXT filePickerLastResult = (XrFilePickerResultEXT)0;
+    char filePickerLastPath[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT] = {};
 
     // Display info from XR_EXT_display_info (static display properties)
     float recommendedViewScaleX = 1.0f;

--- a/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
+++ b/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
@@ -1,0 +1,309 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_workspace_file_dialog extension (Tier 1 spatial file picker).
+ * @author DisplayXR
+ * @ingroup external_openxr
+ *
+ * Async spatial-native file picker. The app calls xrRequestFilePickerEXT and
+ * receives an XrEventDataFilePickerCompleteEXT through xrPollEvent when the
+ * user picks (or cancels). The picker itself is a peer workspace window
+ * (its own OpenXR handle app) spawned by the active workspace controller —
+ * NOT a layer inside the requester's window.
+ *
+ * Async / event-based on purpose: a blocking call would deadlock single-
+ * threaded render loops and stall xrWaitFrame.
+ *
+ * The extension is workspace-scoped: an instance must enable
+ * XR_EXT_spatial_workspace and the session must be the active workspace
+ * (xrActivateSpatialWorkspaceEXT) before xrRequestFilePickerEXT returns
+ * XR_SUCCESS. Outside a workspace it returns XR_ERROR_FEATURE_UNSUPPORTED.
+ *
+ * Fallback to Tier 0: if no workspace controller is registered, or the
+ * active controller does not advertise file-dialog support (registry value
+ * `SupportsFileDialog=1` under its WorkspaceControllers\<id> key), the call
+ * returns XR_FILE_PICKER_FALLBACK_TIER0_EXT immediately. Apps should then
+ * call GetOpenFileName / IFileOpenDialog themselves; the Tier 0 CBT hook
+ * (always installed under DISPLAYXR_WORKSPACE_SESSION=1) handles z-order
+ * and focus restoration onto a visible offscreen owner HWND.
+ */
+#ifndef XR_EXT_WORKSPACE_FILE_DIALOG_H
+#define XR_EXT_WORKSPACE_FILE_DIALOG_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_workspace_file_dialog 1
+#define XR_EXT_workspace_file_dialog_SPEC_VERSION 1
+#define XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME "XR_EXT_workspace_file_dialog"
+
+// Provisional XrStructureType values. The 1000999120..121 range is reserved
+// for this extension. Reconciles with the Khronos registry before any
+// spec-freeze attempt.
+#define XR_TYPE_FILE_PICKER_INFO_EXT                ((XrStructureType)1000999120)
+#define XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT ((XrStructureType)1000999121)
+
+/*!
+ * @brief Success-class XrResult returned when no Tier 1 picker is available.
+ *
+ * Cast as XrResult so callers can compare against the function return value
+ * directly. Positive (non-error) per OpenXR's result-code convention.
+ */
+#define XR_FILE_PICKER_FALLBACK_TIER0_EXT ((XrResult)1000999122)
+
+/*!
+ * @brief Maximum path length carried in the completion event (UTF-8 bytes).
+ *
+ * Sized to Windows `MAX_PATH` (260) rounded down to a power-of-two-ish
+ * value so the encompassing IPC request message stays comfortably inside
+ * the runtime's per-message wire budget. Apps that need long-path
+ * support (`\\?\…` style) should call the Tier 0 path directly; the
+ * completion event returns `XR_FILE_PICKER_RESULT_INVALID_PATH_EXT` if
+ * the user picks a path that does not fit in this buffer.
+ */
+#define XR_MAX_FILE_PICKER_PATH_LENGTH_EXT 256
+
+/*!
+ * @brief Maximum length of a single filter description / extension list
+ * field in XrFilePickerInfoEXT.
+ */
+#define XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT 64
+
+/*!
+ * @brief Maximum length of the optional picker title.
+ */
+#define XR_MAX_FILE_PICKER_TITLE_LENGTH_EXT 128
+
+/*!
+ * @brief Maximum number of filter entries the picker UI displays.
+ */
+#define XR_MAX_FILE_PICKER_FILTERS_EXT 4
+
+/*!
+ * @brief Async-request handle returned by xrRequestFilePickerEXT.
+ *
+ * Opaque monotonic ID. Apps correlate completion events by matching the
+ * `requestId` field of XrEventDataFilePickerCompleteEXT against the value
+ * the runtime wrote here. The runtime drops outstanding requests on
+ * session destroy; late completions for a destroyed session are no-ops.
+ */
+typedef uint64_t XrAsyncRequestIdEXT;
+
+#define XR_NULL_ASYNC_REQUEST_ID_EXT ((XrAsyncRequestIdEXT)0)
+
+/*!
+ * @brief Picker mode.
+ */
+typedef enum XrFilePickerModeEXT {
+    XR_FILE_PICKER_MODE_OPEN_EXT   = 0,
+    XR_FILE_PICKER_MODE_SAVE_EXT   = 1,
+    XR_FILE_PICKER_MODE_FOLDER_EXT = 2,
+    XR_FILE_PICKER_MODE_MAX_ENUM_EXT = 0x7FFFFFFF
+} XrFilePickerModeEXT;
+
+/*!
+ * @brief Flags controlling picker UI behavior.
+ *
+ * MULTI_SELECT_BIT is reserved for spec_version 2. spec_version 1 picker
+ * implementations may return XR_ERROR_FEATURE_UNSUPPORTED if the flag is
+ * set.
+ */
+typedef XrFlags64 XrFilePickerFlagsEXT;
+static const XrFilePickerFlagsEXT XR_FILE_PICKER_FLAG_NONE_EXT             = 0;
+static const XrFilePickerFlagsEXT XR_FILE_PICKER_FLAG_MULTI_SELECT_BIT_EXT = 0x00000001;
+
+/*!
+ * @brief One filter row in the picker's dropdown.
+ *
+ * `extensions` is a semicolon-delimited list of patterns, e.g.
+ * `"*.png;*.jpg;*.jpeg"`. Empty = match all.
+ */
+typedef struct XrFilePickerFilterEXT {
+    char description[XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT]; //!< User-visible label, e.g. "Images"
+    char extensions[XR_MAX_FILE_PICKER_FILTER_LENGTH_EXT];  //!< Semicolon-delimited patterns
+} XrFilePickerFilterEXT;
+
+/*!
+ * @brief Request parameters for xrRequestFilePickerEXT.
+ *
+ * The runtime forwards this struct to the active workspace controller
+ * over IPC. All character fields are NUL-terminated UTF-8. The IPC
+ * codegen does not follow `next` pointer chains — this struct must be
+ * a flat copyable value.
+ */
+typedef struct XrFilePickerInfoEXT {
+    XrStructureType            type;       //!< Must be XR_TYPE_FILE_PICKER_INFO_EXT
+    const void* XR_MAY_ALIAS   next;       //!< Reserved; must be NULL in spec_version 1
+    XrFilePickerModeEXT        mode;       //!< Open / Save / Folder
+    XrFilePickerFlagsEXT       flags;      //!< See XR_FILE_PICKER_FLAG_*
+    char                       title[XR_MAX_FILE_PICKER_TITLE_LENGTH_EXT]; //!< Window title; empty = picker chooses
+    char                       defaultPath[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT]; //!< Starting directory; empty = picker chooses
+    uint32_t                   filterCount; //!< Number of valid entries in filters[]
+    XrFilePickerFilterEXT      filters[XR_MAX_FILE_PICKER_FILTERS_EXT];
+} XrFilePickerInfoEXT;
+
+/*!
+ * @brief Begin an async file-picker request.
+ *
+ * Returns immediately. The runtime allocates a monotonic request ID, hands
+ * the request off to the active workspace controller, and queues an
+ * XrEventDataFilePickerCompleteEXT on the requesting session's event
+ * stream when the picker completes.
+ *
+ * Apps poll xrPollEvent on the same session to receive the completion.
+ *
+ * @param session    A valid XrSession handle that has activated a
+ *                   spatial workspace via xrActivateSpatialWorkspaceEXT.
+ * @param info       Picker parameters. Must not be NULL.
+ * @param requestId  Output: monotonic ID for correlating the completion
+ *                   event. Must not be NULL. Never zero on success.
+ * @return XR_SUCCESS — request accepted; event will follow.
+ *         XR_FILE_PICKER_FALLBACK_TIER0_EXT — no spatial picker available;
+ *         the app should fall back to a flat OS dialog (Tier 0 handles
+ *         z-order and focus restoration automatically). No completion
+ *         event will be queued; *requestId is set to
+ *         XR_NULL_ASYNC_REQUEST_ID_EXT.
+ *         XR_ERROR_FEATURE_UNSUPPORTED — session is not running under a
+ *         workspace.
+ *         XR_ERROR_VALIDATION_FAILURE — info->type is wrong, mode is
+ *         invalid, or the picker is being called from the picker
+ *         process itself (recursion guard).
+ *         XR_ERROR_HANDLE_INVALID — session is invalid.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrRequestFilePickerEXT)(
+    XrSession                       session,
+    const XrFilePickerInfoEXT*      info,
+    XrAsyncRequestIdEXT*            requestId);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrRequestFilePickerEXT(
+    XrSession                       session,
+    const XrFilePickerInfoEXT*      info,
+    XrAsyncRequestIdEXT*            requestId);
+#endif
+
+/*!
+ * @brief Picker completion result codes carried in the event.
+ *
+ * Distinct from `XrResult` to avoid stepping on the Khronos result-code
+ * range; encoded as int32_t in the event.
+ */
+typedef enum XrFilePickerResultEXT {
+    XR_FILE_PICKER_RESULT_SUCCESS_EXT     = 0,  //!< User picked. `path` is valid.
+    XR_FILE_PICKER_RESULT_CANCELLED_EXT   = 1,  //!< User cancelled. `path` is empty.
+    XR_FILE_PICKER_RESULT_PICKER_FAILED_EXT = 2, //!< Picker exited abnormally / crashed.
+    XR_FILE_PICKER_RESULT_INVALID_PATH_EXT = 3, //!< User picked a path that did not fit in the buffer.
+    XR_FILE_PICKER_RESULT_MAX_ENUM_EXT    = 0x7FFFFFFF
+} XrFilePickerResultEXT;
+
+/*!
+ * @brief Completion event delivered via xrPollEvent.
+ *
+ * The runtime routes this event to the session whose xrRequestFilePickerEXT
+ * call produced the matching `requestId`. If the requesting session is
+ * destroyed before the picker completes, the event is dropped silently.
+ *
+ * @extends XrEventDataBaseHeader
+ */
+typedef struct XrEventDataFilePickerCompleteEXT {
+    XrStructureType             type;       //!< Must be XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT
+    const void* XR_MAY_ALIAS    next;
+    XrSession                   session;
+    XrAsyncRequestIdEXT         requestId;
+    XrFilePickerResultEXT       result;
+    char                        path[XR_MAX_FILE_PICKER_PATH_LENGTH_EXT]; //!< NUL-terminated UTF-8; empty on cancel/failure
+} XrEventDataFilePickerCompleteEXT;
+
+// ---- Controller-side surface ----
+//
+// Workspace controllers drain XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT
+// from xrEnumerateWorkspaceInputEventsEXT, fetch the full request via
+// xrGetFilePickerRequestEXT, spawn (or otherwise drive) their picker UI, and
+// deliver the result through xrCompleteFilePickerEXT. Both functions require
+// the calling session to hold the active workspace role
+// (xrActivateSpatialWorkspaceEXT). A non-controller caller receives
+// XR_ERROR_FEATURE_UNSUPPORTED.
+
+/*!
+ * @brief Fetch the full picker request that a workspace client posted via
+ * xrRequestFilePickerEXT.
+ *
+ * Called by the workspace controller in response to an
+ * XR_WORKSPACE_INPUT_EVENT_FILE_PICKER_REQUEST_EXT event. The runtime
+ * returns the requesting client's id and the picker info struct so the
+ * controller can spawn / drive a picker UI.
+ *
+ * @param session    Workspace-controller session.
+ * @param requestId  Value carried by the request event.
+ * @param outClientId  Output: the requesting workspace client.
+ * @param outInfo     Output: filled with the requester's
+ *                    XrFilePickerInfoEXT-equivalent. `type` and `next`
+ *                    are reset by the runtime so the caller can pass
+ *                    the buffer along to its picker without further
+ *                    re-initialisation.
+ * @return XR_SUCCESS on hit;
+ *         XR_ERROR_VALIDATION_FAILURE if requestId is 0 or no pending
+ *         entry matches (already completed, or the requester
+ *         disconnected);
+ *         XR_ERROR_FEATURE_UNSUPPORTED if the calling session is not
+ *         the active workspace controller.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrGetFilePickerRequestEXT)(
+    XrSession              session,
+    XrAsyncRequestIdEXT    requestId,
+    uint32_t              *outClientId,    //!< XrWorkspaceClientId (header-independence: plain uint32_t)
+    XrFilePickerInfoEXT   *outInfo);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetFilePickerRequestEXT(
+    XrSession              session,
+    XrAsyncRequestIdEXT    requestId,
+    uint32_t              *outClientId,
+    XrFilePickerInfoEXT   *outInfo);
+#endif
+
+/*!
+ * @brief Deliver a picker result back to the requesting client.
+ *
+ * The runtime translates this into an XrEventDataFilePickerCompleteEXT
+ * pushed onto the requester's session event queue. Late results (i.e.,
+ * the requester disconnected before the controller responded) are
+ * dropped silently and logged once.
+ *
+ * @param session    Workspace-controller session.
+ * @param requestId  Value carried by the request event.
+ * @param result     XR_FILE_PICKER_RESULT_*. SUCCESS_EXT must be paired
+ *                   with a non-empty path; the runtime overrides
+ *                   `path` to an empty string for non-SUCCESS results.
+ * @param path       NUL-terminated UTF-8; ignored when @p result is not
+ *                   SUCCESS_EXT. May be NULL or empty in that case.
+ * @return XR_SUCCESS on a successful deliver-or-late-result-drop;
+ *         XR_ERROR_VALIDATION_FAILURE if requestId is 0;
+ *         XR_ERROR_FEATURE_UNSUPPORTED if the calling session is not
+ *         the active workspace controller;
+ *         XR_ERROR_PATH_FORMAT_INVALID if @p path exceeds the runtime's
+ *         wire budget (see XR_MAX_FILE_PICKER_PATH_LENGTH_EXT).
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrCompleteFilePickerEXT)(
+    XrSession                  session,
+    XrAsyncRequestIdEXT        requestId,
+    XrFilePickerResultEXT      result,
+    const char                *path);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrCompleteFilePickerEXT(
+    XrSession              session,
+    XrAsyncRequestIdEXT    requestId,
+    XrFilePickerResultEXT  result,
+    const char            *path);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_WORKSPACE_FILE_DIALOG_H

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -89,6 +89,14 @@ target_link_libraries(gaussian_splatting_handle_vk_win PRIVATE
 )
 
 if(MSVC)
+    # /utf-8: tell MSVC the source files are UTF-8 (and the runtime
+    # char set is UTF-8). Without this MSVC reads source literals
+    # using the system codepage (Windows-1252 on US machines) and
+    # mangles multi-byte glyphs like the "…" in "Open…" into
+    # Mojibake (e.g. "Openâ€¦") at compile time. Affects the button
+    # labels rendered by sr_common's HUD.
+    target_compile_options(gaussian_splatting_handle_vk_win PRIVATE /utf-8)
+
     file(RELATIVE_PATH _manifest_rel
         "${CMAKE_BINARY_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}/sr_3dgs_openxr_ext_vk.manifest")

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -62,13 +62,21 @@ static const float HUD_FONT_BASE_FRACTION = 0.50f;
 // (left strip of the window, fracW × fracH = HUD_WIDTH_FRACTION × HUD_HEIGHT_FRACTION).
 // All values are absolute window-fractions for hit-testing; they're
 // translated into HUD-pixel coordinates when passed to RenderHudAndMap.
-static const float OPEN_BTN_X_FRACTION = 0.010f;
-static const float OPEN_BTN_Y_FRACTION = 0.010f;
+/* Button positions in HWND fractions. Inset from the corner is large
+ * enough to clear the runtime's 20-pixel content-click inset around
+ * each workspace tile (used for edge-drag/resize). At fraction 0.010
+ * with a typical small workspace tile (≈500 compositor px wide), the
+ * button rendered inside ≈5 compositor px — inside the 20px inset, so
+ * clicks were eaten by the resize zone instead of being forwarded to
+ * this app. 0.045 / 0.060 stays past the inset on any sane tile size
+ * while keeping the button visually anchored to the top-left. */
+static const float OPEN_BTN_X_FRACTION = 0.045f;
+static const float OPEN_BTN_Y_FRACTION = 0.060f;
 static const float OPEN_BTN_WIDTH_FRACTION  = 0.060f;
 static const float OPEN_BTN_HEIGHT_FRACTION = 0.030f;
 
-static const float MODE_BTN_X_FRACTION = 0.075f;
-static const float MODE_BTN_Y_FRACTION = 0.010f;
+static const float MODE_BTN_X_FRACTION = 0.110f;
+static const float MODE_BTN_Y_FRACTION = 0.060f;
 static const float MODE_BTN_WIDTH_FRACTION  = 0.140f;
 static const float MODE_BTN_HEIGHT_FRACTION = 0.030f;
 

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -268,8 +268,73 @@ static void TryAutoLoadBundledScene() {
     }
 }
 
-// Open a file dialog and load a .ply or .spz scene (called from main thread)
+// Hand a picked path off to the render thread for scene load. Validates the
+// extension first; on failure pops a MessageBox and returns false. Used by
+// both the Win32 GetOpenFileNameA path and the #228 spatial picker result
+// drained in the main loop.
+static bool QueueSceneLoad(HWND hwnd, const std::string& path) {
+    if (!ValidateSceneFile(path)) {
+        MessageBoxA(hwnd, "Invalid scene file. Supported formats: .ply, .spz", "Load Error", MB_OK | MB_ICONERROR);
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_pendingLoadPathMutex);
+        g_pendingLoadPath = path;
+    }
+    g_loadRequested.store(true, std::memory_order_release);
+    LOG_INFO("Queued 3DGS scene load: %s", path.c_str());
+    return true;
+}
+
+// Open a file dialog and load a .ply or .spz scene (called from main thread).
+//
+// Path A — workspace + Tier 1 picker available:
+//     xrRequestFilePickerEXT fires async. The completion event is drained
+//     by PollEvents (common/xr_session_common.cpp) into xr.filePickerLast*;
+//     the main loop dispatches to QueueSceneLoad on result arrival.
+//
+// Path B — workspace mode but no controller / no Tier 1 picker, OR running
+// outside a workspace (standalone window), OR running on a non-DisplayXR
+// OpenXR runtime: xrRequestFilePickerEXT either returns
+// XR_FILE_PICKER_FALLBACK_TIER0_EXT (workspace fallback) or the PFN is
+// null (extension absent). Either way fall through to GetOpenFileNameA
+// and keep the existing standalone UX.
 static void OpenLoadDialog(HWND hwnd) {
+    // Path A: spatial picker, when available + not already in flight.
+    if (g_xr != nullptr && g_xr->pfnRequestFilePickerEXT != nullptr &&
+        !g_xr->filePickerInFlight) {
+        XrFilePickerInfoEXT info = {XR_TYPE_FILE_PICKER_INFO_EXT};
+        info.mode = XR_FILE_PICKER_MODE_OPEN_EXT;
+        strncpy(info.title, "Load Gaussian Splatting Scene",
+                sizeof(info.title) - 1);
+        info.filterCount = 3;
+        strncpy(info.filters[0].description, "3DGS Files",
+                sizeof(info.filters[0].description) - 1);
+        strncpy(info.filters[0].extensions, "*.ply;*.spz",
+                sizeof(info.filters[0].extensions) - 1);
+        strncpy(info.filters[1].description, "PLY Files",
+                sizeof(info.filters[1].description) - 1);
+        strncpy(info.filters[1].extensions, "*.ply",
+                sizeof(info.filters[1].extensions) - 1);
+        strncpy(info.filters[2].description, "SPZ Files",
+                sizeof(info.filters[2].description) - 1);
+        strncpy(info.filters[2].extensions, "*.spz",
+                sizeof(info.filters[2].extensions) - 1);
+
+        XrAsyncRequestIdEXT rid = 0;
+        XrResult r = g_xr->pfnRequestFilePickerEXT(g_xr->session, &info, &rid);
+        if (r == XR_SUCCESS) {
+            g_xr->filePickerInFlight = true;
+            g_xr->filePickerRequestId = rid;
+            LOG_INFO("[#228] xrRequestFilePickerEXT -> rc=0x%x requestId=%llu",
+                r, (unsigned long long)rid);
+            return; // wait for completion event in the main loop
+        }
+        // r == XR_FILE_PICKER_FALLBACK_TIER0_EXT or an error → fall through.
+        LOG_INFO("[#228] xrRequestFilePickerEXT -> rc=0x%x (falling back to Win32)", r);
+    }
+
+    // Path B: existing Win32 file dialog (unchanged behavior).
     OPENFILENAMEA ofn = {};
     char filePath[MAX_PATH] = {};
     ofn.lStructSize = sizeof(ofn);
@@ -281,20 +346,7 @@ static void OpenLoadDialog(HWND hwnd) {
     ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
 
     if (GetOpenFileNameA(&ofn)) {
-        std::string path(filePath);
-        if (ValidateSceneFile(path)) {
-            // Hand the path off to the render thread (see g_pendingLoadPath
-            // comment above). Doing the load here would race the render
-            // thread's per-frame queue submissions and crash NVIDIA drivers.
-            {
-                std::lock_guard<std::mutex> lock(g_pendingLoadPathMutex);
-                g_pendingLoadPath = path;
-            }
-            g_loadRequested.store(true, std::memory_order_release);
-            LOG_INFO("Queued 3DGS scene load: %s", path.c_str());
-        } else {
-            MessageBoxA(hwnd, "Invalid scene file. Supported formats: .ply, .spz", "Load Error", MB_OK | MB_ICONERROR);
-        }
+        QueueSceneLoad(hwnd, std::string(filePath));
     }
 }
 
@@ -690,6 +742,28 @@ static void RenderThreadFunc(
         }
 
         PollEvents(*xr);
+
+        // #228 Tier 1: drain a spatial-picker result if one arrived this
+        // tick. PollEvents wrote the path + result code onto the session
+        // manager; we route it through the same QueueSceneLoad path the
+        // Win32 GetOpenFileNameA branch uses. The render thread picks the
+        // queued path up via g_pendingLoadPath.
+        if (xr->filePickerHasResult) {
+            xr->filePickerHasResult = false;
+            if (xr->filePickerLastResult == XR_FILE_PICKER_RESULT_SUCCESS_EXT &&
+                xr->filePickerLastPath[0] != '\0') {
+                QueueSceneLoad(hwnd, std::string(xr->filePickerLastPath));
+            } else if (xr->filePickerLastResult == XR_FILE_PICKER_RESULT_CANCELLED_EXT) {
+                LOG_INFO("[#228] User cancelled spatial picker — no scene load");
+            } else {
+                // PICKER_FAILED / INVALID_PATH — log and silently drop.
+                // Don't auto-fall-back to Win32: the user already cancelled
+                // out of the spatial flow, surfacing another dialog would
+                // feel like a bug. They can click Load again if needed.
+                LOG_WARN("[#228] Spatial picker delivered result=%d (no load)",
+                    (int)xr->filePickerLastResult);
+            }
+        }
 
         if (xr->sessionRunning) {
             XrFrameState frameState;

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -308,6 +308,15 @@ static bool QueueSceneLoad(HWND hwnd, const std::string& path) {
 // null (extension absent). Either way fall through to GetOpenFileNameA
 // and keep the existing standalone UX.
 static void OpenLoadDialog(HWND hwnd) {
+    // Already showing a spatial picker — second click on Open is a
+    // no-op. Without this guard the prior "filePickerInFlight" check
+    // would skip Path A and fall through to GetOpenFileNameA, opening
+    // BOTH the spatial picker AND a flat Win32 dialog stacked on top.
+    if (g_xr != nullptr && g_xr->filePickerInFlight) {
+        LOG_INFO("[#228] OpenLoadDialog: spatial picker already in flight, ignoring");
+        return;
+    }
+
     // Path A: spatial picker, when available + not already in flight.
     if (g_xr != nullptr && g_xr->pfnRequestFilePickerEXT != nullptr &&
         !g_xr->filePickerInFlight) {
@@ -1256,6 +1265,15 @@ static void RenderThreadFunc(
                                 // is (0,0) → (hudWidth, hudHeight)).
                                 std::vector<HudButton> buttons;
                                 {
+                                    // Hover tracking: compare current cursor (in HWND
+                                    // pixel space, captured by WM_MOUSEMOVE into
+                                    // inputSnapshot.mouseX/Y) against the button's
+                                    // HWND-fraction rect. Hovered buttons get a
+                                    // visual highlight in the HUD renderer.
+                                    const float mx_frac = (g_windowWidth > 0)
+                                        ? (float)inputSnapshot.mouseX / (float)g_windowWidth : 0.0f;
+                                    const float my_frac = (g_windowHeight > 0)
+                                        ? (float)inputSnapshot.mouseY / (float)g_windowHeight : 0.0f;
                                     auto toHudPx = [&](float xf, float yf, float wf, float hf, const std::wstring& label) {
                                         HudButton b;
                                         b.label = label;
@@ -1263,6 +1281,8 @@ static void RenderThreadFunc(
                                         b.y = (yf / HUD_HEIGHT_FRACTION) * (float)hudHeight;
                                         b.width  = (wf / HUD_WIDTH_FRACTION)  * (float)hudWidth;
                                         b.height = (hf / HUD_HEIGHT_FRACTION) * (float)hudHeight;
+                                        b.hovered = (mx_frac >= xf && mx_frac <= xf + wf &&
+                                                     my_frac >= yf && my_frac <= yf + hf);
                                         return b;
                                     };
                                     buttons.push_back(toHudPx(

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -62,21 +62,16 @@ static const float HUD_FONT_BASE_FRACTION = 0.50f;
 // (left strip of the window, fracW × fracH = HUD_WIDTH_FRACTION × HUD_HEIGHT_FRACTION).
 // All values are absolute window-fractions for hit-testing; they're
 // translated into HUD-pixel coordinates when passed to RenderHudAndMap.
-/* Button positions in HWND fractions. Inset from the corner is large
- * enough to clear the runtime's 20-pixel content-click inset around
- * each workspace tile (used for edge-drag/resize). At fraction 0.010
- * with a typical small workspace tile (≈500 compositor px wide), the
- * button rendered inside ≈5 compositor px — inside the 20px inset, so
- * clicks were eaten by the resize zone instead of being forwarded to
- * this app. 0.045 / 0.060 stays past the inset on any sane tile size
- * while keeping the button visually anchored to the top-left. */
-static const float OPEN_BTN_X_FRACTION = 0.045f;
-static const float OPEN_BTN_Y_FRACTION = 0.060f;
+// Button positions in HWND fractions. Now that the runtime no longer
+// applies a forwarding-rect inset (see displayxr-runtime fix), buttons
+// can sit close to the edge without clicks being eaten.
+static const float OPEN_BTN_X_FRACTION = 0.010f;
+static const float OPEN_BTN_Y_FRACTION = 0.010f;
 static const float OPEN_BTN_WIDTH_FRACTION  = 0.060f;
 static const float OPEN_BTN_HEIGHT_FRACTION = 0.030f;
 
-static const float MODE_BTN_X_FRACTION = 0.110f;
-static const float MODE_BTN_Y_FRACTION = 0.060f;
+static const float MODE_BTN_X_FRACTION = 0.075f;
+static const float MODE_BTN_Y_FRACTION = 0.010f;
 static const float MODE_BTN_WIDTH_FRACTION  = 0.140f;
 static const float MODE_BTN_HEIGHT_FRACTION = 0.030f;
 

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -50,11 +50,15 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0) {
             xr.hasDisplayInfoExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME) == 0) {
+            xr.hasFileDialogExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_vulkan_enable: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasVulkan) {
         LOG_ERROR("XR_KHR_vulkan_enable extension not available");
@@ -68,6 +72,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasDisplayInfoExt) {
         enabledExtensions.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
+    }
+    if (xr.hasFileDialogExt) {
+        enabledExtensions.push_back(XR_EXT_WORKSPACE_FILE_DIALOG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -140,6 +147,16 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             (PFN_xrVoidFunction*)&xr.pfnRequestDisplayRenderingModeEXT);
         xrGetInstanceProcAddr(xr.instance, "xrEnumerateDisplayRenderingModesEXT",
             (PFN_xrVoidFunction*)&xr.pfnEnumerateDisplayRenderingModesEXT);
+    }
+
+    // #228 Tier 1 spatial file picker — resolve the app-side entrypoint
+    // when the extension is enabled. Resolution failure is non-fatal: we
+    // just fall through to the Win32 GetOpenFileNameA path at call time.
+    if (xr.hasFileDialogExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrRequestFilePickerEXT",
+            (PFN_xrVoidFunction*)&xr.pfnRequestFilePickerEXT);
+        LOG_INFO("xrRequestFilePickerEXT: %s",
+            xr.pfnRequestFilePickerEXT ? "resolved" : "NULL");
     }
 
     uint32_t viewCount = 0;


### PR DESCRIPTION
## Summary

Route the Load button through `xrRequestFilePickerEXT` when running inside a DisplayXR workspace controller (the shell) that advertises `SupportsFileDialog=1`. A spatial picker UI appears next to the Gauss tile; the user picks a `.ply`/`.spz`; the result is delivered back via the same `g_pendingLoadPath` queue the existing Win32 path uses. Render thread is undisturbed.

Outside a workspace (standalone window), when the runtime returns `XR_FILE_PICKER_FALLBACK_TIER0_EXT`, or when the extension isn't advertised at all (non-DisplayXR OpenXR runtime), the call falls through to `GetOpenFileNameA` — same UX as today.

## Changes

| File | Change |
|---|---|
| `openxr_includes/openxr/XR_EXT_workspace_file_dialog.h` | Vendored from `displayxr-runtime` (the extension header) |
| `common/xr_session_common.h` | Extension flag + PFN + pending-result fields on `XrSessionManager` |
| `common/xr_session_common.cpp` | `XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_EXT` case in `PollEvents` |
| `windows/xr_session.cpp` | Detect + enable the extension, resolve `xrRequestFilePickerEXT` PFN |
| `windows/main.cpp` | `QueueSceneLoad` helper, two-path `OpenLoadDialog`, main-loop result drain |

## Runtime / shell dependencies

Requires:
- A `displayxr-runtime` release that ships `XR_EXT_workspace_file_dialog` (≥ the release built from `main` after #244 merged)
- A `displayxr-shell-pvt` release that ships `displayxr-file-picker.exe` + writes `SupportsFileDialog=1` (the companion PR https://github.com/DisplayXR/displayxr-shell-pvt/pull/14)

README runtime-version pin will need bumping in a follow-up commit once those releases are cut.

## Test plan

- [x] Standalone gauss (no shell): click Load → Win32 `GetOpenFileNameA` dialog appears, scene loads.
- [x] Shell + gauss (workspace mode): click Load → spatial picker appears, double-click a `.ply` → scene loads. Service stays alive thanks to the picker's post-commit grace frames (companion shell PR).
- [ ] Non-DisplayXR OpenXR runtime (e.g. SteamVR): extension absent → unchanged Win32 path. Not tested in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)