### PR TITLE
ci: validate builds on PRs + main pushes

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,19 +1,22 @@
 name: Build macOS
 
-# Tag-triggered macOS .pkg build. Mirrors the BuildInstaller job in
-# displayxr-runtime's build-macos.yml. The demo's release cadence is
-# manual — devs build locally and push a v* tag when ready; this workflow
-# produces `DisplayXRGaussianSplat-<version>.pkg` and attaches it to the
-# GitHub Release.
+# macOS .pkg build. Mirrors the BuildInstaller job in displayxr-runtime's
+# build-macos.yml. The demo's release cadence is manual — devs build locally
+# and push a v* tag when ready; on a v* tag this workflow produces
+# `DisplayXRGaussianSplat-<version>.pkg` and attaches it to the GitHub Release.
 #
-# Scope is intentionally narrow: no PR-time runs, no push-to-main runs.
-# Daily iteration is local-build (per the runtime org's "local builds
-# preferred" convention).
+# PR + push-to-main runs are validation only: they build the app + .pkg and
+# assert its payload to catch breakage before a release. The release-attach
+# step stays gated on a v* ref, so it only fires on tags.
 
 on:
+  pull_request: {}
   push:
+    branches:
+      - main
     tags:
       - 'v*'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,18 +1,21 @@
 name: Build Windows
 
-# Tag-triggered Windows installer build. Mirrors build-macos.yml (and the
-# BuildInstaller job in displayxr-runtime's build-windows.yml). The demo's
-# release cadence is manual — devs push a v* tag when ready; this workflow
-# builds DisplayXRGaussianSplatSetup-<version>.exe and attaches it to the
-# GitHub Release. workflow_dispatch is provided so the build can be exercised
-# without cutting a tag (a dispatch run uploads an artifact but does NOT
-# publish a release — the attach step is gated on a v* ref).
+# Windows installer build. Mirrors build-macos.yml (and the BuildInstaller
+# job in displayxr-runtime's build-windows.yml). The demo's release cadence
+# is manual — devs push a v* tag when ready; on a v* tag this workflow builds
+# DisplayXRGaussianSplatSetup-<version>.exe and attaches it to the GitHub
+# Release. workflow_dispatch lets the build be exercised without cutting a tag.
 #
-# Scope is intentionally narrow: no PR-time runs, no push-to-main runs.
-# Daily iteration is local-build (per the runtime org's convention).
+# PR + push-to-main runs are validation only: they compile the app + installer
+# to catch breakage before a release, but the release-attach step and the
+# versions.json DispatchVersionsBump job stay gated on a v* ref, so they only
+# fire on tags.
 
 on:
+  pull_request: {}
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch: {}


### PR DESCRIPTION
## What

Add `pull_request` and `push: branches: [main]` triggers to both demo build workflows (`build-windows.yml`, `build-macos.yml`), alongside the existing `push: tags: ['v*']` and `workflow_dispatch`.

PR and main-push runs now **compile the app and build the installer** (Windows `DisplayXRGaussianSplatSetup-*.exe`, macOS `DisplayXRGaussianSplat-*.pkg`) and run the existing payload-assert regression guards. This catches build breakage **before** a release tag is cut, instead of only discovering it at release time.

## Release behavior is unchanged (stays tag-only)

- The **"Attach installer/.pkg to GitHub release"** steps keep `if: startsWith(github.ref, 'refs/tags/v')` — no release is created or updated on a PR/main build.
- The **`DispatchVersionsBump`** job keeps its `startsWith(github.ref,'refs/tags/v') && github.repository == 'DisplayXR/displayxr-demo-gaussiansplat'` gate — `versions.json[gauss_demo]` is only bumped on a real `v*` tag.

## Why PR builds won't fail on version

- Windows "Derive installer version" already emits a `0.0.0` placeholder when `GITHUB_REF` isn't a `v*` tag (used by `workflow_dispatch`).
- macOS "Derive installer version" emits a `0.0.0-dev.<sha>` placeholder for non-tag refs.

Both keep NSIS `VIProductVersion` / `productbuild --version` valid for validation builds without publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)