### PR TITLE
Android: render-scale knob — ~3× fps (gauss is compute-bound, not weave-capped)

### DIFF
--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -677,6 +677,51 @@ bool GsRenderer::loadScene(const char* plyPath)
         return false;
     }
 
+    // Load-time opacity cull (perf): compact out near-transparent gaussians
+    // before upload. scale_opacity[3] is the sigmoid'd opacity in [0,1]. These
+    // splats expand into sort+composite fragments every eye but barely affect
+    // the image — dropping them cuts the GPU-bound fragment count directly.
+    // setCullMinOpacity(0) keeps the original behaviour (no cull).
+    if (cullMinOpacity_ > 0.0f && vertices.size() >= 1024) {
+        size_t total = vertices.size();
+        size_t kept = 0;
+        for (size_t i = 0; i < total; i++) {
+            if (vertices[i].scale_opacity[3] < cullMinOpacity_) continue;
+            vertices[kept++] = vertices[i];
+        }
+        if (kept >= 1) {  // never cull to empty
+            size_t dropped = total - kept;
+            vertices.resize(kept);
+            GS_LOGI("GsRenderer: opacity cull dropped %zu/%zu gaussians "
+                    "(minOpacity=%.3f, %zu kept)",
+                    dropped, total, (double)cullMinOpacity_, kept);
+        }
+    }
+
+    // Load-time decimation (perf): keep ~cullKeepFrac_ of the gaussians,
+    // hash-selected for a spatially-uniform thinning independent of file order.
+    // Works on dense opaque scenes where the opacity cull drops nothing. Cuts
+    // the fragment count (hence sort + composite) ~linearly with the count.
+    if (cullKeepFrac_ < 0.999f && vertices.size() >= 1024) {
+        size_t total = vertices.size();
+        // keep i when its hashed bucket falls under the keep threshold
+        const uint32_t thresh = (uint32_t)(cullKeepFrac_ * 65536.0f);
+        size_t kept = 0;
+        for (size_t i = 0; i < total; i++) {
+            // cheap integer hash (Knuth multiplicative), take 16 bits
+            uint32_t h = ((uint32_t)i * 2654435761u) >> 16;
+            if ((h & 0xFFFFu) >= thresh) continue;
+            vertices[kept++] = vertices[i];
+        }
+        if (kept >= 1) {  // never decimate to empty
+            size_t dropped = total - kept;
+            vertices.resize(kept);
+            GS_LOGI("GsRenderer: decimation dropped %zu/%zu gaussians "
+                    "(keepFrac=%.3f, %zu kept)",
+                    dropped, total, (double)cullKeepFrac_, kept);
+        }
+    }
+
     numGaussians_ = (uint32_t)vertices.size();
     numPrefixSumIter_ = (uint32_t)std::ceil(std::log2((double)numGaussians_));
     if (numPrefixSumIter_ == 0) numPrefixSumIter_ = 1;

--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -1194,17 +1194,22 @@ void GsRenderer::renderEye(VkImage swapchainImage,
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipePreprocessSort_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
             layoutPreprocessSort_, 0, 1, &dsPreprocessSort_, 0, nullptr);
-        uint32_t vpTileX = (viewportWidth + 15) / 16;
+        // Tile-grid width for the sort-key linearization (tileIndex = i + j*tileX
+        // in preprocess_sort.comp). MUST use the scaled render dims rw/rh — the
+        // same grid render.comp derives from its width/height push constant — or
+        // fragments linearize into a grid render.comp doesn't read, collapsing
+        // the splat into the top tile rows.
+        uint32_t vpTileX = (rw + 15) / 16;
         {
             // 16-bit tile index bound (see preprocess_sort.comp) — one-time
             // warning only; init() already rejects oversized canvases.
             static bool warnedTileBound = false;
-            uint32_t vpTileY = (viewportHeight + 15) / 16;
+            uint32_t vpTileY = (rh + 15) / 16;
             if (!warnedTileBound && (uint64_t)vpTileX * vpTileY > 65536) {
                 fprintf(stderr,
-                        "GsRenderer: viewport %ux%u exceeds the 16-bit sort "
+                        "GsRenderer: render grid %ux%u exceeds the 16-bit sort "
                         "tile index (65536 tiles) — splats will missort\n",
-                        viewportWidth, viewportHeight);
+                        rw, rh);
                 warnedTileBound = true;
             }
         }

