### PR TITLE
ZDP-relative per-eye clip planes

### DIFF
--- a/common/display3d_view.c
+++ b/common/display3d_view.c
@@ -263,8 +263,8 @@ display3d_compute_view(const XrVector3f *processed_eye,
                        const Display3DScreen *screen,
                        const Display3DTunables *tunables,
                        const XrPosef *display_pose,
-                       float near_z,
-                       float far_z,
+                       float clip_front,
+                       float clip_back,
                        Display3DView *out)
 {
 	Display3DTunables t = tunables ? *tunables : display3d_default_tunables();
@@ -296,6 +296,20 @@ display3d_compute_view(const XrVector3f *processed_eye,
 	eye_world.y += disp_pos.y;
 	eye_world.z += disp_pos.z;
 	out->eye_world = eye_world;
+
+	// ZDP-relative clip planes: a fixed fraction of this eye's perpendicular
+	// distance to the display/convergence plane (ZDP), in front of / behind it.
+	// eye_scaled.z is that per-eye distance (== out->eye_display.z), so the
+	// planes are automatically per-eye and scale with the virtual display
+	// (zoom). clip_back = 0 => far sits at the ZDP (foreground-only, e.g.
+	// transparent mode). See proposal in the demo's clip-plane discussion.
+	float ez_clip = eye_scaled.z;
+	if (ez_clip <= 0.001f)
+		ez_clip = 0.65f;
+	float near_z = ez_clip * (1.0f - clip_front);
+	float far_z = ez_clip * (1.0f + clip_back);
+	if (near_z < 1.0e-4f)
+		near_z = 1.0e-4f;
 
 	// Build view matrix + projection + FOV
 	build_view_matrix(out->view_matrix, disp_ori, eye_world);
@@ -481,8 +495,8 @@ display3d_compute_views(const XrVector3f *raw_eyes,
                                const Display3DScreen *screen,
                                const Display3DTunables *tunables,
                                const XrPosef *display_pose,
-                               float near_z,
-                               float far_z,
+                               float clip_front,
+                               float clip_back,
                                Display3DView *out_views)
 {
 	Display3DTunables t = tunables ? *tunables : display3d_default_tunables();
@@ -497,7 +511,7 @@ display3d_compute_views(const XrVector3f *raw_eyes,
 	// Compute each view via single-eye primitive
 	for (uint32_t i = 0; i < count; i++) {
 		display3d_compute_view(&processed[i], screen, &t,
-		                       display_pose, near_z, far_z,
+		                       display_pose, clip_front, clip_back,
 		                       &out_views[i]);
 	}
 

--- a/common/display3d_view.h
+++ b/common/display3d_view.h
@@ -69,8 +69,10 @@ typedef struct Display3DView {
  * @param screen         Physical screen dimensions
  * @param tunables       View factors (or NULL for defaults: all 1.0)
  * @param display_pose   Display pose in world space (or NULL for identity)
- * @param near_z         Near clip plane distance
- * @param far_z          Far clip plane distance
+ * @param clip_front     Pop-out clip as a fraction of the per-eye eye->display
+ *                       (ZDP) distance: near = ez * (1 - clip_front).
+ * @param clip_back      Recede clip as a fraction: far = ez * (1 + clip_back).
+ *                       clip_back = 0 => far at the ZDP (foreground only).
  * @param out_views      Output array of N views
  */
 void
@@ -80,8 +82,8 @@ display3d_compute_views(const XrVector3f *raw_eyes,
                                const Display3DScreen *screen,
                                const Display3DTunables *tunables,
                                const XrPosef *display_pose,
-                               float near_z,
-                               float far_z,
+                               float clip_front,
+                               float clip_back,
                                Display3DView *out_views);
 
 /*!
@@ -164,8 +166,9 @@ display3d_apply_eye_factors_n(const XrVector3f *raw_eyes,
  * @param screen         Physical screen dimensions
  * @param tunables       View factors (perspective_factor, virtual_display_height)
  * @param display_pose   Display pose in world space (or NULL for identity)
- * @param near_z         Near clip plane distance
- * @param far_z          Far clip plane distance
+ * @param clip_front     Pop-out clip fraction: near = ez * (1 - clip_front).
+ * @param clip_back      Recede clip fraction: far = ez * (1 + clip_back);
+ *                       0 => far at the ZDP (foreground only).
  * @param out            Output view for this eye
  */
 void
@@ -173,8 +176,8 @@ display3d_compute_view(const XrVector3f *processed_eye,
                        const Display3DScreen *screen,
                        const Display3DTunables *tunables,
                        const XrPosef *display_pose,
-                       float near_z,
-                       float far_z,
+                       float clip_front,
+                       float clip_back,
                        Display3DView *out);
 
 /*!

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -1773,10 +1773,18 @@ int main() {
                             tunables.perspective_factor = g_input.viewParams.perspectiveFactor;
                             tunables.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
 
+                            // ZDP-relative clip planes (computed per-eye from eye.z inside
+                            // display3d_compute_view): near = ez*(1-clip_front), far =
+                            // ez*(1+clip_back). Scales with the virtual display (zoom) so
+                            // large scenes don't clip. macOS has no transparent-bg mode, so
+                            // clip_back stays 2.0 (no foreground-only ZDP clamp here).
+                            const float clip_front = 0.5f;
+                            const float clip_back  = 2.0f;
+
                             display3d_compute_views(
                                 rawEyePos.data(), (uint32_t)eyeCount, &nominalViewer,
                                 &screen, &tunables, &cameraPose,
-                                0.01f, 100.0f, eyeViews.data());
+                                clip_front, clip_back, eyeViews.data());
                         }
 
                         // Double-click focus: ray from CENTER physical eyes through the
@@ -1834,7 +1842,7 @@ int main() {
                             cameraPoseWorld.position.y = g_input.cameraPosY;
                             Display3DView centerView;
                             display3d_compute_view(&centerEyeProcessed, &screen2, &tunables2,
-                                                   &cameraPoseWorld, 0.01f, 100.0f, &centerView);
+                                                   &cameraPoseWorld, 0.5f, 2.0f, &centerView);
 
                             XrVector3f rayOriginV, rayDirV;
                             display3d_unproject_ndc_to_ray(ndcX, ndcY,

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -929,6 +929,15 @@ static void RenderThreadFunc(
                             tunables.perspective_factor = inputSnapshot.viewParams.perspectiveFactor;
                             tunables.virtual_display_height = inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
 
+                            // ZDP-relative clip: near/far placed a fixed fraction of the
+                            // per-eye eye->display distance in front of / behind the
+                            // convergence plane (ZDP). display3d_compute_view computes them
+                            // per-eye from eye.z, so they scale with the virtual display
+                            // (zoom) regardless of scene scale. Transparent mode clips at the
+                            // ZDP (clip_back = 0), matching the foreground-only behavior.
+                            const float clip_front = 0.5f;
+                            const float clip_back  = g_transparentBg.load() ? 0.0f : 2.0f;
+
                             XrPosef displayPose;
                             XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
                                 renderPitch, inputSnapshot.yaw, 0);
@@ -949,7 +958,7 @@ static void RenderThreadFunc(
                             display3d_compute_views(
                                 rawEyes, (uint32_t)eyeCount, &nominalViewer,
                                 &screen, &tunables, &displayPose,
-                                0.01f, 100.0f, stereoViews);
+                                clip_front, clip_back, stereoViews);
                         }
 
                         // Double-click focus: center-eye ray through mouse, pick splat,
@@ -992,8 +1001,10 @@ static void RenderThreadFunc(
                             displayPoseLocal.orientation = {q.x, q.y, q.z, q.w};
                             displayPoseLocal.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY, inputSnapshot.cameraPosZ};
                             Display3DView centerView;
+                            const float pick_clip_front = 0.5f;
+                            const float pick_clip_back  = g_transparentBg.load() ? 0.0f : 2.0f;
                             display3d_compute_view(&centerEyeProcessed, &screen2, &tunables2,
-                                                   &displayPoseLocal, 0.01f, 100.0f, &centerView);
+                                                   &displayPoseLocal, pick_clip_front, pick_clip_back, &centerView);
 
                             XrVector3f rayOriginV, rayDirV;
                             display3d_unproject_ndc_to_ray(ndcX, ndcY,


### PR DESCRIPTION
Mirror of the model-viewer change: near/far relative to the ZDP per eye (near=ez*(1-f), far=ez*(1+b); f=0.5/b=2.0, transparent→b=0; macOS b=2.0). Scales with zoom; better depth precision. Updated common/display3d_view.* + windows/main.cpp + macos/main.mm. build-macos CI validates the .mm compile.