### PR TITLE
feat(mcp): expose viewer controls as XR_EXT_mcp_tools agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ A test scene, `butterfly.spz`, is bundled and auto-loads at startup.
 | Ctrl+T | Toggle transparent background (desktop see-through; Windows only, requires runtime ≥ v1.3.0) |
 | Esc | Quit |
 
+## Agent tools (MCP)
+
+When the runtime's MCP capability is enabled (`DISPLAYXR_MCP=1` or the
+Capabilities registry key), the viewer registers its controls as agent
+tools on the runtime-hosted per-process MCP server via
+`XR_EXT_mcp_tools` (macOS build; appId `gaussiansplat`):
+`load_splat`, `get_status`, `set_camera`, `orbit`, `reset_camera`,
+`set_auto_orbit`. Agents reach them through the `displayxr-mcp` adapter
+(`--target pid:<PID>`, or namespaced as `gaussiansplat__<tool>` via
+`--target workspace`) and can verify camera moves with the runtime's
+`capture_frame` tool. With the gate off (the default) the tools are
+absent and the viewer behaves identically.
+
 ## Build from source
 
 ### Prerequisites (both platforms)

--- a/macos/displayxr/gaussian_splatting_handle_vk_macos.displayxr.json
+++ b/macos/displayxr/gaussian_splatting_handle_vk_macos.displayxr.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "gaussiansplat",
   "name": "Gaussian Splat Viewer",
   "type": "3d",
   "category": "demo",

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -30,10 +30,13 @@
 #include <openxr/XR_EXT_cocoa_window_binding.h>
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
+#include <openxr/XR_EXT_mcp_tools.h>
 
+#include <cctype>
 #include <cmath>
 #include <csignal>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -927,6 +930,15 @@ struct AppXrSession {
     bool hasAtlasCaptureExt = false;
     PFN_xrCaptureAtlasEXT pfnCaptureAtlasEXT = nullptr;
 
+    // XR_EXT_mcp_tools (#32): viewer controls exposed as agent tools on the
+    // per-process MCP server the runtime hosts. Inert when the extension or
+    // the MCP capability gate (DISPLAYXR_MCP) is absent — never load-bearing.
+    bool hasMcpToolsExt = false;
+    PFN_xrSetMCPAppInfoEXT pfnSetMCPAppInfoEXT = nullptr;
+    PFN_xrRegisterMCPToolEXT pfnRegisterMCPToolEXT = nullptr;
+    PFN_xrGetMCPToolCallArgsEXT pfnGetMCPToolCallArgsEXT = nullptr;
+    PFN_xrSubmitMCPToolResultEXT pfnSubmitMCPToolResultEXT = nullptr;
+
     // Enumerated rendering mode info
     uint32_t renderingModeCount = 0;
     char renderingModeNames[8][XR_MAX_SYSTEM_NAME_SIZE] = {};
@@ -956,6 +968,371 @@ static void UpdateTopBarButtonTitles(AppXrSession& xr) {
         }
         [g_modeButton setTitle:[NSString stringWithFormat:@"Mode: %s", name]];
     }