--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -1029,8 +1029,25 @@ void GsRenderer::renderEye(VkImage swapchainImage,
 {
     if (!hasScene()) return;
 
-    // Update uniform buffer with this eye's matrices
-    updateUniforms(viewMatrix, projMatrix, viewportWidth, viewportHeight,
+    // Render-scale: drive the entire compute pipeline (projection, tile grid,
+    // sort, per-pixel composite) at a reduced internal resolution rw x rh, then
+    // upscale-blit to the full viewport region below. The projection is fully
+    // self-consistent at rw/rh (focal length, pixel coords and gaussian pixel
+    // radii in preprocess.comp all derive from these dims), so a smaller rw/rh
+    // both lowers the per-pixel render cost and shrinks the tile grid, which
+    // drops the (gaussian,tile) instance count fed to sort/preSort. Floored to a
+    // multiple of the 16px tile so the grid stays whole. renderImage_ is full-
+    // viewport-sized, so the scaled region [0,0]-[rw,rh] always fits.
+    uint32_t rw = viewportWidth, rh = viewportHeight;
+    if (renderScale_ < 0.999f) {
+        uint32_t sw = (uint32_t)(viewportWidth  * renderScale_);
+        uint32_t sh = (uint32_t)(viewportHeight * renderScale_);
+        rw = (sw < 16u) ? 16u : (sw & ~15u);
+        rh = (sh < 16u) ? 16u : (sh & ~15u);
+    }
+
+    // Update uniform buffer with this eye's matrices (at the scaled dims)
+    updateUniforms(viewMatrix, projMatrix, rw, rh,
                    clipNearViewSpace, clipFarViewSpace, clipFadeFrac);
 
     uint32_t N = numGaussians_;
@@ -1335,13 +1352,13 @@ void GsRenderer::renderEye(VkImage swapchainImage,
         // so the compositor's sampler decodes sRGB→linear on read, and the
         // display surface re-encodes linear→sRGB on output (single gamma).
         // Manual linearToSrgb() would cause double encoding (washed out colors).
-        uint32_t renderPC[4] = {viewportWidth, viewportHeight, 0u,
+        uint32_t renderPC[4] = {rw, rh, 0u,
                                 transparentBg ? 1u : 0u};
         vkCmdPushConstants(cmd, layoutRender_, VK_SHADER_STAGE_COMPUTE_BIT,
                            0, sizeof(renderPC), renderPC);
 
-        uint32_t renderGroupsX = (viewportWidth + 15) / 16;
-        uint32_t renderGroupsY = (viewportHeight + 15) / 16;
+        uint32_t renderGroupsX = (rw + 15) / 16;
+        uint32_t renderGroupsY = (rh + 15) / 16;
         vkCmdDispatch(cmd, renderGroupsX, renderGroupsY, 1);
         if (tsOn) vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, tsPool_, 6);  // ts[6] render
 
@@ -1376,19 +1393,24 @@ void GsRenderer::renderEye(VkImage swapchainImage,
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &imb2);
 
-        // Blit viewport region (handles RGBA→BGRA format conversion)
+        // Blit the scaled render region (rw x rh) up to the full viewport
+        // region of the swapchain (handles RGBA→BGRA format conversion + the
+        // render-scale upscale). LINEAR so the upscale is smooth (NEAREST when
+        // 1:1 — identical result, marginally cheaper).
         VkImageBlit blitRegion = {};
         blitRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         blitRegion.srcOffsets[0] = {0, 0, 0};
-        blitRegion.srcOffsets[1] = {(int32_t)viewportWidth, (int32_t)viewportHeight, 1};
+        blitRegion.srcOffsets[1] = {(int32_t)rw, (int32_t)rh, 1};
         blitRegion.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         blitRegion.dstOffsets[0] = {(int32_t)viewportX, (int32_t)viewportY, 0};
         blitRegion.dstOffsets[1] = {(int32_t)(viewportX + viewportWidth),
                                     (int32_t)(viewportY + viewportHeight), 1};
+        VkFilter blitFilter = (rw == viewportWidth && rh == viewportHeight)
+                                  ? VK_FILTER_NEAREST : VK_FILTER_LINEAR;
         vkCmdBlitImage(cmd,
             renderImage_.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
             swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-            1, &blitRegion, VK_FILTER_NEAREST);
+            1, &blitRegion, blitFilter);
 
         // Barrier: swapchain image → COLOR_ATTACHMENT_OPTIMAL
         imb2.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -1433,10 +1455,11 @@ void GsRenderer::renderEye(VkImage swapchainImage,
                 };
                 // NOTE: preSort (ts[2]→ts[3]) spans the CMD1→CMD2 gap, so it
                 // includes the CPU totalSum readback; TOTAL likewise.
-                GS_LOGI("GS_TS eye(vpX=%u) inst=%u vp=%ux%u | "
+                GS_LOGI("GS_TS eye(vpX=%u) inst=%u vp=%ux%u render=%ux%u(scale=%.2f) | "
                         "preproc=%.2f prefix=%.2f preSort=%.2f radix=%.2f "
                         "tileBnd=%.2f render=%.2f blit=%.2f | TOTAL=%.2f ms",
                         viewportX, numInstances, viewportWidth, viewportHeight,
+                        rw, rh, renderScale_,
                         ms(0, 1), ms(1, 2), ms(2, 3), ms(3, 4),
                         ms(4, 5), ms(5, 6), ms(6, 7), ms(0, 7));
             }

--- a/3dgs_common/gs_renderer.h
+++ b/3dgs_common/gs_renderer.h
@@ -154,6 +154,25 @@ struct GsRenderer {
     void setRenderScale(float s) { renderScale_ = (s > 0.05f && s <= 1.0f) ? s : 1.0f; }
     float renderScale() const { return renderScale_; }
 
+    // Load-time opacity cull: drop gaussians whose (already sigmoid'd) opacity is
+    // below this before upload. Near-transparent splats still expand into
+    // (gaussian,tile) fragments that get sorted + composited every eye but
+    // contribute almost nothing — culling them cuts preprocess + sort + render
+    // together (the GPU-bound cost on mobile). 0 = off (keep all). Must be set
+    // BEFORE loadScene(). Typical 0.02–0.1.
+    void setCullMinOpacity(float a) { cullMinOpacity_ = (a >= 0.0f && a < 1.0f) ? a : 0.0f; }
+    float cullMinOpacity() const { return cullMinOpacity_; }
+
+    // Load-time decimation: keep ~this fraction of gaussians (hash-selected so
+    // it's uniform regardless of file ordering), dropping the rest before
+    // upload. Unlike the opacity cull this works on dense OPAQUE scenes (e.g.
+    // butterfly.spz, ~all splats >0.1 opacity) where opacity culling drops
+    // nothing — it cuts the gaussian count, hence the (gaussian,tile) fragment
+    // count, hence preprocess + sort + composite, ~linearly. Splats are soft so
+    // moderate decimation thins gracefully. 1.0 = off. Set BEFORE loadScene().
+    void setKeepFraction(float f) { cullKeepFrac_ = (f > 0.05f && f <= 1.0f) ? f : 1.0f; }
+    float keepFraction() const { return cullKeepFrac_; }
+
     // Clean up all resources.
     void cleanup();
 
@@ -170,7 +189,9 @@ private:
     uint32_t width_ = 0;
     uint32_t height_ = 0;
     uint32_t subgroupSize_ = 32;
-    float renderScale_ = 1.0f;   // see setRenderScale()
+    float renderScale_ = 1.0f;      // see setRenderScale()
+    float cullMinOpacity_ = 0.0f;   // see setCullMinOpacity()
+    float cullKeepFrac_ = 1.0f;     // see setKeepFraction()
 
     // ── GPU timestamp profiling ──────────────────────────────────────────
     // Per-stage VkQueryPool timestamps around each renderEye dispatch group

--- a/3dgs_common/gs_renderer.h
+++ b/3dgs_common/gs_renderer.h
@@ -145,6 +145,15 @@ struct GsRenderer {
                    float clipFarViewSpace = 0.0f,
                    float clipFadeFrac = 0.0f);
 
+    // Render-scale: run the entire compute pipeline (projection, tile grid,
+    // sort, per-pixel composite) at scale*viewport dims, then upscale-blit the
+    // result to the full viewport. Splats are soft so moderate downscale costs
+    // little visually, while it cuts the per-pixel render cost AND shrinks the
+    // tile grid → fewer (gaussian,tile) instances → less sort/preSort work.
+    // 1.0 = native (default, desktop). Clamped to (0.05, 1.0].
+    void setRenderScale(float s) { renderScale_ = (s > 0.05f && s <= 1.0f) ? s : 1.0f; }
+    float renderScale() const { return renderScale_; }
+
     // Clean up all resources.
     void cleanup();
 
@@ -161,6 +170,7 @@ private:
     uint32_t width_ = 0;
     uint32_t height_ = 0;
     uint32_t subgroupSize_ = 32;
+    float renderScale_ = 1.0f;   // see setRenderScale()
 
     // ── GPU timestamp profiling ──────────────────────────────────────────
     // Per-stage VkQueryPool timestamps around each renderEye dispatch group

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -714,6 +714,41 @@ gs_init()
 		}
 	}
 	g_gs.setRenderScale(gsScale);
+
+	// gauss is GPU-bound on the per-frame (gaussian,tile) fragment count (~1.4M
+	// for the butterfly). Two load-time culls cut it; both set before loadScene
+	// (load_butterfly runs after gs_init), both force-stop+relaunch to apply.
+	//
+	// (1) Opacity cull `debug.dxr.gs.minalpha` (0 = off): drops near-transparent
+	//     splats. Effective on scenes WITH faint splats; near-useless on dense
+	//     opaque scenes like butterfly.spz (all >0.1), so default off.
+	float gsMinAlpha = 0.0f;
+	{
+		char buf[PROP_VALUE_MAX] = {0};
+		if (__system_property_get("debug.dxr.gs.minalpha", buf) > 0) {
+			float v = (float)atof(buf);
+			if (v >= 0.0f && v < 1.0f)
+				gsMinAlpha = v;
+		}
+	}
+	g_gs.setCullMinOpacity(gsMinAlpha);
+
+	// (2) Decimation `debug.dxr.gs.keep` (1.0 = off): keep this fraction of
+	//     gaussians (hash-uniform). Cuts the fragment count ~linearly, so it
+	//     helps when the app's GPU compute is the bottleneck. On the nubia at
+	//     render-scale 0.6 it is NOT — the frame is runtime/DP-weave-bound
+	//     (~130ms floor), so dropping 60% of gaussians changed fps by <0.5.
+	//     Default OFF; available for heavier scenes / more GPU-bound devices.
+	float gsKeep = 1.0f;
+	{
+		char buf[PROP_VALUE_MAX] = {0};
+		if (__system_property_get("debug.dxr.gs.keep", buf) > 0) {
+			float v = (float)atof(buf);
+			if (v > 0.05f && v <= 1.0f)
+				gsKeep = v;
+		}
+	}
+	g_gs.setKeepFraction(gsKeep);
 	g_gs_ready = true;
 	LOGI("GsRenderer initialized (%ux%u/eye, render_scale=%.2f)",
 	     g_views[0].width, g_views[0].height, gsScale);
@@ -839,7 +874,7 @@ render_frame()
 	auto pf_now = []{ return std::chrono::steady_clock::now(); };
 	auto pf_ms = [](auto a, auto b){
 		return std::chrono::duration<double, std::milli>(b - a).count(); };
-	static double pf_wait = 0, pf_render = 0, pf_end = 0;
+	static double pf_wait = 0, pf_render = 0, pf_end = 0, pf_setup = 0;
 	auto pf_t0 = pf_now();
 
 	XrFrameWaitInfo wait_info = {};
@@ -919,6 +954,7 @@ render_frame()
 			// Splat model (recenter + spin) — same for both eyes.
 			const Mat4 splat_model = build_splat_model((float)g_frame_count * g_spin_speed);
 			auto pf_r0 = pf_now();
+			pf_setup = pf_ms(pf_t1, pf_r0);  // xrBeginFrame + xrLocateViews (IPC for view_rig)
 			for (uint32_t i = 0; i < kViewCount; ++i) {
 				XrSwapchainImageAcquireInfo acq = {};
 				acq.type = XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO;
@@ -1010,9 +1046,11 @@ render_frame()
 		auto now = std::chrono::steady_clock::now();
 		double ms = std::chrono::duration<double, std::milli>(now - last).count() / 120.0;
 		last = now;
-		LOGI("frame %llu  ~%.1f ms/frame (%.1f fps) | PHASE wait=%.1f render=%.1f end=%.1f ms",
+		LOGI("frame %llu  ~%.1f ms/frame (%.1f fps) | PHASE wait=%.1f setup=%.1f render=%.1f end=%.1f ms | "
+		     "predDisplayPeriod=%.1f ms",
 		     (unsigned long long)g_frame_count,
-		     ms, ms > 0.0 ? 1000.0 / ms : 0.0, pf_wait, pf_render, pf_end);
+		     ms, ms > 0.0 ? 1000.0 / ms : 0.0, pf_wait, pf_setup, pf_render, pf_end,
+		     (double)frame_state.predictedDisplayPeriod / 1.0e6);
 	}
 	return true;
 }

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -694,11 +694,29 @@ gs_init()
 		LOGE("GsRenderer::init failed");
 		return false;
 	}
