### PR TITLE
build: auto-provision OpenXR on fresh clone + pin 1.1.51

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -107,7 +107,9 @@ jobs:
         run: |
           # The demo links the OpenXR loader. Mirror the runtime repo: grab the
           # prebuilt Khronos loader and point CMake at it via OpenXR_ROOT.
-          $openxrVersion = "1.1.43"
+          # Pinned to the same spec rev as the vendored openxr_includes/ headers
+          # (XR_CURRENT_API_VERSION = 1.1.51) and scripts/build-with-deps.bat.
+          $openxrVersion = "1.1.51"
           $openxrUrl = "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-$openxrVersion/openxr_loader_windows-$openxrVersion.zip"
           Invoke-WebRequest -Uri $openxrUrl -OutFile openxr_loader.zip
           Expand-Archive -Path openxr_loader.zip -DestinationPath openxr_sdk -Force

--- a/scripts/build-with-deps.bat
+++ b/scripts/build-with-deps.bat
@@ -7,8 +7,37 @@ if %ERRORLEVEL% NEQ 0 (
 )
 set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Packages\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe;%PATH%"
 cd /d "%~dp0\.."
+
+REM --- Vulkan SDK ----------------------------------------------------------------
+REM Use the VULKAN_SDK env var the LunarG installer sets (any version), instead of
+REM a hardcoded C:/VulkanSDK/<ver> path. find_package(Vulkan) picks it up via the
+REM VULKAN_SDK environment, so no -DCMAKE_PREFIX_PATH is needed.
+if "%VULKAN_SDK%"=="" (
+    echo ERROR: VULKAN_SDK is not set. Install the Vulkan SDK from https://vulkan.lunarg.com
+    echo        and open a fresh terminal so VULKAN_SDK is exported, then re-run.
+    exit /b 1
+)
+
+REM --- OpenXR loader -------------------------------------------------------------
+REM Auto-provision the prebuilt Khronos loader, pinned to the same spec revision as
+REM the vendored openxr_includes/ headers (XR_CURRENT_API_VERSION = 1.1.51). Cached
+REM under build\openxr_sdk so a fresh clone builds with no manually-staged SDK.
+REM (Mirrors what .github/workflows/build-windows.yml does in CI.)
+set "OPENXR_VER=1.1.51"
+set "OPENXR_DIR=%CD%\build\openxr_sdk"
+if not exist "%OPENXR_DIR%\x64\lib\openxr_loader.lib" (
+    echo === Provisioning OpenXR loader %OPENXR_VER% ===
+    if not exist build mkdir build
+    powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+      "$ErrorActionPreference='Stop';" ^
+      "$u='https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-%OPENXR_VER%/openxr_loader_windows-%OPENXR_VER%.zip';" ^
+      "Invoke-WebRequest -Uri $u -OutFile 'build\openxr_loader.zip';" ^
+      "Expand-Archive -Path 'build\openxr_loader.zip' -DestinationPath 'build\openxr_sdk' -Force;" ^
+      "Remove-Item 'build\openxr_loader.zip' -Force" || exit /b 1
+)
+
 echo === Configuring ===
-cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOpenXR_ROOT=C:/dev/openxr_sdk -DCMAKE_PREFIX_PATH=C:/VulkanSDK/1.4.341.1 || exit /b 1
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOpenXR_ROOT="%CD:\=/%/build/openxr_sdk" || exit /b 1
 echo === Building ===
 cmake --build build || exit /b 1
 echo === DONE ===

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -42,7 +42,7 @@ done
 # BUILD_WITH_SYSTEM_JSONCPP=OFF + jsoncpp include-order patch are required
 # to avoid baking a Homebrew jsoncpp path into the redistributable dylib
 # (runtime repo issue #205).
-OPENXR_VERSION="${OPENXR_VERSION:-1.1.43}"
+OPENXR_VERSION="${OPENXR_VERSION:-1.1.51}"
 OPENXR_DIR="/tmp/openxr-install"
 if [ ! -f "$OPENXR_DIR/lib/libopenxr_loader.dylib" ]; then
     echo "==> Building OpenXR loader $OPENXR_VERSION → $OPENXR_DIR"


### PR DESCRIPTION
Ports the displayxr-demo-avatar #12 dev-setup fix to this repo, which inherited the same broken `build-with-deps.bat` from the modelviewer bootstrap.

**The bug (dev clone-and-build only — released installer unaffected):** `scripts/build-with-deps.bat` hardcoded `-DOpenXR_ROOT=C:/dev/openxr_sdk` and `-DCMAKE_PREFIX_PATH=C:/VulkanSDK/1.4.341.1` and, despite its name, never provisioned OpenXR. A fresh clone died at configure with `OpenXR not found` unless you hand-staged those exact paths.

**Fix:**
- OpenXR (Windows dev): auto-download the prebuilt Khronos loader pinned to `release-1.1.51` into `build\openxr_sdk`, point `OpenXR_ROOT` there (mirrors CI).
- Vulkan (Windows dev): use the `VULKAN_SDK` env var (any version) instead of a hardcoded SDK path.
- CI + `build_macos.sh`: bump OpenXR pin `1.1.43` → `1.1.51` to match the vendored `openxr_includes/` headers (`XR_CURRENT_API_VERSION = 1.1.51`).

Fresh clone now builds with only VS 2022 + Ninja + the Vulkan SDK installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)