+}
+
+// ============================================================================
+// Agent tools (XR_EXT_mcp_tools, #32)
+// ============================================================================
+//
+// The viewer's controls are registered as MCP tools on the per-process MCP
+// server the runtime hosts; agents reach them via the displayxr-mcp adapter
+// (`--target pid:N`, or namespaced as `gaussiansplat__<tool>` through
+// `--target workspace`). Dispatch is event-based: a call arrives as
+// XrEventDataMCPToolCallEXT through PollEvents() — on the main loop, where
+// viewer state is consistent — and EVERY call is answered (the runtime fails
+// unanswered calls to the agent after ~5 s). The whole path is inert when the
+// extension or the MCP capability gate (DISPLAYXR_MCP) is absent.
+//
+// Tool arguments are flat JSON objects, scanned with the minimal helpers
+// below (mirrors the reference adopter cube_handle_metal_macos — no JSON
+// library; the schemas keep every argument top-level).
+
+static const char* kMcpAppId = "gaussiansplat"; // == manifest `id` (INV-10.1)
+
+static constexpr float kMcpRad2Deg = 57.2957795f;
+static constexpr float kMcpDeg2Rad = 0.0174532925f;
+static constexpr float kMcpMaxPitchRad = 1.5f;  // same clamp as mouse drag
+
+// Find the value position of `"key" :` in a flat JSON object. Returns NULL if
+// absent. Does not handle keys nested inside sub-objects or string values —
+// the registered schemas keep all arguments top-level.
+static const char* JsonFindValue(const char* json, const char* key) {
+    char quoted[96];
+    snprintf(quoted, sizeof(quoted), "\"%s\"", key);
+    const char* p = json;
+    while ((p = strstr(p, quoted)) != nullptr) {
+        const char* q = p + strlen(quoted);
+        while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') q++;
+        if (*q == ':') {
+            q++;
+            while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') q++;
+            return q;
+        }
+        p = q;
+    }
+    return nullptr;
+}
+
+static bool JsonGetNumber(const char* json, const char* key, double* out) {
+    const char* v = JsonFindValue(json, key);
+    if (!v) return false;
+    char* end = nullptr;
+    double d = strtod(v, &end);
+    if (end == v) return false;
+    *out = d;
+    return true;
+}
+
+static bool JsonGetBool(const char* json, const char* key, bool* out) {
+    const char* v = JsonFindValue(json, key);
+    if (!v) return false;
+    if (strncmp(v, "true", 4) == 0)  { *out = true;  return true; }
+    if (strncmp(v, "false", 5) == 0) { *out = false; return true; }
+    return false;
+}
+
+// Extract + unescape a JSON string value. Handles the standard escapes and
+// BMP \uXXXX (encoded back to UTF-8; surrogate halves degrade to '?').
+static bool JsonGetString(const char* json, const char* key, std::string* out) {
+    const char* v = JsonFindValue(json, key);
+    if (!v || *v != '"') return false;
+    out->clear();
+    for (const char* c = v + 1; *c; c++) {
+        if (*c == '"') return true;
+        if (*c != '\\') { out->push_back(*c); continue; }
+        c++;
+        switch (*c) {
+            case '"':  out->push_back('"');  break;
+            case '\\': out->push_back('\\'); break;
+            case '/':  out->push_back('/');  break;
+            case 'n':  out->push_back('\n'); break;
+            case 't':  out->push_back('\t'); break;
+            case 'r':  out->push_back('\r'); break;
+            case 'b':  out->push_back('\b'); break;
+            case 'f':  out->push_back('\f'); break;
+            case 'u': {
+                unsigned cp = 0;
+                for (int i = 1; i <= 4; i++) {
+                    char h = c[i];
+                    if (!isxdigit((unsigned char)h)) return false;
+                    cp = cp * 16 + (unsigned)(isdigit((unsigned char)h) ? h - '0'
+                                                                        : (tolower(h) - 'a' + 10));
+                }
+                c += 4;
+                if (cp < 0x80) {
+                    out->push_back((char)cp);
+                } else if (cp < 0x800) {
+                    out->push_back((char)(0xC0 | (cp >> 6)));
+                    out->push_back((char)(0x80 | (cp & 0x3F)));
+                } else if (cp >= 0xD800 && cp <= 0xDFFF) {
+                    out->push_back('?'); // unpaired surrogate
+                } else {
+                    out->push_back((char)(0xE0 | (cp >> 12)));
+                    out->push_back((char)(0x80 | ((cp >> 6) & 0x3F)));
+                    out->push_back((char)(0x80 | (cp & 0x3F)));
+                }
+                break;
+            }
+            default: return false; // invalid escape
+        }
+    }
+    return false; // unterminated string
+}
+
+static std::string JsonEscape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (c < 0x20) {
+                    char b[8];
+                    snprintf(b, sizeof(b), "\\u%04x", c);
+                    out += b;
+                } else {
+                    out.push_back((char)c);
+                }
+        }
+    }
+    return out;
+}
+
+// Camera sub-object shared by get_status and set_camera responses.
+static std::string McpCameraJson() {
+    char buf[192];
+    snprintf(buf, sizeof(buf),
+        "{\"position\":[%.4f,%.4f,%.4f],\"yaw_deg\":%.2f,\"pitch_deg\":%.2f,\"zoom\":%.3f}",
+        g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ,
+        g_input.yaw * kMcpRad2Deg, g_input.pitch * kMcpRad2Deg,
+        g_input.viewParams.scaleFactor);
+    return buf;
+}
+
+// Declare app identity + register the viewer's tools. Called once after
+// session create. Descriptions are agent-facing API docs — state what the
+// tool does, the units, and the preconditions.
+static void RegisterAgentTools(AppXrSession& xr) {
+    if (!xr.hasMcpToolsExt || !xr.pfnSetMCPAppInfoEXT || !xr.pfnRegisterMCPToolEXT ||
+        !xr.pfnGetMCPToolCallArgsEXT || !xr.pfnSubmitMCPToolResultEXT)
+        return; // no agent surface — viewer runs identically
+
+    XrMCPAppInfoEXT appInfo = {XR_TYPE_MCP_APP_INFO_EXT};
+    strncpy(appInfo.appId, kMcpAppId, sizeof(appInfo.appId) - 1);
+    XrResult ar = xr.pfnSetMCPAppInfoEXT(xr.session, &appInfo);
+    if (XR_FAILED(ar)) {
+        // XR_ERROR_FEATURE_UNSUPPORTED = MCP capability gate off — expected.
+        LOG_INFO("xrSetMCPAppInfoEXT('%s'): %d — no agent surface", kMcpAppId, (int)ar);
+        return;
+    }
+
+    auto reg = [&](const char* name, const char* desc, const char* schema) {
+        XrMCPToolInfoEXT tool = {XR_TYPE_MCP_TOOL_INFO_EXT};
+        tool.name = name;
+        tool.description = desc;
+        tool.inputSchemaJson = schema;
+        XrResult tr = xr.pfnRegisterMCPToolEXT(xr.session, &tool);
+        if (XR_FAILED(tr)) LOG_WARN("xrRegisterMCPToolEXT('%s') failed: %d", name, (int)tr);
+    };
+
+    reg("load_splat",
+        "Load a Gaussian-splat scene from a file path (.ply or .spz), replacing the "
+        "currently loaded scene and auto-framing the camera on the main object. "
+        "Returns the loaded file and its splat count; an error result if the file "
+        "cannot be read or parsed.",
+        "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\","
+        "\"description\":\"Path to the .ply or .spz scene file (absolute recommended).\"}},"
+        "\"required\":[\"path\"]}");
+
+    reg("get_status",
+        "Read the viewer's live state: loaded scene file and splat count, frames per "
+        "second, camera pose (world position in meters, yaw/pitch in degrees, zoom), "
+        "virtual display height in meters, active rendering mode, transparent-background "
+        "and auto-orbit flags, and whether the XR session is running. Requires no "
+        "arguments.",
+        "{\"type\":\"object\"}");
+
+    reg("set_camera",
+        "Set camera pose components absolutely; give any subset of the arguments and "
+        "the rest stay unchanged. position_x/y/z move the camera rig in world meters; "
+        "yaw_deg/pitch_deg aim it (pitch clamps to about +/-86 deg); zoom scales the "
+        "scene (1 = default, larger zooms in, minimum 0.1). Takes effect on the next "
+        "frame and is visually verifiable via capture_frame. Returns the applied "
+        "camera state.",
+        "{\"type\":\"object\",\"properties\":{"
+        "\"position_x\":{\"type\":\"number\"},"
+        "\"position_y\":{\"type\":\"number\"},"
+        "\"position_z\":{\"type\":\"number\"},"
+        "\"yaw_deg\":{\"type\":\"number\"},"
+        "\"pitch_deg\":{\"type\":\"number\"},"
+        "\"zoom\":{\"type\":\"number\",\"minimum\":0.1}}}");
+
+    reg("orbit",
+        "Rotate the camera by a relative amount: azimuth_deg yaws around the vertical "
+        "axis (positive matches the idle auto-orbit direction); elevation_deg tilts the "
+        "view up (positive) or down, clamped to about +/-86 deg. At least one argument "
+        "is required. Returns the new absolute yaw/pitch in degrees.",
+        "{\"type\":\"object\",\"properties\":{"
+        "\"azimuth_deg\":{\"type\":\"number\",\"description\":\"Relative yaw in degrees.\"},"
+        "\"elevation_deg\":{\"type\":\"number\",\"description\":\"Relative pitch in degrees.\"}}}");
+
+    reg("reset_camera",
+        "Reset the camera to the auto-framed pose of the loaded scene (or the world "
+        "origin if none is loaded): recenters position, levels pitch, restores default "
+        "zoom and depth. Applied on the next frame. Returns the pose being restored.",
+        "{\"type\":\"object\"}");
+
+    reg("set_auto_orbit",
+        "Enable or disable the idle auto-orbit turntable (when enabled, the view slowly "
+        "yaws after 10 seconds without input). Disable it before scripted camera moves "
+        "or captures that must hold still. Returns the new state.",
+        "{\"type\":\"object\",\"properties\":{\"enabled\":{\"type\":\"boolean\"}},"
+        "\"required\":[\"enabled\"]}");
+
+    LOG_INFO("Agent tools registered (appId=%s)", kMcpAppId);
+}
+
+// Execute one agent tool call and answer it. Runs on the main loop (from
+// PollEvents), so handlers touch viewer state directly with no locking.
+static void HandleMcpToolCall(AppXrSession& xr, const XrEventDataMCPToolCallEXT* call) {
+    if (!xr.pfnSubmitMCPToolResultEXT) return;
+
+    // Two-call idiom: the event's argsSize is the exact capacity needed
+    // (incl. NUL). A no-arg tool reports argsSize 0 — treat as "{}".
+    std::string args = "{}";
+    if (xr.pfnGetMCPToolCallArgsEXT && call->argsSize > 0) {
+        std::vector<char> buf(call->argsSize, '\0');
+        uint32_t needed = 0;
+        if (XR_SUCCEEDED(xr.pfnGetMCPToolCallArgsEXT(xr.session, call->callId,
+                (uint32_t)buf.size(), &needed, buf.data())))
+            args.assign(buf.data());
+    }
+    const char* a = args.c_str();
+
+    XrBool32 ok = XR_TRUE;
+    std::string result;
+    char buf[768];
+
+    if (strcmp(call->toolName, "load_splat") == 0) {
+        std::string path;
+        if (!JsonGetString(a, "path", &path) || path.empty()) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"missing required string arg 'path'\"}";
+        } else if (!ValidateSceneFile(path)) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"not a readable .ply/.spz scene: '" + JsonEscape(path) + "'\"}";
+        } else if (!g_gsRenderer.loadScene(path.c_str())) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"failed to load '" + JsonEscape(path) + "' (corrupt or unsupported)\"}";
+        } else {
+            g_loadedFileName = GetPlyFilename(path);
+            ApplyAutoFitForLoadedScene();
+            snprintf(buf, sizeof(buf), "\",\"splat_count\":%u}", g_gsRenderer.gaussianCount());
+            result = "{\"file\":\"" + JsonEscape(path) + buf;
+            LOG_INFO("Agent loaded scene: %s (%u splats)",
+                     g_loadedFileName.c_str(), g_gsRenderer.gaussianCount());
+        }
+    } else if (strcmp(call->toolName, "get_status") == 0) {
+        const char* modeName = (xr.renderingModeCount > 0 &&
+            g_input.currentRenderingMode < xr.renderingModeCount &&
+            xr.renderingModeNames[g_input.currentRenderingMode][0] != '\0')
+            ? xr.renderingModeNames[g_input.currentRenderingMode] : "unknown";
+        double fps = (g_avgFrameTime > 0) ? 1.0 / g_avgFrameTime : 0.0;
+        snprintf(buf, sizeof(buf),
+            "\",\"has_scene\":%s,\"splat_count\":%u,\"fps\":%.1f,\"camera\":%s,"
+            "\"virtual_display_height_m\":%.4f,"
+            "\"rendering_mode\":{\"index\":%u,\"name\":\"%s\"},"
+            "\"transparent_background\":%s,\"auto_orbit\":%s,\"orbiting_now\":%s,"
+            "\"session_running\":%s}",
+            g_gsRenderer.hasScene() ? "true" : "false",
+            g_gsRenderer.gaussianCount(), fps, McpCameraJson().c_str(),
+            g_input.viewParams.virtualDisplayHeight,
+            g_input.currentRenderingMode, modeName,
+            g_transparentBg ? "true" : "false",
+            g_input.animateEnabled ? "true" : "false",
+            g_input.animationActive ? "true" : "false",
+            xr.sessionRunning ? "true" : "false");
+        result = "{\"file\":\"" + JsonEscape(g_loadedFileName) + buf;
+    } else if (strcmp(call->toolName, "set_camera") == 0) {
+        double v;
+        bool any = false;
+        if (JsonGetNumber(a, "position_x", &v)) { g_input.cameraPosX = (float)v; any = true; }
+        if (JsonGetNumber(a, "position_y", &v)) { g_input.cameraPosY = (float)v; any = true; }
+        if (JsonGetNumber(a, "position_z", &v)) { g_input.cameraPosZ = (float)v; any = true; }
+        if (JsonGetNumber(a, "yaw_deg", &v))    { g_input.yaw = (float)(v * kMcpDeg2Rad); any = true; }
+        if (JsonGetNumber(a, "pitch_deg", &v)) {
+            float p = (float)(v * kMcpDeg2Rad);
+            if (p > kMcpMaxPitchRad) p = kMcpMaxPitchRad;
+            if (p < -kMcpMaxPitchRad) p = -kMcpMaxPitchRad;
+            g_input.pitch = p;
+            any = true;
+        }
+        if (JsonGetNumber(a, "zoom", &v)) {
+            float z = (float)v;
+            if (z < 0.1f) z = 0.1f;
+            g_input.viewParams.scaleFactor = z;
+            any = true;
+        }
+        if (!any) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"no recognized args (position_x/y/z, yaw_deg, pitch_deg, zoom)\"}";
+        } else {
+            g_input.transitioning = false;  // agent pose wins over a running focus transition
+            MarkUserInput(g_input);         // restart the auto-orbit idle countdown
+            result = "{\"camera\":" + McpCameraJson() + "}";
+        }
+    } else if (strcmp(call->toolName, "orbit") == 0) {
+        double az = 0.0, el = 0.0;
+        bool hasAz = JsonGetNumber(a, "azimuth_deg", &az);
+        bool hasEl = JsonGetNumber(a, "elevation_deg", &el);
+        if (!hasAz && !hasEl) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"need azimuth_deg and/or elevation_deg\"}";
+        } else {
+            g_input.yaw += (float)(az * kMcpDeg2Rad);
+            float p = g_input.pitch + (float)(el * kMcpDeg2Rad);
+            if (p > kMcpMaxPitchRad) p = kMcpMaxPitchRad;
+            if (p < -kMcpMaxPitchRad) p = -kMcpMaxPitchRad;
+            g_input.pitch = p;
+            g_input.transitioning = false;
+            MarkUserInput(g_input);
+            snprintf(buf, sizeof(buf), "{\"yaw_deg\":%.2f,\"pitch_deg\":%.2f}",
+                     g_input.yaw * kMcpRad2Deg, g_input.pitch * kMcpRad2Deg);
+            result = buf;
+        }
+    } else if (strcmp(call->toolName, "reset_camera") == 0) {
+        g_input.resetViewRequested = true;  // applied by UpdateCameraMovement next frame
+        snprintf(buf, sizeof(buf),
+            "{\"framed\":%s,\"position\":[%.4f,%.4f,%.4f],\"yaw_deg\":%.2f,"
+            "\"virtual_display_height_m\":%.4f}",
+            g_fitValid ? "true" : "false",
+            g_fitValid ? g_fitCenter[0] : 0.0f,
+            g_fitValid ? g_fitCenter[1] : 0.0f,
+            g_fitValid ? g_fitCenter[2] : 0.0f,
+            (g_fitValid ? g_fitYaw : 0.0f) * kMcpRad2Deg,
+            g_fitValid ? g_fitVHeight : kDefaultVirtualDisplayHeightM);
+        result = buf;
+    } else if (strcmp(call->toolName, "set_auto_orbit") == 0) {
+        bool enabled = false;
+        if (!JsonGetBool(a, "enabled", &enabled)) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"missing required boolean arg 'enabled'\"}";
+        } else {
+            g_input.animateEnabled = enabled;
+            g_input.animationActive = false;
+            g_input.lastInputTimeSec = NowSec(); // don't snap-start on enable
+            result = enabled ? "{\"auto_orbit\":true}" : "{\"auto_orbit\":false}";
+        }
+    } else {
+        ok = XR_FALSE;
+        result = std::string("{\"error\":\"unhandled tool '") + call->toolName + "'\"}";
+    }
+
+    xr.pfnSubmitMCPToolResultEXT(xr.session, call->callId, ok, result.c_str());
 }
 
 // Forward declarations for OpenXR functions (same as cube_handle_vk_macos)
