### PR TITLE
feat: foreground-only clipping in transparent mode

### DIFF
--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -38,8 +38,9 @@ struct alignas(16) GsUniformBuffer {
     uint32_t height;           // offset 148
     float tan_fovx;            // offset 152
     float tan_fovy;            // offset 156
+    float clip_far;            // offset 160 — view-space far cull (0 = disabled)
 };
-static_assert(sizeof(GsUniformBuffer) == 160, "GsUniformBuffer must be 160 bytes");
+static_assert(sizeof(GsUniformBuffer) == 176, "GsUniformBuffer must be 176 bytes");
 
 // ── Helper: create a compute pipeline from SPIR-V ───────────────────────
 static VkShaderModule createShaderModule(VkDevice device, const uint32_t* code, size_t sizeBytes)
@@ -810,7 +811,8 @@ uint32_t GsRenderer::gaussianCount() const { return numGaussians_; }
 // ═════════════════════════════════════════════════════════════════════════
 
 void GsRenderer::updateUniforms(const float viewMatrix[16], const float projMatrix[16],
-                                uint32_t vpWidth, uint32_t vpHeight)
+                                uint32_t vpWidth, uint32_t vpHeight,
+                                float clipFar)
 {
     GsUniformBuffer ub;
 
@@ -880,6 +882,9 @@ void GsRenderer::updateUniforms(const float viewMatrix[16], const float projMatr
     ub.tan_fovx = (std::abs(p00) > 1e-6f) ? (1.0f / std::abs(p00)) : 1.0f;
     ub.tan_fovy = (std::abs(p11) > 1e-6f) ? (1.0f / std::abs(p11)) : 1.0f;
 
+    // Foreground-only far cull (view-space forward distance). 0 = disabled.
+    ub.clip_far = clipFar;
+
     // Map and write
     void* mapped = nullptr;
     vkMapMemory(device_, uniformBuffer_.memory, 0, sizeof(GsUniformBuffer), 0, &mapped);
@@ -901,12 +906,14 @@ void GsRenderer::renderEye(VkImage swapchainImage,
                            uint32_t viewportHeight,
                            const float viewMatrix[16],
                            const float projMatrix[16],
-                           bool transparentBg)
+                           bool transparentBg,
+                           float clipFarViewSpace)
 {
     if (!hasScene()) return;
 
     // Update uniform buffer with this eye's matrices
-    updateUniforms(viewMatrix, projMatrix, viewportWidth, viewportHeight);
+    updateUniforms(viewMatrix, projMatrix, viewportWidth, viewportHeight,
+                   clipFarViewSpace);
 
     uint32_t N = numGaussians_;
     uint32_t groups256 = (N + 255) / 256;

--- a/3dgs_common/gs_renderer.h
+++ b/3dgs_common/gs_renderer.h
@@ -111,6 +111,8 @@ struct GsRenderer {
     // transparentBg=true makes the render shader output premultiplied alpha
     // (1 - T) so background-uncovered pixels are 0 — the runtime then strips
     // them on the chroma-key pass for desktop see-through.
+    // clipFarViewSpace>0 culls splats whose view-space forward distance exceeds
+    // it (foreground-only mode: hide content behind the display plane). 0=off.
     void renderEye(VkImage swapchainImage,
                    VkFormat swapchainFormat,
                    uint32_t imageWidth,
@@ -121,7 +123,8 @@ struct GsRenderer {
                    uint32_t viewportHeight,
                    const float viewMatrix[16],
                    const float projMatrix[16],
-                   bool transparentBg = false);
+                   bool transparentBg = false,
+                   float clipFarViewSpace = 0.0f);
 
     // Clean up all resources.
     void cleanup();
@@ -153,7 +156,7 @@ private:
     // ── GPU Buffers (14 total) ───────────────────────────────────────────
     GsBuffer vertexBuffer_;         // N * 240 bytes
     GsBuffer cov3DBuffer_;          // N * 24 bytes
-    GsBuffer uniformBuffer_;        // 160 bytes (host-visible)
+    GsBuffer uniformBuffer_;        // 176 bytes (host-visible)
     GsBuffer vertexAttrBuffer_;     // N * 64 bytes
     GsBuffer tileOverlapBuffer_;    // N * 4 bytes
     GsBuffer prefixSumPingBuffer_;  // N * 4 bytes
@@ -234,6 +237,7 @@ private:
     void growSortBuffers(uint32_t requiredCapacity);
     void dispatchPrecompCov3d();
     void updateUniforms(const float viewMatrix[16], const float projMatrix[16],
-                        uint32_t vpWidth, uint32_t vpHeight);
+                        uint32_t vpWidth, uint32_t vpHeight,
+                        float clipFar = 0.0f);
     void cleanupScene();
 };

--- a/3dgs_common/shaders/preprocess.comp
+++ b/3dgs_common/shaders/preprocess.comp
@@ -23,6 +23,7 @@ layout (std140, set = 1, binding = 0) uniform Params {
     uint height;
     float tan_fovx;
     float tan_fovy;
+    float clip_far;   // view-space far cull distance; 0 = disabled
 };
 
 layout (std430, set = 1, binding = 1) writeonly buffer VertexAttributes {
@@ -128,6 +129,13 @@ void main() {
 
     vec4 p_view = view_mat * vertices[index].position;
     if (p_view.z <= 0.2f) {
+        return;
+    }
+
+    // Foreground-only clip (transparent mode): cull splats past the display
+    // plane. clip_far is the eye->plane forward distance; p_view.z is the
+    // splat's forward distance (view_mat has +Z = forward). 0 = disabled.
+    if (clip_far > 0.0f && p_view.z > clip_far) {
         return;
     }
 

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -1071,14 +1071,32 @@ static void RenderThreadFunc(
                             }
                         }
 
+                        // Foreground-only clip: in transparent mode, cull splats
+                        // behind the virtual display plane so only popping-out
+                        // content shows. Suppressed under the shell's external
+                        // multi-compositor (non-controller workspace session,
+                        // where the per-app transparent bridge is bypassed) —
+                        // signalled by renderingModeIsRequestable being false.
+                        bool standalone = (xr->renderingModeCount == 0) ||
+                            (xr->currentModeIndex < xr->renderingModeCount &&
+                             xr->renderingModeIsRequestable[xr->currentModeIndex]);
+                        bool foregroundClip = g_transparentBg.load() && standalone;
+
                         // Build per-eye view/projection matrices (column-major float[16]).
                         // Sized to the runtime's max view count so Quad mode (4 views) fits.
                         float viewMat[8][16], projMat[8][16];
+                        float clipFar[8] = {0};  // per-eye view-space far cull (0 = off)
                         for (int eye = 0; eye < eyeCount; eye++) {
                             if (useAppProjection) {
                                 int srcEye = monoMode ? 0 : eye;
                                 memcpy(viewMat[eye], stereoViews[srcEye].view_matrix, sizeof(float) * 16);
                                 memcpy(projMat[eye], stereoViews[srcEye].projection_matrix, sizeof(float) * 16);
+                                // eye_display.z = eye->display-plane forward distance,
+                                // same world units as the shader's p_view.z.
+                                if (foregroundClip) {
+                                    float cf = stereoViews[srcEye].eye_display.z;
+                                    clipFar[eye] = (cf > 0.2f) ? cf : 0.0f;  // never cull at/behind near
+                                }
                             } else {
                                 // Fallback: use DirectXMath mono matrices, store as column-major
                                 XMMATRIX v = monoMode ? monoViewMatrix :
@@ -1118,7 +1136,7 @@ static void RenderThreadFunc(
                                         xr->swapchain.width, xr->swapchain.height,
                                         vpX, vpY, renderW, renderH,
                                         viewMat[eye], projMat[eye],
-                                        g_transparentBg.load());
+                                        g_transparentBg.load(), clipFar[eye]);
                                 }
                             } else {
                                 RenderPlaceholder(vkDevice, graphicsQueue, renderCmdPool,


### PR DESCRIPTION
## What

In transparent mode (Ctrl+T), only the part of the scene **in front of** the virtual display plane (the popping-out content) now renders. Geometry sunk behind the plane is culled, instead of being punched through to the desktop along with the foreground.

Requested behavior mirrors the Unity reference (`displayxr-unity-test-transparent`, `foregroundOnlyClip`): far clip per view = the eye→plane z-delta.

## How

This is a **compute splatting pipeline with no fixed-function far clip** — `preprocess.comp` only culled on near depth (`p_view.z <= 0.2`) and never used NDC z, so writing a smaller `far_z` into the projection matrix does nothing. The effect is produced by an explicit **view-space far cull** in `preprocess.comp` at distance = the per-view eye→display-plane delta, which `display3d_compute_view` already exposes as `Display3DView.eye_display.z` (same world units as the shader's `p_view.z`).

- `preprocess.comp`: add `clip_far` to the `Params` UBO; cull `p_view.z > clip_far` (`0` = disabled).
- `GsUniformBuffer`: add `clip_far` (std140 offset 160); `static_assert` 160 → 176.
- `renderEye` / `updateUniforms`: thread a defaulted `clipFar` param (default `0.0f`, so macOS compiles unchanged).
- `windows/main.cpp`: per-view `clipFar = eye_display.z` (guard `> 0.2`), gated on transparent mode **AND** a standalone session via `renderingModeIsRequestable` (v13 `XR_EXT_display_info`) — so the shell's external multi-compositor path is left untouched.

Picking/teleport stay at full range (they use a separate `display3d_compute_view` call), matching the reference's "hit-test stays at full range" choice. Both display-centric and camera-centric rigs are covered because the render path always goes through `display3d_compute_views`, so the display plane *is* the convergence plane.

## Test

Built and run on the Leia SR dev machine: launches, creates the LeiaSR session, loads the bundled scene, and Ctrl+T engages foreground clipping without crashing. User confirmed the visual result works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)