### PR TITLE
Vendor-neutral NOTICE; keep vendored OpenXR headers BSL-1.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,10 +1,12 @@
 DisplayXR Gaussian Splat Demo
-Copyright (c) 2024-2026 Leia, Inc. and the DisplayXR project contributors
+Copyright (c) 2024-2026 The DisplayXR Project and its contributors
 
-This product includes software developed by Leia, Inc. and the DisplayXR
-project contributors. It is licensed under the Apache License, Version 2.0;
-see the LICENSE file for the full text.
+This product includes software developed by the DisplayXR project contributors.
+It is licensed under the Apache License, Version 2.0; see the LICENSE file for
+the full text.
 
-This repository also vendors OpenXR extension headers under openxr_includes/
-that are Copyright Collabora, Ltd. and contributors and remain licensed under
-the Boost Software License 1.0 (BSL-1.0); see each file's SPDX-License-Identifier.
+This repository also vendors OpenXR extension headers under an openxr/ directory
+that are copied verbatim from DisplayXR/displayxr-runtime and remain licensed
+under the Boost Software License 1.0 (BSL-1.0); see each file's
+SPDX-License-Identifier. Some carry Copyright Collabora, Ltd. (the XR_MNDX_*
+headers).

--- a/openxr_includes/openxr/XR_EXT_app_launcher.h
+++ b/openxr_includes/openxr/XR_EXT_app_launcher.h
@@ -1,5 +1,5 @@
 // Copyright 2026, DisplayXR
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_app_launcher extension (Phase 2.B).

--- a/openxr_includes/openxr/XR_EXT_atlas_capture.h
+++ b/openxr_includes/openxr/XR_EXT_atlas_capture.h
@@ -1,5 +1,5 @@
 // Copyright 2026, DisplayXR
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_atlas_capture extension

--- a/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
+++ b/openxr_includes/openxr/XR_EXT_cocoa_window_binding.h
@@ -1,5 +1,5 @@
 // Copyright 2025, Leia Inc.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_cocoa_window_binding extension

--- a/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/openxr_includes/openxr/XR_EXT_display_info.h
@@ -1,5 +1,5 @@
 // Copyright 2025-2026, Leia Inc.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_display_info extension

--- a/openxr_includes/openxr/XR_EXT_macos_gl_binding.h
+++ b/openxr_includes/openxr/XR_EXT_macos_gl_binding.h
@@ -1,5 +1,5 @@
 // Copyright 2025, Leia Inc.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_macos_gl_binding extension

--- a/openxr_includes/openxr/XR_EXT_mcp_tools.h
+++ b/openxr_includes/openxr/XR_EXT_mcp_tools.h
@@ -1,5 +1,5 @@
 // Copyright 2026, DisplayXR
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_mcp_tools extension (app-defined agent tools).

--- a/openxr_includes/openxr/XR_EXT_spatial_workspace.h
+++ b/openxr_includes/openxr/XR_EXT_spatial_workspace.h
@@ -1,5 +1,5 @@
 // Copyright 2026, DisplayXR
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_spatial_workspace extension (Phase 2.A subset)

--- a/openxr_includes/openxr/XR_EXT_view_rig.h
+++ b/openxr_includes/openxr/XR_EXT_view_rig.h
@@ -1,5 +1,5 @@
 // Copyright 2026, DisplayXR
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_view_rig extension

--- a/openxr_includes/openxr/XR_EXT_win32_window_binding.h
+++ b/openxr_includes/openxr/XR_EXT_win32_window_binding.h
@@ -1,5 +1,5 @@
 // Copyright 2025, Leia Inc.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_win32_window_binding extension

--- a/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
+++ b/openxr_includes/openxr/XR_EXT_workspace_file_dialog.h
@@ -1,5 +1,5 @@
 // Copyright 2026, DisplayXR
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSL-1.0
 /*!
  * @file
  * @brief  Header for XR_EXT_workspace_file_dialog extension (Tier 1 spatial file picker).


### PR DESCRIPTION
Follow-up to the Apache-2.0 relicense.

- **NOTICE** no longer names the vendor — **vendor-neutrality contract** (only the Leia plug-in repo may name the vendor). Copyright holder is now "The DisplayXR Project and its contributors".
- Vendored **OpenXR extension headers** under `*/openxr/` are copied verbatim from the **BSL-1.0 runtime**, so they are reverted to **BSL-1.0** (copied-runtime code, per the relicense guardrail). Authored code stays Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)