### PR TITLE
fix: bundle openxr_loader.dll in the Windows installer

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -83,6 +83,20 @@ jobs:
             -DOpenXR_ROOT="${{ github.workspace }}/openxr_sdk"
           cmake --build build
 
+      - name: Stage OpenXR loader next to demo binary
+        shell: pwsh
+        run: |
+          # An OpenXR app must ship its own openxr_loader.dll next to the exe.
+          # CMake POST_BUILD already attempts this, but guarantee it here so the
+          # installer's File "${BIN_DIR}\openxr_loader.dll" can't silently miss
+          # (the runtime's copy is not on an app's DLL search path). Source is
+          # the Khronos loader we downloaded into openxr_sdk.
+          $dll = Get-ChildItem -Path openxr_sdk -Recurse -Filter openxr_loader.dll | Select-Object -First 1
+          if (-not $dll) { Write-Host "::error::openxr_loader.dll not found under openxr_sdk"; exit 1 }
+          New-Item -ItemType Directory -Force build\windows | Out-Null
+          Copy-Item $dll.FullName build\windows\openxr_loader.dll -Force
+          Write-Host "Staged $($dll.FullName) -> build\windows\openxr_loader.dll"
+
       - name: Build installer
         shell: cmd
         env:
@@ -105,6 +119,14 @@ jobs:
             exit 1
           }
           Write-Host "PASS: installer contains no SimulatedReality* binary."
+          # The demo must ship the OpenXR loader next to its exe (apps carry
+          # their own; the runtime's copy is not on an app's DLL search path).
+          # Mirrors the macOS bundle's libopenxr_loader assertion.
+          if ($listing -notmatch 'openxr_loader\.dll') {
+            Write-Host "::error::installer is missing openxr_loader.dll — OpenXR apps must bundle the loader."
+            exit 1
+          }
+          Write-Host "PASS: installer bundles openxr_loader.dll."
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/installer/DisplayXRGaussianSplatInstaller.nsi
+++ b/installer/DisplayXRGaussianSplatInstaller.nsi
@@ -129,6 +129,16 @@ Section "Gaussian Splat Demo" SecDemo
     File "${BIN_DIR}\gaussian_splatting_handle_vk_win.exe"
     File "${BIN_DIR}\butterfly.spz"
 
+    ; OpenXR loader — an OpenXR app must carry its own openxr_loader.dll next
+    ; to the exe. The runtime ships a copy in its install dir, but that dir is
+    ; intentionally not on PATH and is not part of an app's DLL search order
+    ; (app exe dir → System32 → cwd → PATH), so a demo installed under
+    ; Demos\GaussianSplat\ can't find it there. Without this the demo fails to
+    ; launch with "openxr_loader.dll not found". The Windows build stages it
+    ; next to the exe (windows/CMakeLists.txt POST_BUILD + the CI loader-stage
+    ; step), mirroring the macOS bundle which already ships libopenxr_loader.
+    File "${BIN_DIR}\openxr_loader.dll"
+
     ; Drop the registered-mode app manifest + icons under %ProgramData%
     ; (system-wide, installer-elevated — matches §2.2 of the manifest spec).
     ; The shell launcher scans %ProgramData%\DisplayXR\apps\ on every workspace
@@ -237,6 +247,7 @@ Section "Uninstall"
     ; Remove install dir contents.
     Delete "$INSTDIR\gaussian_splatting_handle_vk_win.exe"
     Delete "$INSTDIR\butterfly.spz"
+    Delete "$INSTDIR\openxr_loader.dll"
     Delete "$INSTDIR\Uninstall.exe"
     RMDir "$INSTDIR"
     RMDir "$PROGRAMFILES64\DisplayXR\Demos"

--- a/installer/build-installer.bat
+++ b/installer/build-installer.bat
@@ -4,7 +4,7 @@ set "REPO=%~dp0.."
 set "BIN_DIR=%REPO%\build\windows"
 set "OUT_DIR=%~dp0"
 if "%OUT_DIR:~-1%"=="\" set "OUT_DIR=%OUT_DIR:~0,-1%"
-if "%VERSION%"=="" set "VERSION=1.4.1"
+if "%VERSION%"=="" set "VERSION=1.4.2"
 REM Derive MAJOR/MINOR/PATCH from VERSION (e.g. 1.4.2 -> 1 / 4 / 2) so callers
 REM (CI on a v* tag) only need to set VERSION, not all four vars.
 for /f "tokens=1,2,3 delims=." %%a in ("%VERSION%") do (


### PR DESCRIPTION
## Problem

The Windows installer (`DisplayXRGaussianSplatSetup-*.exe`) shipped only `gaussian_splatting_handle_vk_win.exe` + `butterfly.spz` — **no `openxr_loader.dll`**. An OpenXR app must carry its own loader next to the exe; the runtime's copy lives in `…\DisplayXR\Runtime\`, which is intentionally **not on PATH** and **not in an app's DLL search order** (app exe dir → System32 → cwd → PATH). Installed under `Program Files\DisplayXR\Demos\GaussianSplat\`, the demo therefore fails to launch with `openxr_loader.dll not found`.

The macOS bundle already ships `libopenxr_loader` (with a CI assertion); this brings Windows to parity.

Surfaced while testing `DisplayXRBundle-0.3.0` on a Leia machine — the bundled gauss demo couldn't start.

## Fix

- **NSI**: `File` the loader next to the exe on install; `Delete` it on uninstall.
- **CI** (`build-windows.yml`): stage `openxr_loader.dll` into `build\windows` before packaging (so the NSI `File` can't silently miss), and **assert the produced installer contains `openxr_loader.dll`** — mirroring the existing no-`SimulatedReality` regression guard and the macOS loader assertion.

`windows/CMakeLists.txt` already had a POST_BUILD copy of the loader next to the exe; the explicit CI stage is belt-and-suspenders so packaging never depends on `find_file` resolving the DLL.

## Note

Requires a new demo release (`vX.Y.Z` tag) to reach users, and a bundle re-pin (see displayxr-installer#7) for the meta-installer to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)