@@ -996,6 +1373,7 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         if (strcmp(ext.extensionName, XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME) == 0) xr.hasCocoaWindowBinding = true;
         if (strcmp(ext.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0) xr.hasDisplayInfoExt = true;
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) xr.hasAtlasCaptureExt = true;
+        if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) xr.hasMcpToolsExt = true;
     }
 
     if (!hasVulkan) { LOG_ERROR("XR_KHR_vulkan_enable not available"); return false; }
@@ -1005,6 +1383,7 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     if (xr.hasCocoaWindowBinding) enabled.push_back(XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME);
     if (xr.hasDisplayInfoExt) enabled.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
     if (xr.hasAtlasCaptureExt) enabled.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    if (xr.hasMcpToolsExt) enabled.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
 
     XrInstanceCreateInfo ci = {XR_TYPE_INSTANCE_CREATE_INFO};
     strncpy(ci.applicationInfo.applicationName, "SR3DGSOpenXRExtMacOS", sizeof(ci.applicationInfo.applicationName));
@@ -1053,6 +1432,17 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     if (xr.hasAtlasCaptureExt) {
         xrGetInstanceProcAddr(xr.instance, "xrCaptureAtlasEXT", (PFN_xrVoidFunction*)&xr.pfnCaptureAtlasEXT);
         LOG_INFO("xrCaptureAtlasEXT: %s", xr.pfnCaptureAtlasEXT ? "resolved" : "NULL");
+    }
+
+    // XR_EXT_mcp_tools (#32): resolve the agent-tool entry points.
+    if (xr.hasMcpToolsExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrSetMCPAppInfoEXT", (PFN_xrVoidFunction*)&xr.pfnSetMCPAppInfoEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrRegisterMCPToolEXT", (PFN_xrVoidFunction*)&xr.pfnRegisterMCPToolEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrGetMCPToolCallArgsEXT", (PFN_xrVoidFunction*)&xr.pfnGetMCPToolCallArgsEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitMCPToolResultEXT", (PFN_xrVoidFunction*)&xr.pfnSubmitMCPToolResultEXT);
+        LOG_INFO("XR_EXT_mcp_tools entry points: %s",
+            (xr.pfnSetMCPAppInfoEXT && xr.pfnRegisterMCPToolEXT &&
+             xr.pfnGetMCPToolCallArgsEXT && xr.pfnSubmitMCPToolResultEXT) ? "resolved" : "NULL");
     }
 
     LOG_INFO("OpenXR initialized: %s", xr.systemName);
