### PR TITLE
Vendor-neutral cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Vendor-name guard
+        run: |
+          # Enforces the DisplayXR vendor-neutrality contract: authored files must
+          # not self-brand with the display vendor's company name. The literal is
+          # constructed at runtime so this workflow does not itself contain it.
+          #
+          # Excluded paths:
+          #   .git, .claude       - not authored product content
+          #   openxr/             - OpenXR extension headers vendored VERBATIM from
+          #                         displayxr-runtime; they carry upstream's copyright
+          #                         line and must match byte-for-byte.
+          #   displayxr-common    - policed in its own repo (submodule / FetchContent).
+          #   CHANGELOG.md        - historical record; may name the original vendor SDK.
+          #   CLAUDE.md           - documents the DisplayXR org, which legitimately
+          #                         names the vendor plug-in repo by its published name.
+          #
+          # Tier-A allowlist (ALLOW): legitimate names of the vendor hardware /
+          # plug-in / SDK / OEM the ecosystem integrates with - like naming NVIDIA in
+          # CUDA code. A line containing any of these tokens is permitted.
+          FORBIDDEN="le""ia"
+          ALLOW='cnsdk|leia_cnsdk|libdxrp050_leia_cnsdk|leiasdk|leiasr|displayxr-leia|leia-plugin|leiaplugin|leia_plugin|leia_tag|leia-sr|leia sr|leia hardware|leia display|leia dp|leia android dp|leia sdk|leia plug|leia panel|leia weave|leia face|leia viewer|leia-viewer|leia convention|leia lif|leia heif|leia image format|leiaschema|classic leia|leialoft|leiainc/|LEIA_EXE|LEIA_VER|LEIA_TAG|SecLeia|G_Leia|LeiaUnrealSDK|LeiaPlayerWin'
+          hits=$(grep -rniI \
+                   --exclude-dir=.git --exclude-dir=.claude \
+                   --exclude-dir=openxr --exclude-dir=displayxr-common \
+                   --exclude=CHANGELOG.md --exclude=CLAUDE.md \
+                   "$FORBIDDEN" . | grep -viE "$ALLOW" || true)
+          if [ -n "$hits" ]; then
+            echo "$hits"
+            echo "::error::Vendor company name found in authored files (not covered by the Tier-A allowlist). Neutralize it, or add a legitimate hardware/plug-in token to ALLOW."
+            exit 1
+          fi
+          echo "OK: no non-allowlisted vendor-name references in authored files."
+
+      - name: Workflow YAML is valid
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"

--- a/.github/workflows/no-vendored-math.yml
+++ b/.github/workflows/no-vendored-math.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: |
           # W4 (#396): the C++ scaffolding lives in displayxr::common.
-          # leia_math.h is intentionally absent (app-local reference).
+          # dxr_math.h is intentionally absent (app-local reference).
           hits=$(git ls-files | grep -E '(^|/)(logging|input_handler|window_manager|xr_session_common|xr_window_space_hud|atlas_capture|atlas_capture_macos|hud_renderer|hud_renderer_macos|text_overlay|d3d11_renderer|mip_chain|optimus_dgpu_hint|view_params|stb_image|stb_image_write|stb_image_impl_macos)\.(c|cpp|h|mm)$|(^|/)displayxr_manifest\.cmake$' || true)
           if [ -n "$hits" ]; then
             echo "::error::Re-vendored displayxr::common scaffolding found. The shared C++"

--- a/3dgs_common/CMakeLists.txt
+++ b/3dgs_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025, Leia Inc.
+# Copyright 2025, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Standalone build (displayxr-demo-gaussiansplat repo). Identical to the

--- a/3dgs_common/gs_adreno_renderer.cpp
+++ b/3dgs_common/gs_adreno_renderer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_adreno_renderer.h
+++ b/3dgs_common/gs_adreno_renderer.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_renderer.h
+++ b/3dgs_common/gs_renderer.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_scene_loader.cpp
+++ b/3dgs_common/gs_scene_loader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_scene_loader.h
+++ b/3dgs_common/gs_scene_loader.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_spz_loader.cpp
+++ b/3dgs_common/gs_spz_loader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_spz_loader.h
+++ b/3dgs_common/gs_spz_loader.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_vulkan_utils.cpp
+++ b/3dgs_common/gs_vulkan_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/gs_vulkan_utils.h
+++ b/3dgs_common/gs_vulkan_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/3dgs_common/shaders/adreno_preprocess.comp
+++ b/3dgs_common/shaders/adreno_preprocess.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Adreno/TBDR-native per-gaussian preprocess (graphics-pipeline splat path).