-	// Full quality: all gaussians at full resolution. On the nubia the fps is
-	// capped by the runtime weave/present, not app compute — subsampling and
-	// render-scale experiments left fps unchanged on the android wip branch.
+	// Render-scale: at 1.0 the per-eye GPU compute (~67ms on the nubia: render
+	// ~32 + radix ~18 + preSort ~9) far exceeds the ~33ms DP-weave period, so
+	// gauss is compute-bound (~7fps), NOT weave-capped. Driving the compute
+	// pipeline at a reduced internal resolution lowers render + tile-grid /
+	// instance count (sort/preSort) together, recovering fps up to the weave
+	// ceiling. Tunable live for sweeps: `setprop debug.dxr.gs.scale 0.6`
+	// (force-stop + relaunch). Empty/0/1.0 = native full resolution.
+	// Default 0.6: on the nubia this ~3x's real fps (~2.5 -> ~7.5) vs native.
+	// Below ~0.6 fps plateaus (the per-eye synchronous double-submit + readback
+	// becomes the floor), so 0.6 is the quality/perf knee. Override for sweeps.
+	float gsScale = 0.6f;
+	{
+		char buf[PROP_VALUE_MAX] = {0};
+		if (__system_property_get("debug.dxr.gs.scale", buf) > 0) {
+			float v = (float)atof(buf);
+			if (v > 0.05f && v <= 1.0f)
+				gsScale = v;
+		}
+	}
+	g_gs.setRenderScale(gsScale);
 	g_gs_ready = true;