@@ -1223,6 +1613,10 @@ static bool CreateSession(AppXrSession& xr, VkInstance vkInstance, VkPhysicalDev
         }
     }
 
+    // XR_EXT_mcp_tools (#32): declare identity + register the agent tools.
+    // Inert (logs and returns) when the extension or MCP gate is absent.
+    RegisterAgentTools(xr);
+
     return true;
 }
 
@@ -1331,6 +1725,11 @@ static void PollEvents(AppXrSession& xr) {
                     rmc->previousModeIndex, rmc->currentModeIndex,
                     xr.renderingModeNames[rmc->currentModeIndex]);
             }
+        } else if (event.type == (XrStructureType)XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT) {
+            // Agent invoked one of our registered tools (XR_EXT_mcp_tools).
+            // Execute + answer here on the main loop where viewer state is
+            // consistent; every call is answered (~5 s runtime timeout).
+            HandleMcpToolCall(xr, (const XrEventDataMCPToolCallEXT*)&event);
         }
         event.type = XR_TYPE_EVENT_DATA_BUFFER;
     }

--- a/openxr_includes/openxr/XR_EXT_mcp_tools.h
+++ b/openxr_includes/openxr/XR_EXT_mcp_tools.h
@@ -1,0 +1,227 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_mcp_tools extension (app-defined agent tools).
+ * @author DisplayXR
+ * @ingroup external_openxr
+ *
+ * Lets an app register its own MCP (Model Context Protocol) tools —
+ * "play_pause", "load_model", "run_animation" — on the per-process MCP
+ * server the runtime already hosts. Agents reach them via the
+ * displayxr-mcp adapter (`--target pid:N`, or namespaced as
+ * `<app-id>__<tool>` through `--target workspace`).
+ *
+ * Dispatch is event-based on purpose: the MCP transport thread never
+ * calls into app code. A tool invocation surfaces as an
+ * XrEventDataMCPToolCallEXT through xrPollEvent; the app executes the
+ * tool on its own frame loop (where its state is naturally consistent)
+ * and answers with xrSubmitMCPToolResultEXT. The runtime fails a call
+ * the app has not answered within ~5 seconds.
+ *
+ * Event payloads are fixed-size, so tool arguments use the OpenXR
+ * two-call idiom via xrGetMCPToolCallArgsEXT.
+ *
+ * All functions return XR_ERROR_FEATURE_UNSUPPORTED when the MCP
+ * capability is disabled (HKLM\Software\DisplayXR\Capabilities\MCP /
+ * DISPLAYXR_MCP) — apps should treat that as "no agent surface" and
+ * continue normally.
+ *
+ * Design: displayxr-runtime docs/roadmap/per-app-mcp-tools.md;
+ * spec: docs/specs/extensions/XR_EXT_mcp_tools.md.
+ */
+#ifndef XR_EXT_MCP_TOOLS_H
+#define XR_EXT_MCP_TOOLS_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_mcp_tools 1
+#define XR_EXT_mcp_tools_SPEC_VERSION 1
+#define XR_EXT_MCP_TOOLS_EXTENSION_NAME "XR_EXT_mcp_tools"
+
+// Provisional XrStructureType values. The 1000999130..132 range is
+// reserved for this extension. Reconciles with the Khronos registry
+// before any spec-freeze attempt.
+#define XR_TYPE_MCP_APP_INFO_EXT            ((XrStructureType)1000999130)
+#define XR_TYPE_MCP_TOOL_INFO_EXT           ((XrStructureType)1000999131)
+#define XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT ((XrStructureType)1000999132)
+
+/*!
+ * @brief Maximum app-id length (the manifest `id` slug), incl. NUL.
+ *
+ * Charset is `^[a-z0-9][a-z0-9-]{0,31}$` — lowercase ASCII letters,
+ * digits, hyphens. Underscores are excluded by design: `__` is the
+ * workspace aggregator's namespace separator.
+ */
+#define XR_MAX_MCP_APP_ID_SIZE_EXT 33
+
+/*!
+ * @brief Maximum bare tool-name length, incl. NUL.
+ *
+ * Charset is `^[a-z0-9][a-z0-9_-]{0,62}$` and the name must not
+ * contain the substring `__` (reserved namespace separator).
+ */
+#define XR_MAX_MCP_TOOL_NAME_SIZE_EXT 64
+
+/*!
+ * @brief App identity declaration.
+ *
+ * `appId` MUST match the `id` field of the app's `.displayxr.json`
+ * manifest (manifest spec §3.4); `scripts/check_displayxr_app.py`
+ * lints the pairing. It becomes the agent-visible tool-name prefix.
+ */
+typedef struct XrMCPAppInfoEXT {
+    XrStructureType          type; //!< Must be XR_TYPE_MCP_APP_INFO_EXT
+    const void* XR_MAY_ALIAS next; //!< Reserved; must be NULL in spec_version 1
+    char                     appId[XR_MAX_MCP_APP_ID_SIZE_EXT]; //!< NUL-terminated slug
+} XrMCPAppInfoEXT;
+
+/*!
+ * @brief Declare the app's stable identifier. Call once per session,
+ * before registering tools. May be called again to change it (the
+ * runtime notifies connected agents), but treat the id as immutable
+ * in practice — agents key tool names on it.
+ *
+ * @return XR_SUCCESS, XR_ERROR_VALIDATION_FAILURE (bad type/charset),
+ *         XR_ERROR_FEATURE_UNSUPPORTED (MCP capability disabled),
+ *         XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSetMCPAppInfoEXT)(
+    XrSession                session,
+    const XrMCPAppInfoEXT*   info);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetMCPAppInfoEXT(
+    XrSession                session,
+    const XrMCPAppInfoEXT*   info);
+#endif
+
+/*!
+ * @brief One tool registration.
+ *
+ * `description` is what the agent reads to decide when to call the
+ * tool — write it like API documentation, not a label.
+ * `inputSchemaJson` is a JSON Schema object describing `arguments`
+ * (NULL/empty means "no arguments": `{"type":"object"}`).
+ *
+ * The strings are copied; the struct need not outlive the call.
+ */
+typedef struct XrMCPToolInfoEXT {
+    XrStructureType          type; //!< Must be XR_TYPE_MCP_TOOL_INFO_EXT
+    const void* XR_MAY_ALIAS next; //!< Reserved; must be NULL in spec_version 1
+    const char*              name;            //!< Bare name; runtime/aggregator prefixes
+    const char*              description;     //!< Agent-facing; required
+    const char*              inputSchemaJson; //!< JSON Schema; optional
+} XrMCPToolInfoEXT;
+
+/*!
+ * @brief Register a tool on the session. Tools registered after agents
+ * connected surface immediately (the runtime broadcasts the MCP
+ * `tools/list_changed` notification). All of a session's tools are
+ * unregistered automatically when the session is destroyed; pending
+ * calls fail with an error to the agent.
+ *
+ * @return XR_SUCCESS,
+ *         XR_ERROR_NAME_DUPLICATED (name already registered),
+ *         XR_ERROR_VALIDATION_FAILURE (bad type/name/missing description),
+ *         XR_ERROR_LIMIT_REACHED (per-process tool budget exhausted),
+ *         XR_ERROR_FEATURE_UNSUPPORTED, XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrRegisterMCPToolEXT)(
+    XrSession                session,
+    const XrMCPToolInfoEXT*  tool);
+
+/*!
+ * @brief Unregister a tool by bare name. In-flight calls on the tool
+ * fail to the agent. XR_ERROR_VALIDATION_FAILURE if the name is not
+ * registered on this session.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrUnregisterMCPToolEXT)(
+    XrSession                session,
+    const char*              name);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrRegisterMCPToolEXT(
+    XrSession                session,
+    const XrMCPToolInfoEXT*  tool);
+XRAPI_ATTR XrResult XRAPI_CALL xrUnregisterMCPToolEXT(
+    XrSession                session,
+    const char*              name);
+#endif
+
+/*!
+ * @brief Tool invocation event, delivered via xrPollEvent.
+ *
+ * The app fetches the JSON arguments with xrGetMCPToolCallArgsEXT
+ * (`argsSize` is the required capacity incl. NUL), executes the tool,
+ * and answers with xrSubmitMCPToolResultEXT. An unanswered call fails
+ * to the agent after ~5 seconds; a result submitted after that is
+ * silently dropped (XR_SUCCESS).
+ *
+ * @extends XrEventDataBaseHeader
+ */
+typedef struct XrEventDataMCPToolCallEXT {
+    XrStructureType          type; //!< Must be XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_EXT
+    const void* XR_MAY_ALIAS next;
+    XrSession                session;
+    uint64_t                 callId;   //!< Correlates xrGet…Args/xrSubmit…Result; never 0
+    char                     toolName[XR_MAX_MCP_TOOL_NAME_SIZE_EXT]; //!< NUL-terminated
+    uint32_t                 argsSize; //!< Bytes incl. NUL for xrGetMCPToolCallArgsEXT
+} XrEventDataMCPToolCallEXT;
+
+/*!
+ * @brief Fetch a pending call's JSON arguments (two-call idiom).
+ *
+ * @param capacity     Size of @p buffer in bytes; 0 to query.
+ * @param countOutput  Required size incl. NUL.
+ * @return XR_SUCCESS, XR_ERROR_SIZE_INSUFFICIENT,
+ *         XR_ERROR_VALIDATION_FAILURE (unknown/expired callId),
+ *         XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrGetMCPToolCallArgsEXT)(
+    XrSession                session,
+    uint64_t                 callId,
+    uint32_t                 capacity,
+    uint32_t*                countOutput,
+    char*                    buffer);
+
+/*!
+ * @brief Answer a pending tool call.
+ *
+ * @param success     XR_TRUE → @p resultJson becomes the tool result;
+ *                    XR_FALSE → the agent receives a tool error.
+ * @param resultJson  NUL-terminated JSON value (object recommended).
+ *                    NULL/empty is treated as `{}`. Copied.
+ * @return XR_SUCCESS (also for late results on an expired callId —
+ *         the result is dropped), XR_ERROR_VALIDATION_FAILURE
+ *         (callId never existed), XR_ERROR_HANDLE_INVALID.
+ */
+typedef XrResult (XRAPI_PTR *PFN_xrSubmitMCPToolResultEXT)(
+    XrSession                session,
+    uint64_t                 callId,
+    XrBool32                 success,
+    const char*              resultJson);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetMCPToolCallArgsEXT(
+    XrSession                session,
+    uint64_t                 callId,
+    uint32_t                 capacity,
+    uint32_t*                countOutput,
+    char*                    buffer);
+XRAPI_ATTR XrResult XRAPI_CALL xrSubmitMCPToolResultEXT(
+    XrSession                session,
+    uint64_t                 callId,
+    XrBool32                 success,
+    const char*              resultJson);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_MCP_TOOLS_H

