### PR TITLE
macOS: give the .app a real Dock/Finder/Spotlight icon

### DIFF
--- a/installer/macos/create_app_bundle.sh
+++ b/installer/macos/create_app_bundle.sh
@@ -56,6 +56,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" <<EOF
     <string>${BUNDLE_DISPLAY_NAME}</string>
     <key>CFBundleDisplayName</key>
     <string>${BUNDLE_DISPLAY_NAME}</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
@@ -92,6 +94,41 @@ if [ -f "$ARTIFACT_DIR/assets/butterfly.spz" ]; then
 fi
 if [ -d "$ARTIFACT_DIR/displayxr" ]; then
     cp -R "$ARTIFACT_DIR/displayxr/." "$APP_BUNDLE/Contents/Resources/displayxr/"
+fi
+
+# --- App icon (Contents/Resources/AppIcon.icns) ---
+# Reuse the same 512x512 DisplayXR icon the shell manifest uses
+# (displayxr/icon.png) so the app shows a real icon in Finder / Spotlight /
+# Dock instead of the generic placeholder. Built with stock sips + iconutil.
+# Non-fatal: a missing source or a tool hiccup warns and falls back to the
+# generic icon rather than aborting the whole bundle build.
+make_app_icns() {
+    local src="$1" out="$2" iconset spec px nm
+    iconset="$(mktemp -d)/AppIcon.iconset"
+    mkdir -p "$iconset" || return 1
+    # Source is 512x512 → emit sizes up to 512 (256@2x). 512@2x (1024) is
+    # omitted rather than upscaled, to avoid a blurry largest slot.
+    for spec in 16:16x16 32:16x16@2x 32:32x32 64:32x32@2x 128:128x128 \
+                256:128x128@2x 256:256x256 512:256x256@2x 512:512x512; do
+        px="${spec%%:*}"; nm="${spec##*:}"
+        if ! sips -z "$px" "$px" "$src" --out "$iconset/icon_$nm.png" >/dev/null 2>&1; then
+            rm -rf "$(dirname "$iconset")"; return 1
+        fi
+    done
+    local rc=0
+    iconutil -c icns "$iconset" -o "$out" || rc=1
+    rm -rf "$(dirname "$iconset")"
+    return $rc
+}
+ICON_SRC="$ARTIFACT_DIR/displayxr/icon.png"
+if [ -f "$ICON_SRC" ]; then
+    if make_app_icns "$ICON_SRC" "$APP_BUNDLE/Contents/Resources/AppIcon.icns"; then
+        echo "App icon set from $ICON_SRC"
+    else
+        echo "WARN: app icon generation failed — bundle will use the generic icon." >&2
+    fi
+else
+    echo "WARN: app icon source not found at $ICON_SRC — bundle will use the generic icon." >&2
 fi
 
 # --- Resources/lib: bundled support dylibs ---


### PR DESCRIPTION
## Problem

The installed `Gaussian Splat Viewer.app` had **no icon** — `Info.plist` carried no `CFBundleIconFile` and `Contents/Resources/` had no `.icns`, so Finder / Spotlight / Dock showed the generic placeholder tile.

## Fix

In `installer/macos/create_app_bundle.sh`:
- Build a multi-resolution `AppIcon.icns` from the existing **512×512 `macos/displayxr/icon.png`** — the same DisplayXR icon already used for the shell manifest — using stock `sips` + `iconutil` (9 slots, 16→512px; the 1024 slot is omitted rather than upscaled from 512 to avoid blur).
- Drop it at `Contents/Resources/AppIcon.icns` and add `CFBundleIconFile = AppIcon` to `Info.plist`.
- Non-fatal: a missing source icon or a tool hiccup warns and falls back to the generic icon instead of aborting the bundle build.

No change to `build_macos.sh` / `build_installer.sh` — they already stage `macos/displayxr/` (incl. `icon.png`) into the artifact dir `create_app_bundle.sh` reads, so the icon flows straight into the released `.pkg`.

## Validated locally

- `bash -n` clean.
- End-to-end run of `create_app_bundle.sh` against a minimal artifact dir: bundle builds without aborting, `CFBundleIconFile = AppIcon`, and a valid 9-slot `Mac OS X icon` lands in Resources. Rendered preview = the butterfly icon (matches the bundled `butterfly.spz` scene).

Ships on the next demo release; existing installs pick it up on reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)