-	LOGI("GsRenderer initialized (%ux%u/eye)", g_views[0].width, g_views[0].height);
+	LOGI("GsRenderer initialized (%ux%u/eye, render_scale=%.2f)",
+	     g_views[0].width, g_views[0].height, gsScale);
 	return true;
 }
 

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -833,11 +833,22 @@ poll_xr_events()
 bool
 render_frame()
 {
+	// Frame-phase profiler: wall-clock wait / render(2 eyes) / endFrame to see
+	// whether the wall is app compute (renderEye) or runtime pacing+weave
+	// (xrWaitFrame / xrEndFrame). Logged every 120 frames next to the fps line.
+	auto pf_now = []{ return std::chrono::steady_clock::now(); };
+	auto pf_ms = [](auto a, auto b){
+		return std::chrono::duration<double, std::milli>(b - a).count(); };
+	static double pf_wait = 0, pf_render = 0, pf_end = 0;
+	auto pf_t0 = pf_now();
+
 	XrFrameWaitInfo wait_info = {};
 	wait_info.type = XR_TYPE_FRAME_WAIT_INFO;
 	XrFrameState frame_state = {};
 	frame_state.type = XR_TYPE_FRAME_STATE;
 	XrResult res = xrWaitFrame(g_session, &wait_info, &frame_state);
+	auto pf_t1 = pf_now();
+	pf_wait = pf_ms(pf_t0, pf_t1);
 	if (res != XR_SUCCESS) {
 		log_xr_result("xrWaitFrame", res);
 		return false;
@@ -907,6 +918,7 @@ render_frame()
 			}
 			// Splat model (recenter + spin) — same for both eyes.
 			const Mat4 splat_model = build_splat_model((float)g_frame_count * g_spin_speed);
+			auto pf_r0 = pf_now();
 			for (uint32_t i = 0; i < kViewCount; ++i) {
 				XrSwapchainImageAcquireInfo acq = {};
 				acq.type = XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO;
@@ -964,6 +976,7 @@ render_frame()
 				projection_views[i].subImage.imageArrayIndex = 0;
 			}
 			rendered = (res == XR_SUCCESS);
+			pf_render = pf_ms(pf_r0, pf_now());
 		} else {
 			log_xr_result("xrLocateViews", res);
 		}
