### PR TITLE
ci: add tag-triggered Windows installer build (#14)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,127 @@
+name: Build Windows
+
+# Tag-triggered Windows installer build. Mirrors build-macos.yml (and the
+# BuildInstaller job in displayxr-runtime's build-windows.yml). The demo's
+# release cadence is manual — devs push a v* tag when ready; this workflow
+# builds DisplayXRGaussianSplatSetup-<version>.exe and attaches it to the
+# GitHub Release. workflow_dispatch is provided so the build can be exercised
+# without cutting a tag (a dispatch run uploads an artifact but does NOT
+# publish a release — the attach step is gated on a v* ref).
+#
+# Scope is intentionally narrow: no PR-time runs, no push-to-main runs.
+# Daily iteration is local-build (per the runtime org's convention).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# contents: write is required by softprops/action-gh-release@v2 to
+# create-or-update the GitHub Release on a v* tag push. GH_TOKEN is exported
+# explicitly because the action prefers $GH_TOKEN over its `token:` input.
+permissions:
+  contents: write
+
+jobs:
+  BuildInstaller:
+    runs-on: windows-2022
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vulkan SDK
+        # Same action + version the runtime + Leia-plugin Windows CI use.
+        # Provides glslangValidator (needed by 3dgs_common's shader compile)
+        # under $VULKAN_SDK\Bin.
+        uses: humbletim/install-vulkan-sdk@v1.2
+        with:
+          version: 1.3.283.0
+          cache: true
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Add Vulkan SDK tools to PATH
+        shell: pwsh
+        run: '"$env:VULKAN_SDK\Bin" | Out-File -FilePath $env:GITHUB_PATH -Append'
+
+      - name: Install OpenXR loader
+        shell: pwsh
+        run: |
+          # The demo links the OpenXR loader. Mirror the runtime repo: grab the
+          # prebuilt Khronos loader and point CMake at it via OpenXR_ROOT.
+          $openxrVersion = "1.1.43"
+          $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
+          Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
+          Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
+
+      - name: Derive installer version
+        id: version
+        shell: pwsh
+        run: |
+          # `v1.2.3` -> `1.2.3` for the installer version + filename. Untagged
+          # (workflow_dispatch) builds use a numeric placeholder so the NSIS
+          # VIProductVersion stays valid; they never publish a release.
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            $version = $env:GITHUB_REF -replace '^refs/tags/v',''
+          } else {
+            $version = "0.0.0"
+          }
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Building installer with VERSION=$version"
+
+      - name: Build demo
+        shell: pwsh
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
+            -DOpenXR_ROOT="${{ github.workspace }}/openxr_sdk"
+          cmake --build build
+
+      - name: Build installer
+        shell: cmd
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: call installer\build-installer.bat
+
+      - name: Assert installer carries no vendor SR DLL (regression guard)
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem installer\DisplayXRGaussianSplatSetup-*.exe | Select-Object -First 1
+          if (-not $exe) { Write-Host "::error::installer .exe not produced"; exit 1 }
+          Write-Host "Installer: $($exe.FullName)"
+          # NSIS payloads are listable by 7-Zip (preinstalled on the runner).
+          # SimulatedRealityVulkanBeta.dll is a Leia SDK binary owned by the
+          # Leia plug-in (it ships + self-loads it) — it must never appear in
+          # this vendor-neutral demo's installer. See displayxr-runtime#314.
+          $listing = & 7z l "$($exe.FullName)" 2>&1 | Out-String
+          if ($listing -match 'SimulatedReality') {
+            Write-Host "::error::installer bundles a SimulatedReality* DLL — that's a Leia plug-in concern, not demo content."
+            exit 1
+          }
+          Write-Host "PASS: installer contains no SimulatedReality* binary."
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 3
+          name: DisplayXRGaussianSplat-Windows
+          if-no-files-found: error
+          path: installer/DisplayXRGaussianSplatSetup-*.exe
+
+      # softprops/action-gh-release@v2 create-or-updates the GitHub Release on
+      # a v* tag and attaches the .exe. If the macOS workflow races on the same
+      # tag, the action just appends — both assets land on the same release.
+      - name: Attach installer to GitHub release on tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: installer/DisplayXRGaussianSplatSetup-*.exe
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false

--- a/installer/build-installer.bat
+++ b/installer/build-installer.bat
@@ -5,8 +5,15 @@ set "BIN_DIR=%REPO%\build\windows"
 set "OUT_DIR=%~dp0"
 if "%OUT_DIR:~-1%"=="\" set "OUT_DIR=%OUT_DIR:~0,-1%"
 if "%VERSION%"=="" set "VERSION=1.4.0"
+REM Derive MAJOR/MINOR/PATCH from VERSION (e.g. 1.4.2 -> 1 / 4 / 2) so callers
+REM (CI on a v* tag) only need to set VERSION, not all four vars.
+for /f "tokens=1,2,3 delims=." %%a in ("%VERSION%") do (
+    set "VERSION_MAJOR=%%a"
+    set "VERSION_MINOR=%%b"
+    set "VERSION_PATCH=%%c"
+)
 if "%VERSION_MAJOR%"=="" set "VERSION_MAJOR=1"
-if "%VERSION_MINOR%"=="" set "VERSION_MINOR=4"
+if "%VERSION_MINOR%"=="" set "VERSION_MINOR=0"
 if "%VERSION_PATCH%"=="" set "VERSION_PATCH=0"
 
 if not exist "%BIN_DIR%\gaussian_splatting_handle_vk_win.exe" (


### PR DESCRIPTION
Closes #14. Adds `.github/workflows/build-windows.yml` mirroring `build-macos.yml`: on a `v*` tag, install Vulkan SDK + OpenXR loader, build the demo, run `installer/build-installer.bat`, and attach `DisplayXRGaussianSplatSetup-<version>.exe` to the GitHub Release. `workflow_dispatch` is provided to test the build without tagging (no release published on dispatch). Refactors `build-installer.bat` to derive MAJOR/MINOR/PATCH from `VERSION`. Includes a regression guard asserting the installer carries no `SimulatedReality*` DLL (Leia-plugin concern, per displayxr-runtime#314). Keeps the demo vendor-neutral — no Leia-plugin version gate. Will dispatch-validate on main post-merge.