### PR TITLE
ci: distinct job names + docs-only sentinel so CI can be required

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,6 +8,11 @@ name: Build macOS
 # PR + push-to-main runs are validation only: they build the app + .pkg and
 # assert its payload to catch breakage before a release. The release-attach
 # step stays gated on a v* ref, so it only fires on tags.
+#
+# The DetectChanges job + docs_only step gating let this workflow be a required
+# status check (the "Build macOS" job always runs and reports success in ~30s
+# on doc-only PRs, skipping the heavy build) without blocking doc PRs. Mirrors
+# the sentinel pattern in displayxr-runtime + displayxr-leia-plugin.
 
 on:
   pull_request: {}
@@ -31,7 +36,36 @@ permissions:
   contents: write
 
 jobs:
+  DetectChanges:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+          NON_DOC=$(echo "$CHANGED" | grep -vE '^(docs/|.*\.md$|LICENSE$|\.github/ISSUE_TEMPLATE/)' || true)
+          if [ -n "$CHANGED" ] && [ -z "$NON_DOC" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   BuildInstaller:
+    name: Build macOS
+    needs: DetectChanges
     runs-on: macos-14
     env:
       GH_TOKEN: ${{ github.token }}
@@ -39,7 +73,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Doc-only PR — skipping heavy build steps
+        if: needs.DetectChanges.outputs.docs_only == 'true'
+        run: echo "docs_only=true; build steps will skip and report success."
+
       - name: Install dependencies
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         # No `openxr-loader` formula exists in Homebrew core. The build
         # script clones KhronosGroup/OpenXR-SDK-Source and installs the
         # loader under /tmp/openxr-install (mirroring the runtime repo).
@@ -52,6 +91,7 @@ jobs:
           echo "VULKAN_SDK=$BREW_PREFIX" >> "$GITHUB_ENV"
 
       - name: Derive installer version
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         id: version
         run: |
           # `v1.2.3` → `1.2.3` for productbuild's --version arg and the
@@ -66,11 +106,13 @@ jobs:
           echo "Building installer with VERSION=$VERSION"
 
       - name: Build demo + installer
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         env:
           DISPLAYXR_VERSION: ${{ steps.version.outputs.version }}
         run: ./scripts/build_macos.sh --installer
 
       - name: Assert .pkg payload (regression guard)
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -115,6 +157,7 @@ jobs:
           echo "PASS: .pkg payload contains app + bundled scene + dylibs."
 
       - name: Upload installer
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           retention-days: 3
@@ -127,7 +170,7 @@ jobs:
       # release workflow on the same tag races, the action just appends
       # — both assets end up on the same release.
       - name: Attach .pkg to GitHub release on tag
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: _package/DisplayXRGaussianSplat-*.pkg

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,6 +10,11 @@ name: Build Windows
 # to catch breakage before a release, but the release-attach step and the
 # versions.json DispatchVersionsBump job stay gated on a v* ref, so they only
 # fire on tags.
+#
+# The DetectChanges job + docs_only step gating let this workflow be a required
+# status check (the "Build Windows" job always runs and reports success in
+# ~30s on doc-only PRs, skipping the heavy build) without blocking doc PRs.
+# Mirrors the sentinel pattern in displayxr-runtime + displayxr-leia-plugin.
 
 on:
   pull_request: {}
@@ -31,7 +36,36 @@ permissions:
   contents: write
 
 jobs:
+  DetectChanges:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+          NON_DOC=$(echo "$CHANGED" | grep -vE '^(docs/|.*\.md$|LICENSE$|\.github/ISSUE_TEMPLATE/)' || true)
+          if [ -n "$CHANGED" ] && [ -z "$NON_DOC" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   BuildInstaller:
+    name: Build Windows
+    needs: DetectChanges
     runs-on: windows-2022
     env:
       GH_TOKEN: ${{ github.token }}
@@ -39,7 +73,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Doc-only PR — skipping heavy build steps
+        if: needs.DetectChanges.outputs.docs_only == 'true'
+        run: echo "docs_only=true; build steps will skip and report success."
+
       - name: Install Vulkan SDK
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         # Same action + version the runtime + Leia-plugin Windows CI use.
         # Provides glslangValidator (needed by 3dgs_common's shader compile)
         # under $VULKAN_SDK\Bin.
@@ -48,13 +87,16 @@ jobs:
           version: 1.3.283.0
           cache: true
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - if: needs.DetectChanges.outputs.docs_only != 'true'
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Add Vulkan SDK tools to PATH
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         shell: pwsh
         run: '"$env:VULKAN_SDK\Bin" | Out-File -FilePath $env:GITHUB_PATH -Append'
 
       - name: Install OpenXR loader
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         shell: pwsh
         run: |
           # The demo links the OpenXR loader. Mirror the runtime repo: grab the
@@ -65,6 +107,7 @@ jobs:
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force
 
       - name: Derive installer version
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         id: version
         shell: pwsh
         run: |
@@ -80,6 +123,7 @@ jobs:
           Write-Host "Building installer with VERSION=$version"
 
       - name: Build demo
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         shell: pwsh
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
@@ -87,6 +131,7 @@ jobs:
           cmake --build build
 
       - name: Stage OpenXR loader next to demo binary
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         shell: pwsh
         run: |
           # An OpenXR app must ship its own openxr_loader.dll next to the exe.
@@ -113,12 +158,14 @@ jobs:
           Write-Host "Staged x64 $($dll.FullName) -> build\windows\openxr_loader.dll"
 
       - name: Build installer
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         shell: cmd
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: call installer\build-installer.bat
 
       - name: Assert installer carries no vendor SR DLL (regression guard)
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         shell: pwsh
         run: |
           $exe = Get-ChildItem installer\DisplayXRGaussianSplatSetup-*.exe | Select-Object -First 1
@@ -144,6 +191,7 @@ jobs:
           Write-Host "PASS: installer bundles openxr_loader.dll."
 
       - name: Upload installer
+        if: needs.DetectChanges.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           retention-days: 3
@@ -155,7 +203,7 @@ jobs:
       # a v* tag and attaches the .exe. If the macOS workflow races on the same
       # tag, the action just appends — both assets land on the same release.
       - name: Attach installer to GitHub release on tag
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: installer/DisplayXRGaussianSplatSetup-*.exe


### PR DESCRIPTION
## Why

Enabling CI-gated **auto-merge** on this repo needs its build workflows to be **required status checks**. Two blockers prevented that:

1. **Duplicate check context** — `build-windows.yml` and `build-macos.yml` both named their job `BuildInstaller`, so both produced a check run named `BuildInstaller`. You can't require one without ambiguity.
2. **No docs-only short-circuit** — without a sentinel, requiring the builds would force every doc-only PR through a full Windows + macOS build before it could merge.

## What

- **Distinct job display names:** `BuildInstaller` → `name: Build Windows` / `name: Build macOS`. The job **keys stay `BuildInstaller`**, so `DispatchVersionsBump`'s `needs: [BuildInstaller]` is unchanged. New requirable contexts: **`Build Windows`**, **`Build macOS`**.
- **DetectChanges docs-only sentinel** (mirrors `displayxr-runtime` + `displayxr-leia-plugin`): the build job always runs but gates its heavy steps on `docs_only != 'true'`. Doc-only PRs report success in ~30s; the release-attach steps additionally keep their `v*` tag gate.

## After merge

I'll add `Build Windows` + `Build macOS` as required status checks on `main` and drop the (self-unsatisfiable) required-review rule, giving this repo the same hands-off CI-gated auto-merge as runtime/leia/shell-pvt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)