### PR TITLE
ci: bump actions to Node 24 runtimes ahead of the June 16 default flip

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -27,7 +27,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# contents: write is required by softprops/action-gh-release@v2 to
+# contents: write is required by softprops/action-gh-release@v3 to
 # create-or-update the GitHub Release on v* tag push. The runtime repo's
 # build-macos.yml also exports GH_TOKEN explicitly because the action
 # prefers $GH_TOKEN over its `token:` input when set — without this it
@@ -41,7 +41,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: filter
@@ -77,7 +77,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Doc-only PR — skipping heavy build steps
         if: needs.DetectChanges.outputs.docs_only == 'true'
@@ -164,20 +164,20 @@ jobs:
 
       - name: Upload installer
         if: needs.DetectChanges.outputs.docs_only != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           retention-days: 3
           name: DisplayXRGaussianSplat-macOS
           if-no-files-found: error
           path: _package/DisplayXRGaussianSplat-*.pkg
 
-      # softprops/action-gh-release@v2 create-or-updates the GitHub
+      # softprops/action-gh-release@v3 create-or-updates the GitHub
       # Release on v* tag push and attaches the .pkg. If a Windows
       # release workflow on the same tag races, the action just appends
       # — both assets end up on the same release.
       - name: Attach .pkg to GitHub release on tag
         if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: _package/DisplayXRGaussianSplat-*.pkg
           fail_on_unmatched_files: true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,7 +29,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# contents: write is required by softprops/action-gh-release@v2 to
+# contents: write is required by softprops/action-gh-release@v3 to
 # create-or-update the GitHub Release on a v* tag push. GH_TOKEN is exported
 # explicitly because the action prefers $GH_TOKEN over its `token:` input.
 permissions:
@@ -41,7 +41,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: filter
@@ -77,7 +77,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Doc-only PR — skipping heavy build steps
         if: needs.DetectChanges.outputs.docs_only == 'true'
@@ -198,19 +198,19 @@ jobs:
 
       - name: Upload installer
         if: needs.DetectChanges.outputs.docs_only != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           retention-days: 3
           name: DisplayXRGaussianSplat-Windows
           if-no-files-found: error
           path: installer/DisplayXRGaussianSplatSetup-*.exe
 
-      # softprops/action-gh-release@v2 create-or-updates the GitHub Release on
+      # softprops/action-gh-release@v3 create-or-updates the GitHub Release on
       # a v* tag and attaches the .exe. If the macOS workflow races on the same
       # tag, the action just appends — both assets land on the same release.
       - name: Attach installer to GitHub release on tag
         if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: installer/DisplayXRGaussianSplatSetup-*.exe
           fail_on_unmatched_files: true
@@ -232,7 +232,7 @@ jobs:
     steps:
       - name: Mint dispatch token
         id: dispatch-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DISPLAYXR_APP_ID }}
           private-key: ${{ secrets.DISPLAYXR_APP_PRIVATE_KEY }}
@@ -240,7 +240,7 @@ jobs:
           repositories: displayxr-runtime
 
       - name: Dispatch versions.json bump
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.dispatch-token.outputs.token }}
           repository: DisplayXR/displayxr-runtime

--- a/.github/workflows/no-vendored-math.yml
+++ b/.github/workflows/no-vendored-math.yml
@@ -21,7 +21,7 @@ jobs:
   no-vendored-math:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: No re-vendored displayxr::math sources
         shell: bash
         run: |


### PR DESCRIPTION
GitHub flips JavaScript actions to a Node 24 default on **June 16**. Bump every action pin to the lowest major that declares `runs.using: node24` (each verified against the tag's `action.yml`). Org-wide sweep; runtime already landed as displayxr-runtime#554.

Mapping: checkout v4→v5, cache v4→v5, upload-artifact v4→v6, download-artifact v4→v7 (v5's breaking path change only affects `artifact-ids:` downloads; ours are by `name:`), setup-java v4→v5, setup-node v4→v5, create-github-app-token v1→v3 (same inputs), repository-dispatch v3→v4, action-gh-release v2→v3, gha-setup-ninja v4→v6 (newest available; Node 20 — no Node 24 release upstream yet).

Left as-is (no Node 24 release exists; will be force-run on Node 24 and expected to work): `ilammy/msvc-dev-cmd@v1`. Already Node 24: `lukka/run-vcpkg@v11`, `nttld/setup-ndk@v1`; `humbletim/install-vulkan-sdk@v1.2` is composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