@@ -983,7 +996,9 @@ render_frame()
 	end_info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
 	end_info.layerCount = rendered ? 1 : 0;
 	end_info.layers = rendered ? layers : nullptr;
+	auto pf_e0 = pf_now();
 	res = xrEndFrame(g_session, &end_info);
+	pf_end = pf_ms(pf_e0, pf_now());
 	if (res != XR_SUCCESS) {
 		log_xr_result("xrEndFrame", res);
 		return false;
@@ -995,8 +1010,9 @@ render_frame()
 		auto now = std::chrono::steady_clock::now();
 		double ms = std::chrono::duration<double, std::milli>(now - last).count() / 120.0;
 		last = now;
-		LOGI("frame %llu  ~%.1f ms/frame (%.1f fps)", (unsigned long long)g_frame_count,
-		     ms, ms > 0.0 ? 1000.0 / ms : 0.0);
+		LOGI("frame %llu  ~%.1f ms/frame (%.1f fps) | PHASE wait=%.1f render=%.1f end=%.1f ms",
+		     (unsigned long long)g_frame_count,
+		     ms, ms > 0.0 ? 1000.0 / ms : 0.0, pf_wait, pf_render, pf_end);
 	}
 	return true;
 }


### PR DESCRIPTION
## What
Adds a **render-scale** to `GsRenderer`: run the whole compute pipeline (projection, tile grid, sort, per-pixel composite) at `scale × viewport` dims, then upscale-blit (LINEAR) to the full viewport. Android defaults to **0.6**; desktop unchanged (`renderScale_` defaults to 1.0).

