### PR TITLE
chore: bump displayxr::common v0.3.0 -> v0.4.1 (HUD button label no-wrap)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.3.0
+    GIT_TAG v0.4.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)


### PR DESCRIPTION
@
## What
Bumps the `displayxr::common` FetchContent pin **v0.3.0 → v0.4.1**.

v0.4.1 carries the HUD fix ([displayxr-common#7](https://github.com/DisplayXR/displayxr-common/pull/7)) where over-wide button labels are **clipped to one line instead of wrapping**. In this app that fixes the **Mode** button: when a workspace locks the rendering mode the label gains a ` [locked]` suffix, pushing it past the pill width — it was wrapping to two lines and spilling outside the button. It now stays single-line with overflow clipped.

Same fix already merged for the model-viewer demo ([modelviewer#25](https://github.com/DisplayXR/displayxr-demo-modelviewer/pull/25)); the splat viewer shares the identical `Mode: <name> [locked]` button.

## Note
This pin also rolls forward across **v0.4.0** (the `#396 W7` type-neutral math core), since the app was still on the v0.3.0 line. Both-platform PR CI here is the validation that the math roll-forward builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@