### PR TITLE
feat(signing): SIGN_CMD-gated installer + two-pass signed uninstaller (#666)

### DIFF
--- a/installer/DisplayXRGaussianSplatInstaller.nsi
+++ b/installer/DisplayXRGaussianSplatInstaller.nsi
@@ -34,13 +34,45 @@
 !endif
 
 ;--------------------------------
+; Code signing (SIGN_CMD passed from build-installer.bat; empty/absent =
+; unsigned build). SIGN_CMD carries no secret — on a signing-capable build
+; machine it points at the configured signer; elsewhere it is absent and the
+; build is unsigned.
+;
+; The installer .exe is signed via !finalize. The UNINSTALLER is signed via a
+; two-pass build instead of !uninstfinalize (which is unreliable — the
+; uninstaller NSIS writes at install time inherits the signed installer's
+; cert-table pointer, which can dangle past the smaller uninstaller file =>
+; effectively unsigned): compile an INNER installer whose only job is to
+; WriteUninstaller to %TEMP% and Quit; run it; sign that %TEMP%\Uninstall.exe;
+; then File-include the pre-signed uninstaller in the real pass. INNER is
+; RequestExecutionLevel user so it never triggers UAC from makensis.
+!ifndef INNER
+    !ifdef SIGN_CMD
+        !if "${SIGN_CMD}" != ""
+            !finalize '${SIGN_CMD} "%1"'
+            !makensis '-DINNER "-DVERSION=${VERSION}" "-DVERSION_MAJOR=${VERSION_MAJOR}" "-DVERSION_MINOR=${VERSION_MINOR}" "-DVERSION_PATCH=${VERSION_PATCH}" "-DSOURCE_DIR=${SOURCE_DIR}" "-DBIN_DIR=${BIN_DIR}" "-DOUTPUT_DIR=${OUTPUT_DIR}" "${__FILE__}"' = 0
+            !system '"$%TEMP%\DisplayXRGaussianSplatSetup_inner.exe"' = 2
+            !system '${SIGN_CMD} "$%TEMP%\Uninstall.exe"' = 0
+            !define USE_PRESIGNED_UNINST
+        !endif
+    !endif
+!endif
+
+;--------------------------------
 ; General
 
 Name "DisplayXR Gaussian Splat Demo ${VERSION}"
-OutFile "${OUTPUT_DIR}\DisplayXRGaussianSplatSetup-${VERSION}.exe"
+!ifdef INNER
+    ; Throwaway inner installer: only emits the uninstaller to %TEMP%.
+    OutFile "$%TEMP%\DisplayXRGaussianSplatSetup_inner.exe"
+    RequestExecutionLevel user
+!else
+    OutFile "${OUTPUT_DIR}\DisplayXRGaussianSplatSetup-${VERSION}.exe"
+    RequestExecutionLevel admin
+!endif
 InstallDir "$PROGRAMFILES64\DisplayXR\Demos\GaussianSplat"
 InstallDirRegKey HKLM "Software\DisplayXR\Demos\GaussianSplat" "InstallPath"
-RequestExecutionLevel admin
 ShowInstDetails show
 ShowUninstDetails show
 
@@ -79,6 +111,14 @@ ShowUninstDetails show
 ; Pre-flight: hard-prereq the runtime
 
 Function .onInit
+!ifdef INNER
+    ; Inner pass only: emit the uninstaller to %TEMP% (the binary that gets
+    ; signed and File-included by the real pass) then bail — no UI, no install.
+    ; This whole path is absent from the real installer.
+    SetSilent silent
+    WriteUninstaller "$%TEMP%\Uninstall.exe"
+    Quit
+!endif
     ${IfNot} ${RunningX64}
         MessageBox MB_ICONSTOP "DisplayXR requires 64-bit Windows."
         Abort
@@ -179,7 +219,17 @@ Section "Gaussian Splat Demo" SecDemo
     WriteRegStr HKLM "Software\DisplayXR\Demos\GaussianSplat" "Version" "${VERSION}"
 
     ; Add/Remove Programs entry.
+    ; In a signed build, install the pre-signed uninstaller produced by the
+    ; inner pass (two-pass signing — see the code-signing block in the header);
+    ; otherwise (unsigned build / CI) write it normally. File /oname respects
+    ; the current $OUTDIR (set to $APPDATA\DisplayXR\apps above), so point it
+    ; back at $INSTDIR where the UninstallString entries below expect it.
+!ifdef USE_PRESIGNED_UNINST
+    SetOutPath "$INSTDIR"
+    File "/oname=Uninstall.exe" "$%TEMP%\Uninstall.exe"
+!else
     WriteUninstaller "$INSTDIR\Uninstall.exe"
+!endif
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXRGaussianSplat" \
         "DisplayName" "DisplayXR Gaussian Splat Demo"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXRGaussianSplat" \

--- a/installer/build-installer.bat
+++ b/installer/build-installer.bat
@@ -22,7 +22,30 @@ if not exist "%BIN_DIR%\gaussian_splatting_handle_vk_win.exe" (
     exit /b 1
 )
 
-"C:\Program Files (x86)\NSIS\makensis.exe" /DVERSION=%VERSION% /DVERSION_MAJOR=%VERSION_MAJOR% /DVERSION_MINOR=%VERSION_MINOR% /DVERSION_PATCH=%VERSION_PATCH% "/DBIN_DIR=%BIN_DIR%" "/DSOURCE_DIR=%REPO%" "/DOUTPUT_DIR=%OUT_DIR%" "%~dp0DisplayXRGaussianSplatInstaller.nsi" || exit /b 1
+REM ── Code signing (gated on %SIGN_CMD%) ──────────────────────────────
+REM Signing is OFF unless SIGN_CMD is set in the environment (a signing-
+REM capable build/release machine points it at the configured signer).
+REM This repo carries NO cert and NO secret. A clone without SIGN_CMD
+REM builds unsigned, exactly as before.
+REM
+REM The shipped binaries (demo exe + bundled openxr_loader.dll) MUST be
+REM signed BEFORE makensis packs them — Smart App Control checks the
+REM binaries extracted at install/load time, so signing the finished
+REM installer alone is not enough. The installer .exe and the uninstaller
+REM are signed at makensis time by the .nsi (!finalize + the two-pass
+REM uninstaller block), driven by the /DSIGN_CMD passed below.
+REM SIGN_ARG carries its own quotes so the empty (unsigned) case expands to
+REM nothing rather than an empty quoted "" arg that makensis would choke on.
+set "SIGN_ARG="
+if defined SIGN_CMD (
+    echo === Signing demo binaries [SIGN_CMD set] ===
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\sign-release.ps1" -Path "%BIN_DIR%" -SignCmd "%SIGN_CMD%" || exit /b 1
+    set SIGN_ARG="/DSIGN_CMD=%SIGN_CMD%"
+) else (
+    echo === Signing skipped [SIGN_CMD not set] - installer will be UNSIGNED ===
+)
+
+"C:\Program Files (x86)\NSIS\makensis.exe" /DVERSION=%VERSION% /DVERSION_MAJOR=%VERSION_MAJOR% /DVERSION_MINOR=%VERSION_MINOR% /DVERSION_PATCH=%VERSION_PATCH% "/DBIN_DIR=%BIN_DIR%" "/DSOURCE_DIR=%REPO%" "/DOUTPUT_DIR=%OUT_DIR%" %SIGN_ARG% "%~dp0DisplayXRGaussianSplatInstaller.nsi" || exit /b 1
 
 echo === DONE ===
 echo Installer: %OUT_DIR%DisplayXRGaussianSplatSetup-%VERSION%.exe

--- a/scripts/sign-release.ps1
+++ b/scripts/sign-release.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Sign all DisplayXR-produced binaries in a release folder, then verify the
+  whole tree is signed.
+
+.DESCRIPTION
+  Signing is driven entirely by the command passed in -SignCmd (sourced from
+  the SIGN_CMD environment variable by the build scripts). This script holds
+  NO certificate and NO secret. On machines without signing capability,
+  SIGN_CMD is unset and the build scripts skip signing — the build is
+  unsigned, with no behavior change.
+
+    1. Walk the folder for *.dll / *.exe.
+    2. Any binary WITHOUT a Valid Authenticode signature -> sign it via the
+       configured signer. Binaries that already carry a valid signature
+       (e.g. bundled third-party DLLs) are left untouched.
+    3. Re-verify the ENTIRE tree. If anything is still unsigned, FAIL (exit 1).
+
+  -SignCmd receives the file path as a trailing argument. Callers pass a full
+  signing command (including their own timestamp authority) via SIGN_CMD; the
+  default below is a minimal fallback for ad-hoc use.
+
+.EXAMPLE
+  # sign a staged binary tree before packaging
+  .\sign-release.ps1 -Path .\_package\bin -SignCmd "$env:SIGN_CMD"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    # Signing command; receives the file path as a trailing argument.
+    # Production callers pass a full command (with a timestamp authority)
+    # via the SIGN_CMD environment variable. This default is a bare fallback.
+    [string]$SignCmd = 'signtool sign /fd sha256 /a',
+
+    # Skip signing files already validly signed by anyone (default). Use
+    # -Force to re-sign every binary regardless (overwrites existing sigs).
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-Signed($file) {
+    (Get-AuthenticodeSignature $file).Status -eq 'Valid'
+}
+
+function Invoke-Sign($file) {
+    $parts = $SignCmd -split '\s+'
+    $exe   = $parts[0]
+    $args  = @($parts[1..($parts.Length - 1)]) + $file
+    & $exe @args
+    if ($LASTEXITCODE -ne 0) { throw "Signing failed for $file (exit $LASTEXITCODE)" }
+}
+
+if (-not (Test-Path $Path)) { throw "Path not found: $Path" }
+
+$binaries = Get-ChildItem -Path $Path -Recurse -Include *.dll, *.exe -File
+Write-Host "Found $($binaries.Count) binaries under $Path"
+
+$signed = 0; $skipped = 0
+foreach ($b in $binaries) {
+    if (-not $Force -and (Test-Signed $b.FullName)) {
+        $who = (Get-AuthenticodeSignature $b.FullName).SignerCertificate.Subject
+        Write-Host "  skip (already signed) : $($b.Name)  <$who>"
+        $skipped++
+        continue
+    }
+    Write-Host "  signing               : $($b.Name)"
+    Invoke-Sign $b.FullName
+    $signed++
+}
+
+Write-Host "Signed $signed, skipped $skipped already-signed."
+
+# ---- Verification gate ----
+$unsigned = $binaries | Where-Object { -not (Test-Signed $_.FullName) }
+if ($unsigned) {
+    Write-Host "`nFAIL: the following binaries are still unsigned:" -ForegroundColor Red
+    $unsigned | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host "`nOK: all $($binaries.Count) binaries under $Path are signed." -ForegroundColor Green


### PR DESCRIPTION
Ports the runtime's release-signing pattern (DisplayXR/displayxr-runtime#669) so the demo's shipped binaries, installer, and uninstaller are all code-signed end-to-end and won't trip Smart App Control in a full signed bundle.

Part of the bundle-wide signing rollout tracked in #666.

## What changed
- **`scripts/sign-release.ps1`** — walks a folder, signs any `*.dll`/`*.exe` lacking a Valid Authenticode signature using the command in `SIGN_CMD`, then fails the build if anything is left unsigned. Carries no certificate and no secret.
- **`installer/build-installer.bat`** — when `SIGN_CMD` is set, signs the shipped binaries (demo exe + bundled `openxr_loader.dll`) *before* `makensis` packs them and passes `/DSIGN_CMD` through to the `.nsi`. Unset ⇒ unsigned, exactly as before. The `SIGN_ARG` carries its own quotes so the empty/unsigned case expands to nothing rather than an empty `""` arg.
- **`installer/DisplayXRGaussianSplatInstaller.nsi`** — `!finalize` signs the installer `.exe`; a two-pass signed uninstaller (inner pass writes the uninstaller to `%TEMP%` and quits, it gets signed, the real pass `File`-includes the pre-signed binary) replaces the unreliable `!uninstfinalize` path. Gated behind `INNER` + a non-empty `SIGN_CMD`, so the unsigned/CI path is byte-for-byte unchanged (normal `WriteUninstaller`, no signing). The `File` include resets `$OUTDIR` to `$INSTDIR` first so the uninstaller lands where the registry `UninstallString` points.

## Why no secret lives here
Signing is driven entirely by the `SIGN_CMD` env var, set only on a signing-capable build/release machine. Clones and GitHub-hosted CI leave it unset and build unsigned with no behavior change.

## Validation
Built with a throwaway self-signed cert against the existing demo build:
- shipped demo exe + `openxr_loader.dll`, the installer `.exe`, and the embedded uninstaller are all Authenticode-**Valid** and pass `signtool verify /pa`;
- an unsigned build still produces a **NotSigned** installer with a normal `WriteUninstaller` uninstaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)