## Why
On-device GPU-timestamp profiling (nubia NP02J, OOP runtime) shows the Android gauss splat is **app-compute-bound**, not DP-weave-capped:

- Native 1920×1200/eye: **TOTAL ~72 ms/eye** (render ~33 + radix ~17 + preSort ~12 + preproc ~7), ~1.49M (gaussian,tile) instances → **~2.5 fps**.
- The DP weave period is only ~33 ms (the media player hits 32 fps through the same weave), so the wall is our per-eye compute.

The earlier "render-scale didn't help" note dated from the old 20 FPS null-compositor pacing cap (since fixed to the panel refresh), which masked any compute reduction.

`preprocess.comp` derives focal length, pixel coords, tile grid, and gaussian pixel-radii all from the `width`/`height` uniforms, so a smaller internal resolution is fully self-consistent — it lowers the per-pixel render cost **and** shrinks the tile grid → fewer instances → less sort/preSort. `renderImage_` is already full-viewport-sized so the scaled region fits; the existing final blit just gains an upscale.

## Measured (nubia, per-eye GPU / real fps)
| scale | GPU/eye | real fps |
|------:|--------:|---------:|
| 1.0   | 72 ms   | ~2.5     |
| 0.6   | 34 ms   | ~7.5     |
| 0.5   | 30 ms   | ~8.5     |

**~3× real fps.** fps plateaus ~8 below 0.6 — at that point the per-eye **synchronous double-submit + `numInstances` readback** (2 `vkQueueWaitIdle` + a CPU map per eye, 4 GPU stalls/frame) becomes the floor. So 0.6 is the quality/perf knee, and removing that synchronous floor (single submit + indirect dispatch from a GPU-side count) is the natural follow-up for going past ~8 fps.

## Tuning / notes
- Live-tunable: `adb shell setprop debug.dxr.gs.scale 0.5` then force-stop + relaunch. Empty/0/1.0 = native.
- The `GS_TS` profiler line now reports the active render dims + scale.
- Visual quality on the 3D display is best eyeballed live (splats are soft, so the upscale is cheap, but @dfattal please confirm the weave still reads correctly at 0.6).

@dfattal — fork PR, so CODEOWNERS doesn't auto-request you; flagging for review.