--- a/windows/displayxr/gaussian_splatting_handle_vk_win.displayxr.json
+++ b/windows/displayxr/gaussian_splatting_handle_vk_win.displayxr.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "gaussiansplat",
   "name": "Gaussian Splat Viewer",
   "type": "3d",
   "category": "demo",


### PR DESCRIPTION
Closes #32.

Registers the splat viewer's controls as per-app MCP tools on the runtime-hosted per-process MCP server (`XR_EXT_mcp_tools`), mirroring the merged mediaplayer adoption (displayxr-demo-mediaplayer#10) and the reference adopter `cube_handle_metal_macos` (runtime#448). Spec: `displayxr-runtime/docs/specs/extensions/XR_EXT_mcp_tools.md`; design: `docs/roadmap/per-app-mcp-tools.md`.

## What's in here

- **Vendored header** — `openxr_includes/openxr/XR_EXT_mcp_tools.h` (this repo's vendored DisplayXR-extension-header dir, already on every target's include path; same file mediaplayer vendors under `third_party/displayxr-openxr/`).
- **Identity** — `"id": "gaussiansplat"` in both `.displayxr.json` manifests + `xrSetMCPAppInfoEXT` at session create. `check_displayxr_app.py --strict` passes (INV-10.1).
- **Tools** (`macos/main.mm`), mapped to real viewer state, no core refactors:
  | tool | maps to |
  |---|---|
  | `load_splat {path}` | same path as drag-and-drop: `ValidateSceneFile` → `GsRenderer::loadScene` → auto-fit |
  | `get_status` | file, splat count, fps, camera pose (position/yaw/pitch/zoom), vH, rendering mode, transparency, auto-orbit, session state |
  | `set_camera {position_x/y/z?, yaw_deg?, pitch_deg?, zoom?}` | absolute partial updates onto `InputState` (pitch clamped like mouse drag, zoom ≥ 0.1) |
  | `orbit {azimuth_deg?, elevation_deg?}` | relative yaw/pitch deltas |
  | `reset_camera` | `resetViewRequested` (returns the auto-framed pose being restored) |
  | `set_auto_orbit {enabled}` | `animateEnabled` (+ idle-timer reset, no snap-start) |
- **Dispatch** — answered from the existing `PollEvents` pump on the main loop: two-call `xrGetMCPToolCallArgsEXT`, `success=XR_FALSE` + `{"error":...}` on bad args, every call answered (~5 s runtime timeout). Flat-JSON arg scanners + escaper — no JSON library dependency.
- **Inert when absent** — extension not enumerated, PFNs unresolved, or MCP gate off ⇒ no agent surface, viewer behaves identically.

Windows (`windows/main.cpp` / `xr_session.cpp`) wiring is a follow-up; the manifest `id` is already in place there.

## Validation (macOS sim display, dev-built runtime @ `origin/main` 60e0313)

Launched with `DISPLAYXR_MCP=1` + `XR_RUNTIME_JSON` + `XRT_PLUGIN_SEARCH_PATH`, driven via the `displayxr-mcp` adapter with a Content-Length framing helper (cribbed from `tests/mcp/test_app_tools.sh`). Live transcript excerpts in the PR comment below: `_meta` appId + groups, `gaussiansplat__*` namespacing + `workspace__list_apps`, camera move → `capture_frame` act→capture→verify, and a bad call surfacing as a JSON-RPC error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)