### PR TITLE
fix(#10): unblock manifest delete in uninstaller when shell is running

### DIFF
--- a/installer/DisplayXRGaussianSplatInstaller.nsi
+++ b/installer/DisplayXRGaussianSplatInstaller.nsi
@@ -214,10 +214,22 @@ Section "Uninstall"
     nsExec::ExecToLog 'taskkill /f /im gaussian_splatting_handle_vk_win.exe'
     Pop $0
 
+    ; The DisplayXR Shell periodically scans %ProgramData%\DisplayXR\apps\
+    ; and may hold an open handle to gaussian_splatting.displayxr.json, which
+    ; makes the Delete below silently fail (issue #10). Kill it first; the
+    ; user re-invokes the shell to get it back. Sleep 500 gives Windows a
+    ; moment to release the handle.
+    DetailPrint "Stopping DisplayXR Shell to release manifest handles..."
+    nsExec::ExecToLog 'taskkill /f /im displayxr-shell.exe'
+    Pop $0
+    Sleep 500
+
     ; Remove the registered-mode manifest + icons.
-    Delete "$APPDATA\DisplayXR\apps\gaussian_splatting.displayxr.json"
-    Delete "$APPDATA\DisplayXR\apps\icon.png"
-    Delete "$APPDATA\DisplayXR\apps\icon_sbs.png"
+    ; /REBOOTOK schedules deletion on next reboot if the file is still locked
+    ; at uninstall time (belt-and-suspenders on top of the taskkill above).
+    Delete /REBOOTOK "$APPDATA\DisplayXR\apps\gaussian_splatting.displayxr.json"
+    Delete /REBOOTOK "$APPDATA\DisplayXR\apps\icon.png"
+    Delete /REBOOTOK "$APPDATA\DisplayXR\apps\icon_sbs.png"
     RMDir "$APPDATA\DisplayXR\apps"
 
     ; Remove install dir contents.


### PR DESCRIPTION
Closes #10.

## Summary

- NSIS `Delete` silently fails against a locked file. The DisplayXR Shell periodically scans `%ProgramData%\DisplayXR\apps\` and may hold an open handle to `gaussian_splatting.displayxr.json`, so silent uninstall leaked the manifest whenever the shell was running.
- Mirror the pattern in `displayxr-mcp/installer/DisplayXRMCPInstaller.nsi`: `taskkill /f /im displayxr-shell.exe` + `Sleep 500` immediately before the manifest `Delete`s in the Uninstall section.
- Add `/REBOOTOK` to the three manifest `Delete` calls as a belt-and-suspenders fallback (anything the OS still can't release at uninstall time is removed on next reboot).

One file, 15 insertions / 3 deletions.

## Test plan

- [x] **Shell-running case (the regression):** silent install → launch `displayxr-shell.exe gaussian_splatting_handle_vk_win.exe` → silent uninstall via `Uninstall.exe /S` → `%ProgramData%\DisplayXR\apps\` removed, install dir removed, shell process killed.
- [x] **Shell-not-running case:** silent install → silent uninstall → same clean end state. `taskkill` returns "process not found" which is discarded via `Pop $0`, so the uninstall still completes.
- [x] Installer builds cleanly with the existing `installer\build-installer.bat` (no version bump, no script changes).

## Out of scope

- Installer version bump / release — the user runs that as a separate manual step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)