### PR TITLE
chore: cut v1.4.1 (drop bundled Leia SR DLL + Windows installer CI)

### DIFF
--- a/installer/build-installer.bat
+++ b/installer/build-installer.bat
@@ -4,7 +4,7 @@ set "REPO=%~dp0.."
 set "BIN_DIR=%REPO%\build\windows"
 set "OUT_DIR=%~dp0"
 if "%OUT_DIR:~-1%"=="\" set "OUT_DIR=%OUT_DIR:~0,-1%"
-if "%VERSION%"=="" set "VERSION=1.4.0"
+if "%VERSION%"=="" set "VERSION=1.4.1"
 REM Derive MAJOR/MINOR/PATCH from VERSION (e.g. 1.4.2 -> 1 / 4 / 2) so callers
 REM (CI on a v* tag) only need to set VERSION, not all four vars.
 for /f "tokens=1,2,3 delims=." %%a in ("%VERSION%") do (


### PR DESCRIPTION
Release v1.4.1: first gauss release without the bundled `SimulatedRealityVulkanBeta.dll` (Leia plug-in v1.0.3 self-loads it) and the first with a CI-built + auto-attached Windows installer (#14). Bumps the local-build installer-version fallback to 1.4.1.