--- a/3dgs_common/shaders/common.glsl
+++ b/3dgs_common/shaders/common.glsl
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 

--- a/3dgs_common/shaders/hist.comp
+++ b/3dgs_common/shaders/hist.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from VkRadixSort by Mirco Werner (https://github.com/MircoWerner/VkRadixSort)
 // via 3DGS.cpp. Radix sort histogram pass.

--- a/3dgs_common/shaders/precomp_cov3d.comp
+++ b/3dgs_common/shaders/precomp_cov3d.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 // One-time 3D covariance precomputation from scale+rotation.

--- a/3dgs_common/shaders/prefix_sum.comp
+++ b/3dgs_common/shaders/prefix_sum.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 // Parallel inclusive prefix sum (Hillis-Steele style).

--- a/3dgs_common/shaders/preprocess.comp
+++ b/3dgs_common/shaders/preprocess.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 // Per-frame Gaussian preprocessing: project to 2D, eval SH, compute tile AABB.

--- a/3dgs_common/shaders/preprocess_sort.comp
+++ b/3dgs_common/shaders/preprocess_sort.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 // Generate sort keys (tileIdx<<16 | depth16) from prefix sum offsets.

--- a/3dgs_common/shaders/render.comp
+++ b/3dgs_common/shaders/render.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 // Per-pixel tile-based alpha blending, writes to storage image.

--- a/3dgs_common/shaders/sort.comp
+++ b/3dgs_common/shaders/sort.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from VkRadixSort by Mirco Werner (https://github.com/MircoWerner/VkRadixSort)
 // via 3DGS.cpp. Radix sort scatter pass.

--- a/3dgs_common/shaders/splat.frag
+++ b/3dgs_common/shaders/splat.frag
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Fragment stage of the graphics-pipeline splat rasterizer. Evaluates the 2D

--- a/3dgs_common/shaders/splat.vert
+++ b/3dgs_common/shaders/splat.vert
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Adreno/TBDR-native Gaussian-splat rasterizer (graphics pipeline).

--- a/3dgs_common/shaders/splat_keys.comp
+++ b/3dgs_common/shaders/splat_keys.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Depth-sort key generation for the graphics-pipeline splat rasterizer.

--- a/3dgs_common/shaders/tile_boundary.comp
+++ b/3dgs_common/shaders/tile_boundary.comp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Ported from 3DGS.cpp (https://github.com/shg8/3DGS.cpp)
 // Find start/end index per tile in the sorted array.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025, Leia Inc.
+# Copyright 2025, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Top-level CMakeLists.txt for the displayxr-demo-gaussiansplat standalone

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2026, Leia Inc.
+// Copyright 2026, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Android leg of displayxr-demo-gaussiansplat. A vendor-neutral OpenXR client

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2026, Leia Inc.
+    Copyright 2026, The DisplayXR Project and its contributors
     SPDX-License-Identifier: Apache-2.0
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2026, Leia Inc.
+# Copyright 2026, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Native build for the Android leg of displayxr-demo-gaussiansplat (3D

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026, Leia Inc.
+// Copyright 2026, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // gausssplat_vk_android entry point. Android leg of the DisplayXR

--- a/android/src/main/java/com/displayxr/gausssplat_vk_android/MainActivity.kt
+++ b/android/src/main/java/com/displayxr/gausssplat_vk_android/MainActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2026, Leia Inc.
+// Copyright 2026, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Thin NativeActivity wrapper. Two jobs:

--- a/android/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2026, Leia Inc.
+    Copyright 2026, The DisplayXR Project and its contributors
     SPDX-License-Identifier: Apache-2.0
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">

--- a/android/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2026, Leia Inc.
+    Copyright 2026, The DisplayXR Project and its contributors
     SPDX-License-Identifier: Apache-2.0
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">

--- a/android/src/main/res/values/ic_launcher_background.xml
+++ b/android/src/main/res/values/ic_launcher_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2026, Leia Inc.
+    Copyright 2026, The DisplayXR Project and its contributors
     SPDX-License-Identifier: Apache-2.0
     Adaptive-icon background — sampled from the icon.png edge color.
 -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2026, Leia Inc.
+// Copyright 2026, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Root Gradle build for the Android leg. Minimal by design — this repo's

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,11 +1,11 @@
-# Copyright 2025, Leia Inc.
+# Copyright 2025, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Standalone build (displayxr-demo-* repo). The shared C++ scaffolding
 # (logging / input / window / xr_session_common / HUD / D3D11 renderer /
 # atlas-capture helper / stb) AND the off-axis Kooima math now come from
 # displayxr-common, pinned by tag instead of vendored here (epic #396 W3
-# math, W4 scaffolding). Only leia_math.h (app-local reference math) stays
+# math, W4 scaffolding). Only dxr_math.h (app-local reference math) stays
 # in this directory.
 
 cmake_minimum_required(VERSION 3.21)

--- a/common/dxr_math.h
+++ b/common/dxr_math.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 // Copied from DisplayXR SDK reference example (parallax_toggle)
 
@@ -9,7 +9,7 @@
 
 #pragma pack(push,1)
 
-namespace leia {
+namespace dxr {
 
 struct vec3f
 {
@@ -278,6 +278,6 @@ inline mat4f CalculateMVP(const vec3f& eye, float screenWidthMM, float screenHei
     return mvp;
 }
 
-} // namespace leia
+} // namespace dxr
 
 #pragma pack(pop)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-# Copyright 2026, Leia Inc.
+# Copyright 2026, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 
 android.useAndroidX=true

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025, Leia Inc.
+# Copyright 2025, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Standalone build — lives inside displayxr-demo-gaussiansplat repo as

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-// Copyright 2026, Leia Inc.
+// Copyright 2026, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 // Gradle settings for the Android leg of displayxr-demo-gaussiansplat. The

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2025, Leia Inc.
+# Copyright 2025, The DisplayXR Project and its contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Standalone build — lives inside displayxr-demo-gaussiansplat repo as

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/windows/resource.rc
+++ b/windows/resource.rc
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <winver.h>
@@ -16,13 +16,13 @@ BEGIN
     BEGIN
         BLOCK "040904B0"
         BEGIN
-            VALUE "CompanyName",      "Leia Inc."
+            VALUE "CompanyName",      "The DisplayXR Project"
             VALUE "FileDescription",  "SR 3DGS OpenXR Ext Vulkan Test Application"
             VALUE "FileVersion",      "1.0.0.0"
             VALUE "InternalName",     "gaussian_splatting_handle_vk_win"
-            VALUE "LegalCopyright",   "Copyright 2025 Leia Inc."
+            VALUE "LegalCopyright",   "Copyright 2025 The DisplayXR Project and its contributors"
             VALUE "OriginalFilename", "gaussian_splatting_handle_vk_win.exe"
-            VALUE "ProductName",      "Leia SR Test Apps"
+            VALUE "ProductName",      "DisplayXR 3D Gaussian Splatting"
             VALUE "ProductVersion",   "1.0.0.0"
         END
     END

--- a/windows/sr_3dgs_openxr_ext_vk.manifest
+++ b/windows/sr_3dgs_openxr_ext_vk.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="amd64"
-    name="Leia.SR.3DGSOpenXRExtVK"
+    name="DisplayXR.SR3DGSOpenXRExtVK"
     type="win32"
   />
   <description>Leia SR 3DGS OpenXR Ext Vulkan Test Application</description>

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -1,4 +1,4 @@
-// Copyright 2025, Leia Inc.
+// Copyright 2025, The DisplayXR Project and its contributors
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file


### PR DESCRIPTION
Bring this repo into line with the DisplayXR vendor-neutrality contract — the display vendor's company name should appear only in `displayxr-leia-plugin`.

**Tier 1 — reference-math rename**
- `common/leia_math.h` → `common/dxr_math.h`; `namespace leia` → `namespace dxr`. This is dead app-local reference math (nothing `#include`s it — the real off-axis math comes from `displayxr::common` via FetchContent), so the rename is non-compile-affecting.

**Tier 2 — copyright attribution**
- `Copyright … Leia Inc` → `Copyright … The DisplayXR Project and its contributors` (year spans preserved; `SPDX-License-Identifier` lines untouched).

**Self-branding**
- Windows resource `CompanyName` / `ProductName` and the side-by-side assembly identity neutralized to DisplayXR.

**Guard**
- New `.github/workflows/lint.yml` vendor-name guard with a Tier-A allowlist so legitimate hardware / plug-in / SDK references (CNSDK, Leia SR, the `leia-plugin` repo, Leia Image Format, …) stay legal. Vendored upstream OpenXR headers under `openxr/` keep upstream's copyright and are excluded by the guard.
