### PR TITLE
Release v1.3.2

### DIFF
--- a/installer/build-installer.bat
+++ b/installer/build-installer.bat
@@ -4,10 +4,10 @@ set "REPO=%~dp0.."
 set "BIN_DIR=%REPO%\build\windows"
 set "OUT_DIR=%~dp0"
 if "%OUT_DIR:~-1%"=="\" set "OUT_DIR=%OUT_DIR:~0,-1%"
-if "%VERSION%"=="" set "VERSION=1.3.1"
+if "%VERSION%"=="" set "VERSION=1.3.2"
 if "%VERSION_MAJOR%"=="" set "VERSION_MAJOR=1"
 if "%VERSION_MINOR%"=="" set "VERSION_MINOR=3"
-if "%VERSION_PATCH%"=="" set "VERSION_PATCH=1"
+if "%VERSION_PATCH%"=="" set "VERSION_PATCH=2"
 
 if not exist "%BIN_DIR%\gaussian_splatting_handle_vk_win.exe" (
     echo ERROR: demo binary not found at %BIN_DIR%\gaussian_splatting_handle_vk_win.exe


### PR DESCRIPTION
Patch bump bundling fix(#10) — uninstaller now kills `displayxr-shell.exe` and uses `Delete /REBOOTOK` so the `gaussian_splatting.displayxr.json` manifest no longer leaks when the shell is running at silent-uninstall time.

Mirror of the historical `Release v1.3.1` bump (`ffce665`): `VERSION` and `VERSION_PATCH` only in `installer/build-installer.bat`.

## Next steps after merge

Per the demo release flow in the runtime CLAUDE.md:
1. `git tag v1.3.2 && git push origin v1.3.2`
2. `installer\build-installer.bat` → produces `DisplayXRGaussianSplatSetup-1.3.2.exe`
3. `gh release create v1.3.2 ...` with the installer asset attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)