### PR TITLE
feat: W7 — consume runtime render-ready views via XR_EXT_view_rig (macOS + Windows) [#396]

### DIFF
--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -868,30 +868,23 @@ void GsRenderer::updateUniforms(const float viewMatrix[16], const float projMatr
 {
     GsUniformBuffer ub;
 
-    // Y-flip the world before any view-derived computation. The compute
-    // shader writes via ndc2Pix(ndc.y) (Vulkan: ndc.y=+1 → pixel.y near
-    // height-1, i.e. bottom-of-image), so without compensation a +Y-up
-    // world appears upside-down. The "obvious" fix — negating the Y row
-    // of proj_mat (i.e. flipping clip.y) — places splat *centers* right-
-    // side-up but doesn't propagate into the cov2d Jacobian, leaving the
-    // anisotropic 2D ellipses computed against the un-flipped world. The
-    // resulting size mismatch (cov2d[0][0] differs by a non-trivial
-    // 4·a·b·Σ[0,1] term for any non-axis-aligned view × non-diagonal Σ)
-    // shows up as radial streaks / fuzz on splat edges. Flipping at the
-    // *view* stage (right-multiply by diag(1,-1,1,1)) instead keeps
-    // W = R_c2w consistent with the world frame the cov2d formula assumes.
+    // Vulkan Y-down handling (W7, #396). The compute shader writes via
+    // ndc2Pix(ndc.y) (Vulkan: ndc.y=+1 → pixel.y near height-1, bottom of
+    // image), so a +Y-up world would render upside-down. We do NOT reflect the
+    // view/world to fix it — a view-matrix Y reflection (diag(1,-1,1,1)) leaves
+    // the static image correct but flips rotational handedness, inverting mouse
+    // pitch (D·R_x·D = R_x(-θ)). Instead the flip lives entirely at the RASTER
+    // stage in preprocess.comp: pixel.y = ndc2Pix(-ndc.y) and the cov2d
+    // off-diagonal is negated so the ellipse reflects with the center (a
+    // negative-viewport equivalent for the compute rasterizer). That keeps the
+    // center, the cov2d Jacobian, AND the camera controls all consistent.
     //
-    // CALLER CONTRACT: the demo must pass `viewMatrix` already built with
-    // a Y-mirrored display pose (i.e. cameraPose.position.y = -intended_y)
-    // so the off-axis Kooima projection's eye-vs-display geometry stays
-    // consistent with the world flip we apply here. Without that, the
-    // scene renders with a 2·cy vertical offset.
+    // CALLER CONTRACT (W7): the demo passes a plain clean +Y-up-world view
+    // matrix — the render-ready XR_EXT_view_rig XrView pose via
+    // mat4_view_from_xr_pose. No Y-mirrored display pose; -R^T·t recovers the
+    // true world camera position for the SH evaluation below.
     float vmFlipped[16];
     memcpy(vmFlipped, viewMatrix, 16 * sizeof(float));
-    vmFlipped[4] = -vmFlipped[4];
-    vmFlipped[5] = -vmFlipped[5];
-    vmFlipped[6] = -vmFlipped[6];
-    vmFlipped[7] = -vmFlipped[7];
 
     // Extract camera position from the (Y-flipped) view matrix: cam = -R^T * t
     // Column-major: col0=[0..3], col1=[4..7], col2=[8..11], col3=[12..15]
@@ -901,9 +894,10 @@ void GsRenderer::updateUniforms(const float viewMatrix[16], const float projMatr
     ub.camera_position[2] = -(vmFlipped[8]*tx + vmFlipped[9]*ty + vmFlipped[10]*tz);
     ub.camera_position[3] = 1.0f;
 
-    // proj_mat = projMatrix * vmFlipped (combined view-projection,
-    // with Y-flip already baked into the view stage). The shader does
-    // p_hom = proj_mat * worldPos → clip space. No proj-stage Y negation.
+    // proj_mat = projMatrix * vmFlipped (clean combined view-projection — no
+    // Y reflection here; the raster-stage flip in preprocess.comp handles
+    // Vulkan Y-down, so the off-axis projection stays in its native +Y-up
+    // frame). The shader does p_hom = proj_mat * worldPos → clip space.
     for (int col = 0; col < 4; col++) {
         for (int row = 0; row < 4; row++) {
             float sum = 0.0f;

--- a/3dgs_common/shaders/preprocess.comp
+++ b/3dgs_common/shaders/preprocess.comp
@@ -69,6 +69,13 @@ mat2 compute_cov2d(vec3 cam) {
     mat3 cov2d = transpose(T) * Sigma * T;
     cov2d[0][0] += 0.3f;
     cov2d[1][1] += 0.3f;
+    // Vulkan Y-down raster flip (W7, #396): the splat center is written with
+    // pixel.y = ndc2Pix(-ndc.y) below, so the 2D ellipse must be reflected
+    // vertically to match — negate the xy off-diagonal. det (hence radius) and
+    // eigenvalues are unchanged; only the ellipse orientation reflects. Doing
+    // it here (not via a view-matrix reflection) keeps mouse pitch correct.
+    cov2d[0][1] = -cov2d[0][1];
+    cov2d[1][0] = -cov2d[1][0];
     return mat2(cov2d);
 }
 
@@ -188,7 +195,11 @@ void main() {
         return;
     }
 
-    vec2 uv = vec2(ndc2Pix(ndc.x, int(width)), ndc2Pix(ndc.y, int(height)));
+    // Vulkan Y-down raster flip (W7, #396): negate ndc.y when mapping to the
+    // pixel center so a +Y-up world renders upright without reflecting the view
+    // matrix (which would invert mouse pitch). Paired with the cov2d off-diagonal
+    // negation in compute_cov2d so the ellipse reflects with the center.
+    vec2 uv = vec2(ndc2Pix(ndc.x, int(width)), ndc2Pix(-ndc.y, int(height)));
 
     uvec4 bounding_box = uvec4(
         uint(clamp(int((uv.x - radii) / TILE_WIDTH), 0, tile_shape.x)),

--- a/common/view_rig_math.h
+++ b/common/view_rig_math.h
@@ -1,0 +1,126 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  View/projection builders for the XR_EXT_view_rig consume path (#396 W7)
+ *
+ * The runtime owns the off-axis Kooima math and returns render-ready
+ * XrView{pose, fov}; the app only needs to turn those into GL-convention
+ * column-major float[16] view/projection matrices, plus the rig-local eye
+ * depth that anchors the ZDP-relative clip policy. These are exact copies of
+ * the helpers verified live in macos/main.mm (commit 24e41b2) — keep the math
+ * verbatim so the two platforms can't drift; macos/main.mm adopts this header
+ * in a later pass.
+ */
+#ifndef VIEW_RIG_MATH_H
+#define VIEW_RIG_MATH_H 1
+
+#include <openxr/openxr.h>
+
+#include <cmath>
+#include <cstring>
+
+static inline void vrm_mat4_identity(float* m) {
+    memset(m, 0, 16 * sizeof(float));
+    m[0] = m[5] = m[10] = m[15] = 1.0f;
+}
+
+// result = a * b (column-major)
+static inline void vrm_mat4_multiply(float* result, const float* a, const float* b) {
+    float tmp[16];
+    for (int col = 0; col < 4; col++) {
+        for (int row = 0; row < 4; row++) {
+            tmp[col * 4 + row] =
+                a[0 * 4 + row] * b[col * 4 + 0] +
+                a[1 * 4 + row] * b[col * 4 + 1] +
+                a[2 * 4 + row] * b[col * 4 + 2] +
+                a[3 * 4 + row] * b[col * 4 + 3];
+        }
+    }
+    memcpy(result, tmp, 16 * sizeof(float));
+}
+
+static inline void vrm_mat4_translation(float* m, float tx, float ty, float tz) {
+    vrm_mat4_identity(m);
+    m[12] = tx; m[13] = ty; m[14] = tz;
+}
+
+static inline void mat4_from_xr_fov(float* m, XrFovf fov, float nearZ, float farZ) {
+    float tanL = tanf(fov.angleLeft);
+    float tanR = tanf(fov.angleRight);
+    float tanU = tanf(fov.angleUp);
+    float tanD = tanf(fov.angleDown);
+    float w = tanR - tanL;
+    float h = tanU - tanD;
+    memset(m, 0, 16 * sizeof(float));
+    m[0]  = 2.0f / w;
+    m[5]  = 2.0f / h;
+    m[8]  = (tanR + tanL) / w;
+    m[9]  = (tanU + tanD) / h;
+    m[10] = -(farZ + nearZ) / (farZ - nearZ);
+    m[11] = -1.0f;
+    m[14] = -(2.0f * farZ * nearZ) / (farZ - nearZ);
+}
+
+static inline void mat4_view_from_xr_pose(float* viewMat, XrPosef pose) {
+    float qx = pose.orientation.x, qy = pose.orientation.y;
+    float qz = pose.orientation.z, qw = pose.orientation.w;
+    float rot[16];
+    vrm_mat4_identity(rot);
+    rot[0]  = 1 - 2*(qy*qy + qz*qz);
+    rot[1]  = 2*(qx*qy + qz*qw);
+    rot[2]  = 2*(qx*qz - qy*qw);
+    rot[4]  = 2*(qx*qy - qz*qw);
+    rot[5]  = 1 - 2*(qx*qx + qz*qz);
+    rot[6]  = 2*(qy*qz + qx*qw);
+    rot[8]  = 2*(qx*qz + qy*qw);
+    rot[9]  = 2*(qy*qz - qx*qw);
+    rot[10] = 1 - 2*(qx*qx + qy*qy);
+    float invRot[16];
+    vrm_mat4_identity(invRot);
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            invRot[j*4+i] = rot[i*4+j];
+    float invTrans[16];
+    vrm_mat4_translation(invTrans, -pose.position.x, -pose.position.y, -pose.position.z);
+    vrm_mat4_multiply(viewMat, invRot, invTrans);
+}
+
+// Same convention as XMQuaternionRotationRollPitchYaw(pitch, yaw, 0).
+static inline void quat_from_yaw_pitch(float yaw, float pitch, XrQuaternionf* out) {
+    float cy = cosf(yaw / 2.0f), sy = sinf(yaw / 2.0f);
+    float cp = cosf(pitch / 2.0f), sp = sinf(pitch / 2.0f);
+    out->w = cy * cp;
+    out->x = cy * sp;
+    out->y = sy * cp;
+    out->z = -sy * sp;
+}
+
+static inline void quat_rotate_vec3(XrQuaternionf q, float vx, float vy, float vz,
+    float* ox, float* oy, float* oz) {
+    float tx = 2.0f * (q.y * vz - q.z * vy);
+    float ty = 2.0f * (q.z * vx - q.x * vz);
+    float tz = 2.0f * (q.x * vy - q.y * vx);
+    *ox = vx + q.w * tx + (q.y * tz - q.z * ty);
+    *oy = vy + q.w * ty + (q.z * tx - q.x * tz);
+    *oz = vz + q.w * tz + (q.x * ty - q.y * tx);
+}
+
+// Display-local eye distance for the ZDP-anchored clip (#396 W7 consume path):
+// z of (rigPose^-1 * eyeWorld). Equals the old eye_display.z (display-space eye
+// Z) that display3d resolved, so near = ez - vH / far = ez + far_offset stays
+// identical. Degenerates to pose.position.z at identity rig pose. fov is
+// clip-independent, so this is all the app keeps of the old per-eye math.
+static inline float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    XrQuaternionf inv = {-rig.orientation.x, -rig.orientation.y,
+                         -rig.orientation.z, rig.orientation.w};
+    float ox, oy, oz;
+    quat_rotate_vec3(inv,
+                     eyeWorld.x - rig.position.x,
+                     eyeWorld.y - rig.position.y,
+                     eyeWorld.z - rig.position.z,
+                     &ox, &oy, &oz);
+    return oz;
+}
+
+#endif // VIEW_RIG_MATH_H

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -31,6 +31,7 @@
 #include <openxr/XR_EXT_display_info.h>
 #include <openxr/XR_EXT_atlas_capture.h>
 #include <openxr/XR_EXT_mcp_tools.h>
+#include <openxr/XR_EXT_view_rig.h>
 
 #include <cctype>
 #include <cmath>
@@ -274,6 +275,23 @@ static void quat_rotate_vec3(XrQuaternionf q, float vx, float vy, float vz,
     *ox = vx + q.w * tx + (q.y * tz - q.z * ty);
     *oy = vy + q.w * ty + (q.z * tx - q.x * tz);
     *oz = vz + q.w * tz + (q.x * ty - q.y * tx);
+}
+
+// Display-local eye distance for the ZDP-anchored clip (#396 W7 consume path):
+// z of (rigPose^-1 * eyeWorld). Equals the old eye_display.z (display-space eye
+// Z) that display3d resolved, so near = ez - vH / far = ez + far_offset stays
+// identical. Degenerates to pose.position.z at identity rig pose. fov is
+// clip-independent, so this is all the app keeps of the old per-eye math.
+static float RigLocalEyeZ(const XrPosef& rig, const XrVector3f& eyeWorld) {
+    XrQuaternionf inv = {-rig.orientation.x, -rig.orientation.y,
+                         -rig.orientation.z, rig.orientation.w};
+    float ox, oy, oz;
+    quat_rotate_vec3(inv,
+                     eyeWorld.x - rig.position.x,
+                     eyeWorld.y - rig.position.y,
+                     eyeWorld.z - rig.position.z,
+                     &ox, &oy, &oz);
+    return oz;
 }
 
 // ============================================================================
@@ -563,12 +581,12 @@ static void OpenLoadDialog() {
 - (void)mouseDragged:(NSEvent *)event {
     MarkUserInput(g_input);
     g_input.yaw -= (float)[event deltaX] * 0.005f;
-    // pitch += because the renderer Y-mirrors the world internally
-    // (gs_renderer.cpp); without this, mouse-drag-up would tilt the
-    // camera DOWN. cube_handle apps go the other way (-= deltaY)
-    // because they Y-flip at rasterization (negative VkViewport.height),
-    // not at view stage.
-    g_input.pitch += (float)[event deltaY] * 0.005f;
+    // pitch -= deltaY: since W7 (#396) gs_renderer flips Vulkan-Y at the
+    // RASTER stage (ndc2Pix(-ndc.y) + cov2d off-diagonal negation), NOT by
+    // reflecting the view matrix. A view-stage reflection would invert
+    // rotational handedness (needing += here); the raster flip does not, so
+    // we use the same -= convention as the cube_handle apps.
+    g_input.pitch -= (float)[event deltaY] * 0.005f;
     float maxPitch = 1.5f;
     if (g_input.pitch > maxPitch) g_input.pitch = maxPitch;
     if (g_input.pitch < -maxPitch) g_input.pitch = -maxPitch;
@@ -938,6 +956,10 @@ struct AppXrSession {
     PFN_xrRegisterMCPToolEXT pfnRegisterMCPToolEXT = nullptr;
     PFN_xrGetMCPToolCallArgsEXT pfnGetMCPToolCallArgsEXT = nullptr;
     PFN_xrSubmitMCPToolResultEXT pfnSubmitMCPToolResultEXT = nullptr;
+
+    // XR_EXT_view_rig (W7 of #396): the runtime owns the off-axis Kooima math
+    // and returns render-ready XrView{pose, fov}; the app deletes its own.
+    bool hasViewRigExt = false;
 
     // Enumerated rendering mode info
     uint32_t renderingModeCount = 0;
@@ -1374,6 +1396,7 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         if (strcmp(ext.extensionName, XR_EXT_DISPLAY_INFO_EXTENSION_NAME) == 0) xr.hasDisplayInfoExt = true;
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) xr.hasAtlasCaptureExt = true;
         if (strcmp(ext.extensionName, XR_EXT_MCP_TOOLS_EXTENSION_NAME) == 0) xr.hasMcpToolsExt = true;
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) xr.hasViewRigExt = true;
     }
 
     if (!hasVulkan) { LOG_ERROR("XR_KHR_vulkan_enable not available"); return false; }
@@ -1384,6 +1407,8 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     if (xr.hasDisplayInfoExt) enabled.push_back(XR_EXT_DISPLAY_INFO_EXTENSION_NAME);
     if (xr.hasAtlasCaptureExt) enabled.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
     if (xr.hasMcpToolsExt) enabled.push_back(XR_EXT_MCP_TOOLS_EXTENSION_NAME);
+    if (xr.hasViewRigExt) enabled.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
+    LOG_INFO("XR_EXT_view_rig: %s", xr.hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     XrInstanceCreateInfo ci = {XR_TYPE_INSTANCE_CREATE_INFO};
     strncpy(ci.applicationInfo.applicationName, "SR3DGSOpenXRExtMacOS", sizeof(ci.applicationInfo.applicationName));
@@ -2151,6 +2176,32 @@ int main(int argc, char** argv) {
                     eyeTrackingState.type = (XrStructureType)XR_TYPE_VIEW_EYE_TRACKING_STATE_EXT;
                     viewState.next = &eyeTrackingState;
 
+                    // Clean +Y-up world camera pose (no Y-mirror — the GsRenderer now
+                    // owns the Vulkan Y-down flip at its view stage; see updateUniforms).
+                    XrPosef cameraPose;
+                    quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &cameraPose.orientation);
+                    cameraPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
+                    const float rigVH =
+                        g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
+
+                    // XR_EXT_view_rig (#396 W7): chain the display rig so the runtime
+                    // owns the window resolve + off-axis Kooima and returns render-ready
+                    // XrView{pose, fov}. The raw channel (behind eye-tracking state)
+                    // carries display-space eyes for the HUD readout.
+                    const bool useRig =
+                        xr.hasViewRigExt && xr.displayWidthM > 0 && xr.displayHeightM > 0;
+                    XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                    XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                    if (useRig) {
+                        displayRig.pose = cameraPose;
+                        displayRig.virtualDisplayHeight = rigVH;
+                        displayRig.ipdFactor = g_input.viewParams.ipdFactor;
+                        displayRig.parallaxFactor = g_input.viewParams.parallaxFactor;
+                        displayRig.perspectiveFactor = g_input.viewParams.perspectiveFactor;
+                        locateInfo.next = &displayRig;
+                        eyeTrackingState.next = &viewRigRaw;
+                    }
+
                     uint32_t runtimeViewCount = xr.maxViewCount > 0 ? xr.maxViewCount : 2;
                     if (runtimeViewCount > 8) runtimeViewCount = 8;
                     XrView views[8] = {};
@@ -2179,42 +2230,24 @@ int main(int argc, char** argv) {
 
                         int eyeCount = monoMode ? 1 : (int)modeViewCount;
 
-                        // Collect raw eye positions for every view this mode uses.
-                        std::vector<XrVector3f> rawEyePos(modeViewCount);
-                        for (uint32_t v = 0; v < modeViewCount; v++)
-                            rawEyePos[v] = views[v].pose.position;
-
-                        // HUD exposes the first two for display; log everything up to 8.
-                        for (uint32_t v = 0; v < modeViewCount && v < 8; v++) {
-                            xr.eyePositions[v][0] = rawEyePos[v].x;
-                            xr.eyePositions[v][1] = rawEyePos[v].y;
-                            xr.eyePositions[v][2] = rawEyePos[v].z;
+                        // HUD eye readout. Under the rig, views[] carries render-ready
+                        // WORLD eyes, so the display-space eyes come from the raw channel
+                        // (XrViewDisplayRawEXT); without the rig, fall back to views[].
+                        if (useRig && viewRigRaw.eyeCountOutput > 0) {
+                            for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
+                                xr.eyePositions[v][0] = viewRigRaw.rawEyes[v].x;
+                                xr.eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
+                                xr.eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
+                            }
+                        } else {
+                            for (uint32_t v = 0; v < modeViewCount && v < 8; v++) {
+                                xr.eyePositions[v][0] = views[v].pose.position.x;
+                                xr.eyePositions[v][1] = views[v].pose.position.y;
+                                xr.eyePositions[v][2] = views[v].pose.position.z;
+                            }
                         }
                         xr.isEyeTracking = (eyeTrackingState.isTracking == XR_TRUE);
                         xr.activeEyeTrackingMode = (uint32_t)eyeTrackingState.activeMode;
-
-                        // Mono mode: centroid of all runtime views.
-                        if (monoMode) {
-                            XrVector3f c = {0, 0, 0};
-                            for (uint32_t v = 0; v < modeViewCount; v++) {
-                                c.x += rawEyePos[v].x; c.y += rawEyePos[v].y; c.z += rawEyePos[v].z;
-                            }
-                            float inv = 1.0f / (float)modeViewCount;
-                            c.x *= inv; c.y *= inv; c.z *= inv;
-                            rawEyePos.assign(1, c);
-                        }
-
-                        // Clean +Y-up world frame. The Vulkan render Y-mirror is owned
-                        // entirely by display3d_compute_views(..., vulkan_flip_y=1) (which
-                        // pairs with updateUniforms' NDC view-row flip). App code never
-                        // negates Y itself — the pick reuses these same clean values with
-                        // vulkan_flip_y=0, so render and pick can't drift.
-                        XrPosef cameraPose;
-                        quat_from_yaw_pitch(g_input.yaw, g_input.pitch, &cameraPose.orientation);
-                        cameraPose.position = {g_input.cameraPosX, g_input.cameraPosY, g_input.cameraPosZ};
-
-                        // nominalViewer in the clean world frame — used for parallax lerp.
-                        XrVector3f nominalViewer = {xr.nominalViewerX, xr.nominalViewerY, xr.nominalViewerZ};
 
                         // Per-view extent driven entirely by the current rendering
                         // mode's view_scale and the live window size. Atlas dims
@@ -2231,70 +2264,66 @@ int main(int argc, char** argv) {
                         if (renderH == 0) renderH = 1;
                         g_renderW = renderW; g_renderH = renderH;
 
-                        // Per-view Kooima pose + projection — one entry per view in this
-                        // multiview mode (1 for mono, 2 for stereo, 4 for quad, etc.).
+                        // --- Consume the runtime's render-ready XrView{pose, fov} (#396 W7) ---
+                        // The runtime owns the off-axis Kooima (window resolve included); the
+                        // app keeps only the clip policy (fov is clip-independent). near =
+                        // ez - vH, far = ez + far_offset, where ez = rig-local eye Z
+                        // (RigLocalEyeZ == the display-space eye Z display3d used to resolve).
+                        // Transparent-bg (Ctrl+T) clamps far to the ZDP (foreground-only);
+                        // opaque pushes it to ~infinity (1000·vH). The view matrix is the
+                        // plain clean-frame mat4_view_from_xr_pose — GsRenderer owns the
+                        // Vulkan Y-down flip at its view stage. eyeViews[] is just a per-view
+                        // container so the projection/render loops below stay unchanged.
                         std::vector<Display3DView> eyeViews((size_t)eyeCount);
-                        bool hasKooima = (xr.displayWidthM > 0 && xr.displayHeightM > 0);
-                        if (hasKooima) {
-                            float dispPxW = xr.displayPixelWidth > 0 ? (float)xr.displayPixelWidth : (float)xr.swapchain.width;
-                            float dispPxH = xr.displayPixelHeight > 0 ? (float)xr.displayPixelHeight : (float)xr.swapchain.height;
-                            float pxSizeX = xr.displayWidthM / dispPxW;
-                            float pxSizeY = xr.displayHeightM / dispPxH;
-                            float winW_m = (float)g_windowW * pxSizeX;
-                            float winH_m = (float)g_windowH * pxSizeY;
-
-                            // Window-relative Kooima: compute eye offset from window center
-                            float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                            if (g_window != nil) {
-                                NSRect winFrame = [g_window frame];
-                                NSScreen *screen_ns = [g_window screen] ?: [NSScreen mainScreen];
-                                NSRect screenFrame = [screen_ns frame];
-                                float winCenterX = (winFrame.origin.x - screenFrame.origin.x) + winFrame.size.width / 2.0f;
-                                float winCenterY = (winFrame.origin.y - screenFrame.origin.y) + winFrame.size.height / 2.0f;
-                                float dispCenterX = screenFrame.size.width / 2.0f;
-                                float dispCenterY = screenFrame.size.height / 2.0f;
-                                CGFloat backingScale = [g_window backingScaleFactor];
-                                float pxSizeXBacking = pxSizeX / (float)backingScale;
-                                float pxSizeYBacking = pxSizeY / (float)backingScale;
-                                eyeOffsetX = (winCenterX - dispCenterX) * pxSizeXBacking;
-                                eyeOffsetY = (winCenterY - dispCenterY) * pxSizeYBacking;
+                        bool hasKooima = useRig;
+                        if (useRig) {
+                            // Mono: collapse the active views to their centroid (pose + fov).
+                            std::vector<XrView> srcViews;
+                            if (monoMode && modeViewCount >= 1) {
+                                XrView cv = views[0];
+                                XrVector3f c = {0, 0, 0};
+                                XrFovf f = {0, 0, 0, 0};
+                                for (uint32_t v = 0; v < modeViewCount; v++) {
+                                    c.x += views[v].pose.position.x;
+                                    c.y += views[v].pose.position.y;
+                                    c.z += views[v].pose.position.z;
+                                    f.angleLeft  += views[v].fov.angleLeft;
+                                    f.angleRight += views[v].fov.angleRight;
+                                    f.angleUp    += views[v].fov.angleUp;
+                                    f.angleDown  += views[v].fov.angleDown;
+                                }
+                                float inv = 1.0f / (float)modeViewCount;
+                                cv.pose.position = {c.x * inv, c.y * inv, c.z * inv};
+                                cv.fov = {f.angleLeft * inv, f.angleRight * inv,
+                                          f.angleUp * inv, f.angleDown * inv};
+                                srcViews.assign(1, cv);
+                            } else {
+                                for (int e = 0; e < eyeCount; e++)
+                                    srcViews.push_back(views[e < (int)runtimeViewCount ? e : 0]);
                             }
-                            // Window-relative Kooima offset (real geometric correction,
-                            // applied in the clean +Y-up frame). The Vulkan render Y-mirror
-                            // is NOT applied here — display3d_compute_views(vulkan_flip_y=1)
-                            // owns it, so rawEyePos stays clean and the pick path can reuse
-                            // these exact eyes with vulkan_flip_y=0.
-                            for (auto& e : rawEyePos) { e.x -= eyeOffsetX; e.y -= eyeOffsetY; }
 
-                            Display3DScreen screen = {winW_m, winH_m};
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = g_input.viewParams.ipdFactor;
-                            tunables.parallax_factor = g_input.viewParams.parallaxFactor;
-                            tunables.perspective_factor = g_input.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
-
-                            // ZDP-relative clip planes (anchored per-eye from eye.z inside
-                            // display3d_compute_view): near = ez - near_offset, far =
-                            // ez + far_offset, with the offsets given as ABSOLUTE distances
-                            // in virtual-display-height (vH) units. Transparent-bg mode
-                            // (Ctrl+T) clamps the far plane to the ZDP (far_offset = 0,
-                            // foreground-only); opaque mode pushes it effectively to
-                            // infinity (1000*vH).
-                            const float vH = tunables.virtual_display_height;
-                            const float near_offset = vH;
-                            const float far_offset  = g_transparentBg ? 0.0f : 1000.0f * vH;
-
-                            display3d_compute_views(
-                                rawEyePos.data(), (uint32_t)eyeCount, &nominalViewer,
-                                &screen, &tunables, &cameraPose,
-                                near_offset, far_offset, /*vulkan_flip_y=*/1, eyeViews.data());
+                            for (int eye = 0; eye < eyeCount; eye++) {
+                                const XrView& sv = srcViews[eye];
+                                float ez = RigLocalEyeZ(cameraPose, sv.pose.position);
+                                float near_z = (ez - rigVH > 1.0e-4f) ? (ez - rigVH) : 1.0e-4f;
+                                float far_z  = g_transparentBg ? ez : (ez + 1000.0f * rigVH);
+                                if (far_z < near_z + 1.0e-4f) far_z = near_z + 1.0e-4f;
+                                mat4_view_from_xr_pose(eyeViews[eye].view_matrix, sv.pose);
+                                mat4_from_xr_fov(eyeViews[eye].projection_matrix, sv.fov, near_z, far_z);
+                                eyeViews[eye].fov = sv.fov;
+                                eyeViews[eye].eye_world = sv.pose.position;
+                                eyeViews[eye].orientation = sv.pose.orientation;
+                                eyeViews[eye].eye_display = {0.0f, 0.0f, ez};  // ZDP depth (pick/transparent)
+                                eyeViews[eye].near_z = near_z;
+                                eyeViews[eye].far_z = far_z;
+                            }
                         }
 
                         // Double-click focus: ray from CENTER physical eyes through the
                         // physical mouse location on the display surface, pick nearest splat,
                         // then smoothly move & re-orient the virtual display to face back
                         // along the ray.
-                        if (g_input.teleportRequested && hasKooima) {
+                        if (g_input.teleportRequested && useRig) {
                             g_input.teleportRequested = false;
                             NSSize viewSize = [[g_window contentView] bounds].size;
                             float ndcX = 2.0f * g_input.teleportMouseX / (float)viewSize.width - 1.0f;
@@ -2304,50 +2333,52 @@ int main(int argc, char** argv) {
                             // Win32 mouse y=0 is at the TOP.)
                             float ndcY = 2.0f * g_input.teleportMouseY / (float)viewSize.height - 1.0f;
 
-                            // Center-eye view for picking. Same eye-factor + Kooima pipeline
-                            // as the render (display3d_compute_center_view), reusing the exact
-                            // clean rawEyePos / nominalViewer / cameraPose the render consumed
-                            // — but with vulkan_flip_y=0, so the ray lives in the clean +Y-up
-                            // world frame the splats are in. No hand-rolled inverse of
-                            // eye_display = processed·es, no manual Y mirror: the pick ray
-                            // shares the render's math and can't drift from it.
-                            float dispPxW2 = xr.displayPixelWidth > 0 ? (float)xr.displayPixelWidth : (float)xr.swapchain.width;
-                            float dispPxH2 = xr.displayPixelHeight > 0 ? (float)xr.displayPixelHeight : (float)xr.swapchain.height;
-                            float winW_m2 = (float)g_windowW * (xr.displayWidthM / dispPxW2);
-                            float winH_m2 = (float)g_windowH * (xr.displayHeightM / dispPxH2);
-                            Display3DScreen screen2 = {winW_m2, winH_m2};
-                            Display3DTunables tunables2;
-                            tunables2.ipd_factor = g_input.viewParams.ipdFactor;
-                            tunables2.parallax_factor = g_input.viewParams.parallaxFactor;
-                            tunables2.perspective_factor = g_input.viewParams.perspectiveFactor;
-                            tunables2.virtual_display_height = g_input.viewParams.virtualDisplayHeight / g_input.viewParams.scaleFactor;
-
-                            // Well-conditioned frustum for the pick ray (a full line, so
-                            // the near/far choice doesn't truncate it); offsets in vH units.
-                            const float vH2 = tunables2.virtual_display_height;
-                            Display3DView centerView;
-                            display3d_compute_center_view(
-                                rawEyePos.data(), (uint32_t)rawEyePos.size(), &nominalViewer,
-                                &screen2, &tunables2, &cameraPose,
-                                vH2, 1000.0f * vH2, /*vulkan_flip_y=*/0, &centerView);
+                            // Center-eye pick view reconstructed from the render-ready rig
+                            // views: average the active eye poses + fovs into a symmetric
+                            // center frustum in the clean +Y-up world frame the splats live
+                            // in (no Y flip — the pick ray must match the world, not the
+                            // Vulkan raster). A well-conditioned near/far (the ray is a full
+                            // line). pickClipFar in transparent mode is the ZDP = rig-local
+                            // center eye Z, matching the old centerView.eye_display.z.
+                            XrVector3f cpos = {0, 0, 0};
+                            XrFovf cfov = {0, 0, 0, 0};
+                            for (int e = 0; e < eyeCount; e++) {
+                                cpos.x += eyeViews[e].eye_world.x;
+                                cpos.y += eyeViews[e].eye_world.y;
+                                cpos.z += eyeViews[e].eye_world.z;
+                                cfov.angleLeft  += eyeViews[e].fov.angleLeft;
+                                cfov.angleRight += eyeViews[e].fov.angleRight;
+                                cfov.angleUp    += eyeViews[e].fov.angleUp;
+                                cfov.angleDown  += eyeViews[e].fov.angleDown;
+                            }
+                            float invE = 1.0f / (float)eyeCount;
+                            XrPosef cpose;
+                            cpose.position = {cpos.x * invE, cpos.y * invE, cpos.z * invE};
+                            cpose.orientation = cameraPose.orientation;
+                            cfov = {cfov.angleLeft * invE, cfov.angleRight * invE,
+                                    cfov.angleUp * invE, cfov.angleDown * invE};
+                            float ez = RigLocalEyeZ(cameraPose, cpose.position);
+                            float pickNear = (ez - rigVH > 1.0e-4f) ? (ez - rigVH) : 1.0e-4f;
+                            float pickFar = ez + 1000.0f * rigVH;
+                            float pickView[16], pickProj[16];
+                            mat4_view_from_xr_pose(pickView, cpose);
+                            mat4_from_xr_fov(pickProj, cfov, pickNear, pickFar);
 
                             XrVector3f rayOriginV, rayDirV;
                             display3d_unproject_ndc_to_ray(ndcX, ndcY,
-                                centerView.view_matrix, centerView.projection_matrix,
-                                &rayOriginV, &rayDirV);
+                                pickView, pickProj, &rayOriginV, &rayDirV);
 
                             float rayOrigin[3] = {rayOriginV.x, rayOriginV.y, rayOriginV.z};
                             float rayDir[3]    = {rayDirV.x,    rayDirV.y,    rayDirV.z};
                             float hitPos[3];
                             // Only recenter on visible splats: reject any in front of the
-                            // near plane (centerView near_z), and — in transparent/
-                            // foreground mode — behind the ZDP (eye_display.z). Opaque mode
-                            // shows everything behind the display, so no far reject there.
-                            // A full miss returns false -> no recenter.
-                            float pickClipFar = g_transparentBg ? centerView.eye_display.z : 0.0f;
+                            // near plane (pickNear), and — in transparent/foreground mode —
+                            // behind the ZDP (ez). Opaque mode shows everything behind the
+                            // display, so no far reject there. A full miss returns false.
+                            float pickClipFar = g_transparentBg ? ez : 0.0f;
                             if (g_gsRenderer.pickGaussian(rayOrigin, rayDir, hitPos, 100.0f,
-                                                          centerView.view_matrix,
-                                                          centerView.near_z, pickClipFar)) {
+                                                          pickView,
+                                                          pickNear, pickClipFar)) {
                                 // Both endpoints stored in the clean +Y-up WORLD frame (the
                                 // same frame as g_input.cameraPosX/Y/Z and the splats) so the
                                 // slerp interpolates consistently.

--- a/openxr_includes/openxr/XR_EXT_view_rig.h
+++ b/openxr_includes/openxr/XR_EXT_view_rig.h
@@ -1,0 +1,152 @@
+// Copyright 2026, DisplayXR
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Header for XR_EXT_view_rig extension
+ * @author David Fattal
+ * @ingroup external_openxr
+ *
+ * App-facing control of the runtime's view-rig math: the app chains a rig
+ * descriptor (the handful of Kooima tunables) onto xrLocateViews and consumes
+ * standard XrView{pose, fov} — render-ready, clip-independent — instead of
+ * re-implementing the view math from raw eye positions. A separate raw-result
+ * struct exposes the complete rig inputs (display-space eyes, display plane,
+ * canvas rect, sample time, tracking lock) for aware consumers that keep doing
+ * their own math (e.g. the WebXR bridge).
+ *
+ * Two rigs exist, matching the two canonical pipelines:
+ *  - display rig (display-centric): the window/canvas is a portal into the
+ *    scene; tunables = virtual display height (m2v scale), ipd factor,
+ *    parallax factor, perspective factor.
+ *  - camera rig (camera-centric): an app-defined camera whose frustum eye
+ *    tracking perturbs; tunables = ipd factor, parallax factor, convergence,
+ *    vertical FOV.
+ *
+ * Descriptors carry NO clip parameters (fov is clip-independent — near/far and
+ * depth convention stay app-side) and NO placement parameters (the runtime owns
+ * the window/canvas geometry). The rig is strictly per-locate: chain a
+ * descriptor on every xrLocateViews you want it to drive (animating
+ * convergence or virtual display height is just passing different values next
+ * frame), and a locate that chains nothing keeps the default behavior —
+ * including the raw-eye transport in XrView.pose for external-window apps.
+ *
+ * The app-facing halves are pure next-chain structs on xrLocateViews. The one
+ * entry point, xrSetWorkspaceViewRigEXT, is for the workspace controller only:
+ * an app's own rig is honored by default (app visual policy within its canvas),
+ * but in workspace mode the controller may take over the clients' view geometry
+ * through this call (e.g. forcing identity m2v during a layout animation). Full
+ * design: docs/adr/ADR-024-raw-vs-render-ready-views.md (W7 of issue #396).
+ */
+#ifndef XR_EXT_VIEW_RIG_H
+#define XR_EXT_VIEW_RIG_H 1
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XR_EXT_view_rig 1
+#define XR_EXT_view_rig_SPEC_VERSION 2
+#define XR_EXT_VIEW_RIG_EXTENSION_NAME "XR_EXT_view_rig"
+
+// Reserved 1000999xxx range, next free block after mcp_tools (…130-132).
+// Final values reconcile with the Khronos registry before spec freeze.
+#define XR_TYPE_DISPLAY_RIG_EXT      ((XrStructureType)1000999140)
+#define XR_TYPE_CAMERA_RIG_EXT       ((XrStructureType)1000999141)
+#define XR_TYPE_VIEW_DISPLAY_RAW_EXT ((XrStructureType)1000999142)
+
+//! Capacity of XrViewDisplayRawEXT::rawEyes (matches the runtime's max views).
+#define XR_VIEW_RIG_MAX_RAW_EYES_EXT 8
+
+// ---- Request: chain exactly ONE of these on XrViewLocateInfo::next. ----
+
+/*!
+ * @brief Display-centric rig: the window/canvas is a portal into the scene.
+ *
+ * Maps 1:1 onto the runtime's display-rig tunables. Out-of-range values are
+ * clamped (with a one-shot runtime WARN), never rejected.
+ */
+typedef struct XrDisplayRigEXT {
+    XrStructureType          type;   //!< Must be XR_TYPE_DISPLAY_RIG_EXT
+    const void* XR_MAY_ALIAS next;
+    XrPosef pose;                  //!< virtual display plane pose in the locate space
+    float   virtualDisplayHeight;  //!< app units; m2v = this / physical canvas height
+    float   ipdFactor;             //!< [0,1] multiplies view-pose spread about the center
+    float   parallaxFactor;        //!< [0,1] lerps eye centroid toward nominal viewer
+    float   perspectiveFactor;     //!< [0.1,10] scales eye XYZ (object perspective)
+} XrDisplayRigEXT;
+
+/*!
+ * @brief Camera-centric rig: an app camera whose frustum eye tracking perturbs.
+ *
+ * Maps 1:1 onto the runtime's camera-rig tunables (convergenceDiopters is the
+ * inverse convergence distance the math consumes; verticalFov converts to
+ * half-tan at the boundary). Out-of-range values are clamped (one-shot WARN),
+ * never rejected.
+ */
+typedef struct XrCameraRigEXT {
+    XrStructureType          type;   //!< Must be XR_TYPE_CAMERA_RIG_EXT
+    const void* XR_MAY_ALIAS next;
+    XrPosef pose;                  //!< camera pose in the locate space
+    float   ipdFactor;             //!< [0,1] multiplies view-pose spread about the center
+    float   parallaxFactor;        //!< [0,1] lerps eye centroid toward nominal viewer
+    float   convergenceDiopters;   //!< 1/m to the convergence plane; 0 = infinity
+    float   verticalFov;           //!< radians, full vertical angle
+} XrCameraRigEXT;
+
+// ---- Result: app chains this on XrViewState::next; runtime fills it. ----
+
+/*!
+ * @brief Raw rig inputs for the locate, filled by the runtime.
+ *
+ * The complete input set the rigs consume, untransformed: per-view eye
+ * positions verbatim in physical display space (NOT canvas-rebased — apply
+ * the canvas rect yourself, e.g. via display3d_resolve_window_rect), the
+ * display-plane pose, the effective canvas the runtime resolved for this
+ * session, the eye-sample timestamp and the physical tracker lock. Reported
+ * eyes are the DP's full per-view set verbatim — one eye per active view
+ * (the display processor owns multi-view fill: e.g. it reports N eyes for an
+ * N-view mode; the runtime never synthesizes eyes). When the tracker has no
+ * lock the runtime still reports nominal-viewer eyes with isTracking = XR_FALSE.
+ */
+typedef struct XrViewDisplayRawEXT {
+    XrStructureType    type;       //!< Must be XR_TYPE_VIEW_DISPLAY_RAW_EXT
+    void* XR_MAY_ALIAS next;
+    XrVector3f  rawEyes[XR_VIEW_RIG_MAX_RAW_EYES_EXT]; //!< display-space eye positions (meters,
+                                   //!< display-center origin, +X right +Y up +Z toward viewer)
+    uint32_t    eyeCountOutput;    //!< eyes written = the DP's per-view count
+                                   //!< for this locate (one per active view)
+    XrPosef     displayPlanePose;  //!< physical display plane in the locate space
+    XrRect2Di   canvasRectPx;      //!< effective canvas on the panel (window client
+                                   //!< area / texture sub-rect / runtime window)
+    XrExtent2Df canvasSizeMeters;  //!< physical size of that canvas
+    int64_t     sampleTimeNs;      //!< when the eyes were sampled (monotonic)
+    XrBool32    isTracking;        //!< physical tracker lock (vs nominal fallback)
+} XrViewDisplayRawEXT;
+
+// ---- Entry point: workspace controller only. ----
+
+// Impose a view rig on the workspace's app clients (or clear it). By default an
+// app's own rig is honored within its canvas; while an override is set here, the
+// runtime applies THIS rig to the clients' locates instead — the controller
+// takes over view geometry (e.g. forcing identity m2v during a layout animation).
+//
+//   session — the active workspace controller's session (else
+//             XR_ERROR_VALIDATION_FAILURE).
+//   rig     — NULL, or an XrDisplayRigEXT / XrCameraRigEXT (its `type` selects
+//             which); NULL clears the override so clients fall back to honoring
+//             their own rigs. Out-of-range tunables are clamped.
+//
+// Per-call, not chained: the override stays in effect until changed or cleared.
+typedef XrResult(XRAPI_PTR *PFN_xrSetWorkspaceViewRigEXT)(XrSession session, const void *rig);
+
+#ifndef XR_NO_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSetWorkspaceViewRigEXT(XrSession session, const void *rig);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XR_EXT_VIEW_RIG_H

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -27,6 +27,8 @@
 #include "gs_renderer.h"
 #include "gs_scene_loader.h"
 #include "display3d_view.h"
+#include "view_rig_math.h"
+#include <openxr/XR_EXT_view_rig.h>
 
 #include "hud_renderer.h"
 #include "text_overlay.h"
@@ -633,15 +635,11 @@ static void RenderThreadFunc(
             std::lock_guard<std::mutex> lock(g_inputMutex);
             inputSnapshot = g_inputState;
         }
-        // Pitch sign flip for the GS demo: shared input_handler.cpp mutates
-        // pitch with `-= dy` (cube_handle convention, paired with negative
-        // VkViewport.height Y-flip at rasterization). The GS demo Y-flips
-        // at the *view* stage in gs_renderer.cpp instead — that inverts the
-        // visual response, so we negate here to restore drag-down → look-down.
-        // Only `renderPitch` is used downstream; `inputSnapshot.pitch` itself
-        // stays in shared-handler convention so the writeback at end of frame
-        // doesn't compound.
-        float renderPitch = -inputSnapshot.pitch;
+        // No pitch sign flip: since W7 (#396) gs_renderer flips Vulkan-Y at
+        // the RASTER stage (preprocess.comp), not by reflecting the view
+        // matrix, so the shared input_handler's `-= dy` cube_handle
+        // convention drives the camera directly — drag-down → look-down.
+        float renderPitch = inputSnapshot.pitch;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
             resetRequested = g_inputState.resetViewRequested;
@@ -833,6 +831,36 @@ static void RenderThreadFunc(
                         locateInfo.space = xr->localSpace;
 
                         XrViewState viewState = {XR_TYPE_VIEW_STATE};
+
+                        // Clean +Y-up world camera pose (no Y-mirror — the GsRenderer owns
+                        // the Vulkan Y-down flip at the raster stage; see preprocess.comp).
+                        XrPosef cameraPose;
+                        quat_from_yaw_pitch(inputSnapshot.yaw, inputSnapshot.pitch,
+                                            &cameraPose.orientation);
+                        cameraPose.position = {inputSnapshot.cameraPosX,
+                                               inputSnapshot.cameraPosY,
+                                               inputSnapshot.cameraPosZ};
+                        const float rigVH = inputSnapshot.viewParams.virtualDisplayHeight /
+                                            inputSnapshot.viewParams.scaleFactor;
+
+                        // XR_EXT_view_rig (#396 W7): chain the display rig so the runtime
+                        // owns the window resolve + off-axis Kooima and returns render-ready
+                        // XrView{pose, fov}. The raw channel carries display-space eyes for
+                        // the HUD readout.
+                        const bool useRig =
+                            XrViewRigExtAvailable() && xr->displayWidthM > 0 && xr->displayHeightM > 0;
+                        XrDisplayRigEXT displayRig = {XR_TYPE_DISPLAY_RIG_EXT};
+                        XrViewDisplayRawEXT viewRigRaw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+                        if (useRig) {
+                            displayRig.pose = cameraPose;
+                            displayRig.virtualDisplayHeight = rigVH;
+                            displayRig.ipdFactor = inputSnapshot.viewParams.ipdFactor;
+                            displayRig.parallaxFactor = inputSnapshot.viewParams.parallaxFactor;
+                            displayRig.perspectiveFactor = inputSnapshot.viewParams.perspectiveFactor;
+                            locateInfo.next = &displayRig;
+                            viewState.next = &viewRigRaw;
+                        }
+
                         // Over-allocate to the runtime's max possible view_count (sim_display
                         // reports 4 for Quad mode; LeiaSR reports 2). Hardcoding 2 here used
                         // to fail with XR_ERROR_SIZE_INSUFFICIENT under sim_display.
@@ -841,11 +869,23 @@ static void RenderThreadFunc(
                         for (uint32_t i = 0; i < 8; i++) rawViews[i] = {XR_TYPE_VIEW};
                         xrLocateViews(xr->session, &locateInfo, &viewState, 8, &viewCount, rawViews);
 
+                        // HUD eye readout. Under the rig, rawViews[] carries render-ready
+                        // WORLD eyes, so the display-space eyes come from the raw channel
+                        // (XrViewDisplayRawEXT); without the rig, LocateViews() already
+                        // stored them from its own (rig-free) locate.
+                        if (useRig && viewRigRaw.eyeCountOutput > 0) {
+                            for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
+                                xr->eyePositions[v][0] = viewRigRaw.rawEyes[v].x;
+                                xr->eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
+                                xr->eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
+                            }
+                        }
+
                         bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);
 
                         // View count for the active rendering mode (1=mono, 2=stereo, 4=quad).
                         // Sized off the runtime's per-mode advertisement so the eye-loop and
-                        // per-view buffers (rawEyes / stereoViews / viewMat / projectionViews)
+                        // per-view buffers (stereoViews / viewMat / projectionViews)
                         // all line up with what xrEndFrame expects.
                         uint32_t activeViewCount = (xr->renderingModeCount > 0)
                             ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2u;
@@ -880,162 +920,130 @@ static void RenderThreadFunc(
                         if (renderW == 0) renderW = 1;
                         if (renderH == 0) renderH = 1;
 
-                        // App-side Kooima projection (per-view, sized to active mode)
+                        // --- Consume the runtime's render-ready XrView{pose, fov} (#396 W7) ---
+                        // The runtime owns the off-axis Kooima (window resolve included); the
+                        // app keeps only the clip policy (fov is clip-independent). near =
+                        // ez - vH, far = ez + far_offset, where ez = rig-local eye Z
+                        // (RigLocalEyeZ == the display-space eye Z display3d used to resolve).
+                        // Transparent-bg (Ctrl+T) clamps far to the ZDP (foreground-only);
+                        // opaque pushes it to ~infinity (1000·vH). The view matrix is the
+                        // plain clean-frame mat4_view_from_xr_pose — GsRenderer owns the
+                        // Vulkan Y-down flip at the raster stage. stereoViews[] is just a
+                        // per-view container so the render loops below stay unchanged.
                         Display3DView stereoViews[8];
-                        // Clean (un-flipped) cyclopean view for picking, computed from the
-                        // SAME clean eyes/pose the render uses — shared, never reconstructed.
-                        Display3DView pickCenterView{};
-                        bool useAppProjection = (xr->hasDisplayInfoExt && xr->displayWidthM > 0.0f);
-                        if (useAppProjection) {
-                            float dispPxW = xr->displayPixelWidth > 0 ? (float)xr->displayPixelWidth : (float)xr->swapchain.width;
-                            float dispPxH = xr->displayPixelHeight > 0 ? (float)xr->displayPixelHeight : (float)xr->swapchain.height;
-                            float pxSizeX = xr->displayWidthM / dispPxW;
-                            float pxSizeY = xr->displayHeightM / dispPxH;
-                            float winW_m = (float)windowW * pxSizeX;
-                            float winH_m = (float)windowH * pxSizeY;
-
-                            // Window-relative Kooima: compute eye offset from window center
-                            float eyeOffsetX = 0.0f, eyeOffsetY = 0.0f;
-                            {
-                                POINT clientOrigin = {0, 0};
-                                ClientToScreen(hwnd, &clientOrigin);
-                                HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                                MONITORINFO mi = {sizeof(mi)};
-                                if (GetMonitorInfo(hMon, &mi)) {
-                                    float winCenterX = (float)(clientOrigin.x - mi.rcMonitor.left) + windowW / 2.0f;
-                                    float winCenterY = (float)(clientOrigin.y - mi.rcMonitor.top) + windowH / 2.0f;
-                                    float dispW = (float)(mi.rcMonitor.right - mi.rcMonitor.left);
-                                    float dispH = (float)(mi.rcMonitor.bottom - mi.rcMonitor.top);
-                                    eyeOffsetX = (winCenterX - dispW / 2.0f) * pxSizeX;
-                                    eyeOffsetY = -((winCenterY - dispH / 2.0f) * pxSizeY);
-                                }
-                            }
-
-                            // Build per-view raw eye positions in the clean +Y-up world
-                            // frame. The Vulkan render Y-mirror is owned entirely by
-                            // display3d_compute_views(vulkan_flip_y=1) (paired with
-                            // updateUniforms' NDC view-row flip) — so rawEyes stays clean and
-                            // the pick path reuses these exact eyes with vulkan_flip_y=0.
-                            XrVector3f rawEyes[8];
+                        bool useAppProjection = useRig;
+                        if (useRig) {
+                            // Mono: collapse the active views to their centroid (pose + fov).
+                            uint32_t srcCount = activeViewCount;
+                            if (srcCount > viewCount) srcCount = viewCount;
+                            if (srcCount < 1) srcCount = 1;
+                            XrView srcViews[8];
                             if (monoMode) {
-                                // Mono center = average of left/right raw views (0 and 1).
-                                XrVector3f l = rawViews[0].pose.position;
-                                XrVector3f r = rawViews[1].pose.position;
-                                rawEyes[0].x = (l.x + r.x) * 0.5f - eyeOffsetX;
-                                rawEyes[0].y = (l.y + r.y) * 0.5f - eyeOffsetY;
-                                rawEyes[0].z = (l.z + r.z) * 0.5f;
-                            } else {
-                                for (int i = 0; i < eyeCount; i++) {
-                                    XrVector3f e = rawViews[i].pose.position;
-                                    e.x -= eyeOffsetX;
-                                    e.y -= eyeOffsetY;
-                                    rawEyes[i] = e;
+                                XrView cv = rawViews[0];
+                                XrVector3f c = {0, 0, 0};
+                                XrFovf f = {0, 0, 0, 0};
+                                for (uint32_t v = 0; v < srcCount; v++) {
+                                    c.x += rawViews[v].pose.position.x;
+                                    c.y += rawViews[v].pose.position.y;
+                                    c.z += rawViews[v].pose.position.z;
+                                    f.angleLeft  += rawViews[v].fov.angleLeft;
+                                    f.angleRight += rawViews[v].fov.angleRight;
+                                    f.angleUp    += rawViews[v].fov.angleUp;
+                                    f.angleDown  += rawViews[v].fov.angleDown;
                                 }
+                                float inv = 1.0f / (float)srcCount;
+                                cv.pose.position = {c.x * inv, c.y * inv, c.z * inv};
+                                cv.fov = {f.angleLeft * inv, f.angleRight * inv,
+                                          f.angleUp * inv, f.angleDown * inv};
+                                srcViews[0] = cv;
+                            } else {
+                                for (int e = 0; e < eyeCount; e++)
+                                    srcViews[e] = rawViews[e < (int)viewCount ? e : 0];
                             }
 
-                            Display3DTunables tunables;
-                            tunables.ipd_factor = inputSnapshot.viewParams.ipdFactor;
-                            tunables.parallax_factor = inputSnapshot.viewParams.parallaxFactor;
-                            tunables.perspective_factor = inputSnapshot.viewParams.perspectiveFactor;
-                            tunables.virtual_display_height = inputSnapshot.viewParams.virtualDisplayHeight / inputSnapshot.viewParams.scaleFactor;
-
-                            // ZDP-relative clip: near/far placed at fixed *absolute*
-                            // offsets (in virtual-display-height units) in front of /
-                            // behind each eye's perpendicular distance to the convergence
-                            // plane (ZDP). display3d_compute_view anchors them per-eye from
-                            // eye.z (near = ez - near_offset, far = ez + far_offset).
-                            // Transparent mode clips at the ZDP (far_offset = 0); opaque
-                            // pushes the far plane effectively to infinity (1000*vH).
-                            const float vH = tunables.virtual_display_height;
-                            const float near_offset = vH;
-                            const float far_offset  = g_transparentBg.load() ? 0.0f : 1000.0f * vH;
-
-                            XrPosef displayPose;
-                            XMVECTOR pOri = XMQuaternionRotationRollPitchYaw(
-                                renderPitch, inputSnapshot.yaw, 0);
-                            XMFLOAT4 q;
-                            XMStoreFloat4(&q, pOri);
-                            displayPose.orientation = {q.x, q.y, q.z, q.w};
-                            // Clean +Y-up world frame. The Vulkan render Y-mirror is owned by
-                            // display3d_compute_views(..., vulkan_flip_y=1) below; the pick
-                            // reuses these same clean values with vulkan_flip_y=0.
-                            displayPose.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY, inputSnapshot.cameraPosZ};
-
-                            // nominalViewer in the clean world frame — used for parallax lerp.
-                            XrVector3f nominalViewer = {xr->nominalViewerX, xr->nominalViewerY, xr->nominalViewerZ};
-                            Display3DScreen screen = {winW_m, winH_m};
-
-                            display3d_compute_views(
-                                rawEyes, (uint32_t)eyeCount, &nominalViewer,
-                                &screen, &tunables, &displayPose,
-                                near_offset, far_offset, /*vulkan_flip_y=*/1, stereoViews);
-
-                            // Cyclopean view for picking: same eyes/pose/factors, but the
-                            // clean +Y-up world frame (vulkan_flip_y=0). Built here where the
-                            // clean inputs are in scope; the pick path below just unprojects
-                            // through it — no hand-rolled inverse, no manual Y mirror.
-                            // Pick projection only needs a well-conditioned frustum (the
-                            // unprojected ray is a full line, unaffected by near/far), so
-                            // use transparency-independent offsets regardless of mode.
-                            display3d_compute_center_view(
-                                rawEyes, (uint32_t)eyeCount, &nominalViewer,
-                                &screen, &tunables, &displayPose,
-                                vH, 1000.0f * vH, /*vulkan_flip_y=*/0, &pickCenterView);
+                            for (int eye = 0; eye < eyeCount; eye++) {
+                                const XrView& sv = srcViews[eye];
+                                float ez = RigLocalEyeZ(cameraPose, sv.pose.position);
+                                float near_z = (ez - rigVH > 1.0e-4f) ? (ez - rigVH) : 1.0e-4f;
+                                float far_z  = g_transparentBg.load() ? ez : (ez + 1000.0f * rigVH);
+                                if (far_z < near_z + 1.0e-4f) far_z = near_z + 1.0e-4f;
+                                mat4_view_from_xr_pose(stereoViews[eye].view_matrix, sv.pose);
+                                mat4_from_xr_fov(stereoViews[eye].projection_matrix, sv.fov, near_z, far_z);
+                                stereoViews[eye].fov = sv.fov;
+                                stereoViews[eye].eye_world = sv.pose.position;
+                                stereoViews[eye].orientation = sv.pose.orientation;
+                                stereoViews[eye].eye_display = {0.0f, 0.0f, ez};  // ZDP depth (pick/transparent)
+                                stereoViews[eye].near_z = near_z;
+                                stereoViews[eye].far_z = far_z;
+                            }
                         }
 
                         // Double-click focus: center-eye ray through mouse, pick splat,
                         // smoothly re-pose the virtual display to face back along the ray.
-                        if (inputSnapshot.teleportRequested && useAppProjection) {
+                        if (inputSnapshot.teleportRequested && useRig) {
                             float ndcX = 2.0f * inputSnapshot.teleportMouseX / (float)windowW - 1.0f;
                             float ndcY = -(2.0f * inputSnapshot.teleportMouseY / (float)windowH - 1.0f);
 
-                            // Use the clean cyclopean view built in the render block from the
-                            // same eyes/pose/factors (pickCenterView, vulkan_flip_y=0). No
-                            // reconstruction, no manual Y mirror — the pick ray shares the
-                            // render's math. NDC Y was already adjusted above for Win32's
-                            // top-left mouse origin.
-                            const Display3DView& centerView = pickCenterView;
+                            // Center-eye pick view reconstructed from the render-ready rig
+                            // views: average the active eye poses + fovs into a symmetric
+                            // center frustum in the clean +Y-up world frame the splats live
+                            // in (no Y flip — the pick ray must match the world, not the
+                            // Vulkan raster). A well-conditioned near/far (the ray is a full
+                            // line). pickClipFar in transparent mode is the ZDP = rig-local
+                            // center eye Z, matching the old centerView.eye_display.z. NDC Y
+                            // was already adjusted above for Win32's top-left mouse origin.
+                            XrVector3f cpos = {0, 0, 0};
+                            XrFovf cfov = {0, 0, 0, 0};
+                            for (int e = 0; e < eyeCount; e++) {
+                                cpos.x += stereoViews[e].eye_world.x;
+                                cpos.y += stereoViews[e].eye_world.y;
+                                cpos.z += stereoViews[e].eye_world.z;
+                                cfov.angleLeft  += stereoViews[e].fov.angleLeft;
+                                cfov.angleRight += stereoViews[e].fov.angleRight;
+                                cfov.angleUp    += stereoViews[e].fov.angleUp;
+                                cfov.angleDown  += stereoViews[e].fov.angleDown;
+                            }
+                            float invE = 1.0f / (float)eyeCount;
+                            XrPosef cpose;
+                            cpose.position = {cpos.x * invE, cpos.y * invE, cpos.z * invE};
+                            cpose.orientation = cameraPose.orientation;
+                            cfov = {cfov.angleLeft * invE, cfov.angleRight * invE,
+                                    cfov.angleUp * invE, cfov.angleDown * invE};
+                            float ez = RigLocalEyeZ(cameraPose, cpose.position);
+                            float pickNear = (ez - rigVH > 1.0e-4f) ? (ez - rigVH) : 1.0e-4f;
+                            float pickFar = ez + 1000.0f * rigVH;
+                            float pickView[16], pickProj[16];
+                            mat4_view_from_xr_pose(pickView, cpose);
+                            mat4_from_xr_fov(pickProj, cfov, pickNear, pickFar);
 
                             XrVector3f rayOriginV, rayDirV;
                             display3d_unproject_ndc_to_ray(ndcX, ndcY,
-                                centerView.view_matrix, centerView.projection_matrix,
-                                &rayOriginV, &rayDirV);
+                                pickView, pickProj, &rayOriginV, &rayDirV);
 
                             float rayOrigin[3] = {rayOriginV.x, rayOriginV.y, rayOriginV.z};
                             float rayDir[3]    = {rayDirV.x,    rayDirV.y,    rayDirV.z};
                             float hitPos[3];
                             // Only recenter on splats that are actually visible: reject any
-                            // outside the rendered view-space window. Near plane = centerView
-                            // near_z (always active); far plane = the ZDP (eye_display.z) only
-                            // in transparent/foreground mode, else no far reject (opaque shows
-                            // everything behind the display). A full miss returns false -> no
-                            // recenter, which is the existing behavior.
-                            float pickClipNear = centerView.near_z;
-                            float pickClipFar  = g_transparentBg.load() ? centerView.eye_display.z : 0.0f;
+                            // in front of the near plane (pickNear), and — in transparent/
+                            // foreground mode — behind the ZDP (ez). Opaque mode shows
+                            // everything behind the display, so no far reject there. A full
+                            // miss returns false -> no recenter, the existing behavior.
+                            float pickClipFar = g_transparentBg.load() ? ez : 0.0f;
                             std::lock_guard<std::mutex> sceneLock(g_sceneMutex);
                             if (g_gsRenderer.pickGaussian(rayOrigin, rayDir, hitPos, 100.0f,
-                                                          centerView.view_matrix,
-                                                          pickClipNear, pickClipFar)) {
-                                // Both endpoints stored in WORLD frame (the same frame as
-                                // inputSnapshot.cameraPosX/Y/Z and inputSnapshot.pitch/yaw)
-                                // so the slerp's writeback decodes back into world-frame
-                                // pitch/yaw. pickCenterView's orientation was built from
-                                // renderPitch (-pitch); we must NOT reuse that render-frame
-                                // quaternion here, else the slerp's `state.pitch = asin(fwd.y)`
-                                // decode produces a sign-flipped pitch and the display rotates
-                                // on teleport.
-                                XMVECTOR worldOriQ = XMQuaternionRotationRollPitchYaw(
-                                    inputSnapshot.pitch, inputSnapshot.yaw, 0);
-                                XMFLOAT4 wq;
-                                XMStoreFloat4(&wq, worldOriQ);
-                                XrQuaternionf worldOri = {wq.x, wq.y, wq.z, wq.w};
-
+                                                          pickView,
+                                                          pickNear, pickClipFar)) {
+                                // Both endpoints stored in the clean +Y-up WORLD frame (the
+                                // same frame as inputSnapshot.cameraPosX/Y/Z and the splats)
+                                // so the slerp interpolates consistently. cameraPose is that
+                                // world orientation — no pitch-sign rebuild needed since the
+                                // raster-stage flip removed the render-frame negation.
                                 XrPosef fromWorld;
-                                fromWorld.orientation = worldOri;
+                                fromWorld.orientation = cameraPose.orientation;
                                 fromWorld.position = {inputSnapshot.cameraPosX, inputSnapshot.cameraPosY, inputSnapshot.cameraPosZ};
                                 XrPosef target;
                                 target.position = {hitPos[0], hitPos[1], hitPos[2]};
-                                target.orientation = worldOri;  // preserve current orientation — translate-only
+                                target.orientation = cameraPose.orientation;  // preserve current orientation — translate-only
                                 std::lock_guard<std::mutex> inputLock(g_inputMutex);
                                 g_inputState.transitionFrom = fromWorld;
                                 g_inputState.transitionTo = target;
@@ -1053,9 +1061,16 @@ static void RenderThreadFunc(
                         XMMATRIX monoViewMatrix, monoProjMatrix;
                         XrPosef monoPose = rawViews[0].pose;
                         if (monoMode) {
-                            monoPose.position.x = (rawViews[0].pose.position.x + rawViews[1].pose.position.x) * 0.5f;
-                            monoPose.position.y = (rawViews[0].pose.position.y + rawViews[1].pose.position.y) * 0.5f;
-                            monoPose.position.z = (rawViews[0].pose.position.z + rawViews[1].pose.position.z) * 0.5f;
+                            if (useRig) {
+                                // Centroid view already built into stereoViews[0]; submit
+                                // its world eye with the camera orientation.
+                                monoPose.position = stereoViews[0].eye_world;
+                                monoPose.orientation = cameraPose.orientation;
+                            } else {
+                                monoPose.position.x = (rawViews[0].pose.position.x + rawViews[1].pose.position.x) * 0.5f;
+                                monoPose.position.y = (rawViews[0].pose.position.y + rawViews[1].pose.position.y) * 0.5f;
+                                monoPose.position.z = (rawViews[0].pose.position.z + rawViews[1].pose.position.z) * 0.5f;
+                            }
 
                             if (!useAppProjection) {
                                 monoProjMatrix = xr->projMatrices[0];
@@ -1220,7 +1235,15 @@ static void RenderThreadFunc(
                                 projectionViews[eye].subImage.imageRect.extent = {
                                     (int32_t)renderW, (int32_t)renderH};
                                 projectionViews[eye].subImage.imageArrayIndex = 0;
-                                projectionViews[eye].pose = monoMode ? monoPose : rawViews[eye].pose;
+                                if (useRig) {
+                                    // Submit the consumed per-view world eye with the camera
+                                    // orientation (mirrors the macOS W7 leg).
+                                    projectionViews[eye].pose.position =
+                                        stereoViews[monoMode ? 0 : eye].eye_world;
+                                    projectionViews[eye].pose.orientation = cameraPose.orientation;
+                                } else {
+                                    projectionViews[eye].pose = monoMode ? monoPose : rawViews[eye].pose;
+                                }
                                 projectionViews[eye].fov = useAppProjection ?
                                     stereoViews[monoMode ? 0 : eye].fov :
                                     (monoMode ? rawViews[0].fov : rawViews[eye].fov);

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -7,7 +7,17 @@
 
 #include "xr_session.h"
 #include "logging.h"
+#include <openxr/XR_EXT_view_rig.h>
 #include <cstring>
+
+// XR_EXT_view_rig (W7 of #396): the runtime owns the off-axis Kooima math and
+// returns render-ready XrView{pose, fov}; the app deletes its own. The flag
+// lives demo-side (file-static + accessor) because XrSessionManager comes from
+// displayxr::common, which doesn't carry view-rig state yet — upstream it there
+// and re-pin when the package adopts the extension.
+static bool s_hasViewRigExt = false;
+
+bool XrViewRigExtAvailable() { return s_hasViewRigExt; }
 
 #define XR_CHECK(call) \
     do { \
@@ -56,6 +66,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0) {
             xr.hasAtlasCaptureExt = true;
         }
+        if (strcmp(ext.extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+            s_hasViewRigExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_vulkan_enable: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
@@ -63,6 +76,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_EXT_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_EXT_atlas_capture: %s", xr.hasAtlasCaptureExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_EXT_view_rig: %s", s_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasVulkan) {
         LOG_ERROR("XR_KHR_vulkan_enable extension not available");
@@ -82,6 +96,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (xr.hasAtlasCaptureExt) {
         enabledExtensions.push_back(XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME);
+    }
+    if (s_hasViewRigExt) {
+        enabledExtensions.push_back(XR_EXT_VIEW_RIG_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -15,6 +15,10 @@
 // Initialize OpenXR instance with Vulkan + win32_window_binding extensions
 bool InitializeOpenXR(XrSessionManager& xr);
 
+// XR_EXT_view_rig (W7 of #396) detected + enabled by InitializeOpenXR. Demo-side
+// because displayxr::common's XrSessionManager doesn't carry view-rig state yet.
+bool XrViewRigExtAvailable();
+
 // Get Vulkan graphics requirements and set up Vulkan instance/device per OpenXR spec
 bool GetVulkanGraphicsRequirements(XrSessionManager& xr);
 


### PR DESCRIPTION
## Summary

W7 of displayxr-runtime#396 for the gauss demo, both platforms: the app chains an `XrDisplayRigEXT` onto every `xrLocateViews` and consumes the runtime's **render-ready** `XrView{pose, fov}`, deleting the app-side Kooima (`display3d_compute_views`/`_center_view` + the window-center eye-offset gathers). The app keeps only the ZDP-anchored clip policy (fov is clip-independent): `near = ez - vH`, `far = ez + 1000*vH` (opaque) / `far = ez` (transparent Ctrl+T), with `ez = RigLocalEyeZ(cameraPose, viewPose)`.

- **macOS leg** (`24e41b2` lineage): verified live on macOS 2026-06-10 (sim_display, anaglyph + transparent).
- **Windows leg**: mirrors the macOS template; verified live on the Leia SR dev display 2026-06-10 — butterfly upright + crisp, off-axis + yaw/pitch correct, opaque + Ctrl+T, double-click focus hits center and off-center with correct ray direction, full-miss no-ops. Zero WARN/ERROR in session logs.
- **Shared renderer**: gs_renderer now owns the Vulkan Y-down flip at the RASTER stage (preprocess.comp), not via a view-matrix reflection — so neither platform negates pitch at the view stage anymore (macOS `mouseDragged -=`, Windows drops `renderPitch = -pitch`).
- **`common/view_rig_math.h`** (new): the view/projection builders (`mat4_from_xr_fov`, `mat4_view_from_xr_pose`, `RigLocalEyeZ` + quat helpers) extracted verbatim so the platforms can't drift. Windows consumes it now; macos/main.mm keeps its statics and adopts the header in a later macOS session.

## Rebase notes (over W4 displayxr::common consumption)

- `XrSessionManager` now comes from `displayxr::common`, which has no view-rig state yet — the Windows `hasViewRigExt` flag lives demo-side as `XrViewRigExtAvailable()` in `windows/xr_session.{h,cpp}`. Follow-up: upstream the field to displayxr-common and re-pin.
- `macos/main.mm` re-merged with the #32 MCP-tools additions (keep-both, four hunks).
- MCP `set_camera`/`orbit_camera` pitch semantics under W7: positive `pitch_deg` now means look **up** (matches the documented elevation semantics; previously rendered inverted).

## Verification

- Windows: built + run against runtime DLL 2026-06-09 (`XR_EXT_view_rig` v2 AVAILABLE), full interactive checklist + programmatic pick probes on both the pre-rebase and post-rebase builds.
- macOS: compile-checked by CI here; runtime-verified at the original (pre-rebase) commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)