### PR TITLE
feat: smooth 2D<->3D mode-switch disparity ramp (win + macOS)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v0.4.1
+    GIT_TAG v1.1.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -54,6 +54,7 @@
 #include <sys/stat.h>
 
 #include "view_params.h"
+#include "mode_switch.h" // dxr::ModeSwitch — smooth 2D<->3D disparity ramp (inline on macOS)
 #include "display3d_view.h"
 #include "camera3d_view.h"
 #include "gs_renderer.h"
@@ -159,6 +160,12 @@ static volatile bool g_running = true;
 static NSWindow *g_window = nil;
 static NSView *g_metalView = nil;
 static InputState g_input;
+// Smooth 2D<->3D disparity ramp, driven inline (macOS app-owned mode model).
+// g_msLastMode tracks the runtime-confirmed mode (synced on fire + event) so the
+// sequencer knows the ramp direction.
+static dxr::ModeSwitch g_modeSwitch;
+static bool g_modeSwitchConfigured = false;
+static uint32_t g_msLastMode = 1; // matches g_input.currentRenderingMode default
 static const float CAMERA_HALF_TAN_VFOV = 0.32491969623f;
 
 typedef void (*PFN_sim_display_set_output_mode)(int mode);
@@ -641,15 +648,19 @@ static void OpenLoadDialog() {
             g_input.loadRequested = true;
             break;
         case '-': case '_': {
-            float v = g_input.viewParams.ipdFactor - 0.1f;
+            // Edit steadyIpdFactor (the ModeSwitch ramp target); seed ipdFactor
+            // in lockstep for the idle/non-ramp render path.
+            float v = g_input.viewParams.steadyIpdFactor - 0.1f;
             if (v < 0.1f) v = 0.1f;
+            g_input.viewParams.steadyIpdFactor = v;
             g_input.viewParams.ipdFactor = v;
             g_input.viewParams.parallaxFactor = v;
             break;
         }
         case '=': case '+': {
-            float v = g_input.viewParams.ipdFactor + 0.1f;
+            float v = g_input.viewParams.steadyIpdFactor + 0.1f;
             if (v > 1.0f) v = 1.0f;
+            g_input.viewParams.steadyIpdFactor = v;
             g_input.viewParams.ipdFactor = v;
             g_input.viewParams.parallaxFactor = v;
             break;
@@ -1745,6 +1756,7 @@ static void PollEvents(AppXrSession& xr) {
             auto* rmc = (XrEventDataRenderingModeChangedEXT*)&event;
             if (rmc->currentModeIndex < xr.renderingModeCount) {
                 g_input.currentRenderingMode = rmc->currentModeIndex;
+                g_msLastMode = rmc->currentModeIndex; // keep the ramp's from-mode in sync
                 UpdateTopBarButtonTitles(xr);
                 LOG_INFO("Rendering mode changed: %u -> %u (%s)",
                     rmc->previousModeIndex, rmc->currentModeIndex,
@@ -2136,15 +2148,47 @@ int main(int argc, char** argv) {
         UpdateCameraMovement(g_input, deltaTime, xr.displayHeightM);
 
         // Handle rendering mode change (V=cycle, 0-3=direct, Mode button, or the
-        // startup default-mode request). Held until the session is running so the
-        // request reaches a begun session rather than being dropped (this handler
-        // runs before PollEvents, which is what begins the session).
-        if (g_input.renderingModeChangeRequested && xr.sessionRunning) {
-            g_input.renderingModeChangeRequested = false;
-            if (xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
-                xr.pfnRequestDisplayRenderingModeEXT(xr.session, g_input.currentRenderingMode);
+        // startup default-mode request) through the dxr::ModeSwitch sequencer:
+        // it eases g_input.viewParams.ipdFactor around the switch and fires the
+        // request on the right frame. Held until the session is running so the
+        // request reaches a begun session (this handler runs before PollEvents).
+        if (!g_modeSwitchConfigured) {
+            g_modeSwitch.configure(0.18f, dxr::ModeSwitchEasing::SmoothStep);
+            g_modeSwitchConfigured = true;
+        }
+        {
+            const float steady = g_input.viewParams.steadyIpdFactor;
+            auto vcOf = [&](uint32_t m) -> uint32_t {
+                return (m < xr.renderingModeCount && xr.renderingModeViewCounts[m] > 0)
+                           ? xr.renderingModeViewCounts[m] : 1;
+            };
+            if (g_input.renderingModeChangeRequested && xr.sessionRunning &&
+                xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
+                g_input.renderingModeChangeRequested = false;
+                const uint32_t target = g_input.currentRenderingMode;
+                if (target == g_msLastMode) {
+                    // Startup / re-assert / same mode: fire directly, no ramp.
+                    xr.pfnRequestDisplayRenderingModeEXT(xr.session, target);
+                    g_msLastMode = target;
+                    UpdateTopBarButtonTitles(xr);
+                } else {
+                    const float curIpd = g_modeSwitch.active() ? g_modeSwitch.ipd() : steady;
+                    g_modeSwitch.request(target, vcOf(target), g_msLastMode, vcOf(g_msLastMode),
+                                         curIpd, steady);
+                }
             }
-            UpdateTopBarButtonTitles(xr);
+            if (g_modeSwitch.active()) {
+                float ipd = steady; bool fire = false; uint32_t mode = g_msLastMode;
+                g_modeSwitch.update(deltaTime, &ipd, &fire, &mode);
+                g_input.viewParams.ipdFactor = ipd;
+                if (fire && xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE) {
+                    xr.pfnRequestDisplayRenderingModeEXT(xr.session, mode);
+                    g_msLastMode = mode;
+                    UpdateTopBarButtonTitles(xr);
+                }
+            } else {
+                g_input.viewParams.ipdFactor = steady;
+            }
         }
 
         // Handle eye tracking mode toggle

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -628,8 +628,6 @@ static void RenderThreadFunc(
         bool resetRequested = false;
         bool animateToggle = false;
         bool loadReq = false;
-        bool cycleModeRequested = false;
-        int32_t absoluteModeRequest = -1;
         uint32_t windowW, windowH;
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
@@ -648,9 +646,9 @@ static void RenderThreadFunc(
             g_inputState.resetViewRequested = false;
             g_inputState.teleportRequested = false;
             g_inputState.fullscreenToggleRequested = false;
-            cycleModeRequested = g_inputState.cycleRenderingModeRequested;
+            // ModeSwitch consumes the V/0-8 flags off inputSnapshot (captured
+            // above); clear them on the shared state so they fire exactly once.
             g_inputState.cycleRenderingModeRequested = false;
-            absoluteModeRequest = g_inputState.absoluteRenderingModeRequested;
             g_inputState.absoluteRenderingModeRequested = -1;
             g_inputState.eyeTrackingModeToggleRequested = false;
             if (g_inputState.transparentBgToggleRequested) {
@@ -701,18 +699,12 @@ static void RenderThreadFunc(
             }
         }
 
-        // Rendering mode requests (V/mode-button=cycle, 0-8=absolute). Single
-        // source of truth: runtime owns current mode via xr->currentModeIndex.
-        if (cycleModeRequested && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE && xr->renderingModeCount > 0) {
-            uint32_t next = (xr->currentModeIndex + 1) % xr->renderingModeCount;
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, next);
-        }
-        if (absoluteModeRequest >= 0 && xr->pfnRequestDisplayRenderingModeEXT &&
-            xr->session != XR_NULL_HANDLE &&
-            (uint32_t)absoluteModeRequest < xr->renderingModeCount) {
-            xr->pfnRequestDisplayRenderingModeEXT(xr->session, (uint32_t)absoluteModeRequest);
-        }
+        // Rendering mode requests (V/mode-button=cycle, 0-8=absolute) through the
+        // shared ModeSwitch sequencer: eases viewParams.ipdFactor around the switch
+        // and fires xrRequestDisplayRenderingModeEXT on the right frame. Ramped ipd
+        // lands on inputSnapshot.viewParams.ipdFactor (what the render path reads).
+        // Runtime owns current mode via xr->currentModeIndex.
+        XrSessionUpdateModeSwitch(*xr, inputSnapshot, perfStats.deltaTime);
 
         // Handle eye tracking mode toggle (T key)
         if (inputSnapshot.eyeTrackingModeToggleRequested) {


### PR DESCRIPTION
## What

Wires the merged `dxr::ModeSwitch` sequencer (displayxr-common **v1.1.1**) into both platforms so V/0-8 rendering-mode switches **ease** the stereo disparity over ~0.18 s instead of snapping.

- **Windows** (`windows/main.cpp`): bump common pin → v1.1.1; replace the mode-request consume block with one `XrSessionUpdateModeSwitch(*xr, inputSnapshot, perfStats.deltaTime)` call. Ramped ipd lands on `inputSnapshot.viewParams.ipdFactor` (what the render path reads).
- **macOS** (`macos/main.mm`): inline `dxr::ModeSwitch` (macOS uses the app-owned mode model). `g_msLastMode` tracks the runtime-confirmed mode for ramp direction (synced on fire + the RenderingModeChanged event); a `target==current` request (startup/re-assert) fires directly, real toggles ramp. shift `+/-` now edit `steadyIpdFactor` (seeding `ipdFactor` in lockstep).

## Test

- **Windows**: builds clean (Ninja/Release); logic matches the Leia-validated runtime cube apps (incl. the first-press fix in v1.1.1).
- **macOS**: compiled in this PR’s `Build macOS` CI; needs a Mac eyeball of the ramp feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)