### PR TITLE
feat: open the app window on the 3D panel (XrDisplayDesktopPositionEXT, display_info v16)

### DIFF
--- a/macos/main.mm
+++ b/macos/main.mm
@@ -744,14 +744,24 @@ static void SignalHandler(int sig) {
     g_running = false;
 }
 
-static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
+static bool CreateMacOSWindow(uint32_t width, uint32_t height, int32_t screenLeft, int32_t screenTop) {
     [NSApplication sharedApplication];
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
     AppDelegate *delegate = [[AppDelegate alloc] init];
     [NSApp setDelegate:delegate];
 
+    // INV-1.3: open on the 3D panel (runtime#715). (screenLeft, screenTop) is
+    // the panel top-left in top-down global coordinates (origin = primary
+    // top-left, XrDisplayDesktopPositionEXT); flip into AppKit's bottom-up
+    // space. (0,0) = primary/unknown — the titled window is auto-constrained
+    // below the menu bar, so it is always a safe create position.
     NSRect frame = NSMakeRect(100, 100, width, height);
+    NSScreen *primary = [NSScreen screens].firstObject;
+    if (primary != nil) {
+        CGFloat topY = primary.frame.size.height - (CGFloat)screenTop;
+        frame = NSMakeRect((CGFloat)screenLeft, topY - (CGFloat)height, width, height);
+    }
     NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                        NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
     g_window = [[NSWindow alloc] initWithContentRect:frame
@@ -764,7 +774,8 @@ static bool CreateMacOSWindow(uint32_t width, uint32_t height) {
     // the demo must. Harmless when opaque (renderer outputs alpha = 1).
     [g_window setOpaque:NO];
     [g_window setBackgroundColor:[NSColor clearColor]];
-    [g_window center];
+    // Do NOT [g_window center] — that would drag the window back onto the
+    // screen containing (0,0) and defeat the INV-1.3 panel placement above.
 
     g_metalView = [[MetalView alloc] initWithFrame:frame];
     [g_window setContentView:g_metalView];
@@ -941,6 +952,11 @@ struct AppXrSession {
     float nominalViewerX = 0, nominalViewerY = 0, nominalViewerZ = 0.5f;
     float recommendedViewScaleX = 0.5f, recommendedViewScaleY = 1.0f;
     uint32_t displayPixelWidth = 0, displayPixelHeight = 0;
+    // INV-1.3 / runtime#715: 3D panel top-left in virtual-desktop pixels
+    // (top-down, origin = primary top-left) from XrDisplayDesktopPositionEXT
+    // (display_info v16). (0,0) = primary/unknown — safe default, incl. on
+    // older runtimes that ignore the unknown chain entry.
+    int32_t displayScreenLeft = 0, displayScreenTop = 0;
 
     // Eye tracking
     float eyePositions[8][3] = {};  // [view][x,y,z] — raw per-eye positions in display space
@@ -1442,6 +1458,11 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         XrSystemProperties sp = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT di = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT ec = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position (display_info v16, runtime#715),
+        // consumed by CreateMacOSWindow so the window opens on the 3D panel.
+        XrDisplayDesktopPositionEXT dp = {};
+        dp.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
+        ec.next = &dp;
         di.next = &ec; sp.next = &di;
         if (XR_SUCCEEDED(xrGetSystemProperties(xr.instance, xr.systemId, &sp))) {
             xr.recommendedViewScaleX = di.recommendedViewScaleX;
@@ -1454,6 +1475,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
             xr.displayPixelWidth = di.displayPixelWidth;
             xr.displayPixelHeight = di.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)ec.supportedModes;
+            xr.displayScreenLeft = dp.left;
+            xr.displayScreenTop = dp.top;
+            LOG_INFO("Display desktop position: (%d, %d)", xr.displayScreenLeft, xr.displayScreenTop);
         }
         xrGetInstanceProcAddr(xr.instance, "xrRequestDisplayModeEXT", (PFN_xrVoidFunction*)&xr.pfnRequestDisplayModeEXT);
         if (xr.supportedEyeTrackingModes != 0)
@@ -2004,10 +2028,18 @@ int main(int argc, char** argv) {
         }
     }
 
-    // Step 1: Create macOS window
+    // Step 1: Initialize OpenXR FIRST — xrGetSystemProperties needs only
+    // instance + system id, and returns the 3D panel desktop position the
+    // window below is created at (INV-1.3 ordering: instance → system →
+    // properties → window → session; runtime#715).
+    AppXrSession xr = {};
+    if (!InitializeOpenXR(xr)) { LOG_ERROR("OpenXR init failed"); return 1; }
+
+    // Step 2: Create the macOS window (app-owned) on the 3D panel
     g_windowW = 1280; g_windowH = 720;
-    if (!CreateMacOSWindow(g_windowW, g_windowH)) {
+    if (!CreateMacOSWindow(g_windowW, g_windowH, xr.displayScreenLeft, xr.displayScreenTop)) {
         LOG_ERROR("Failed to create macOS window");
+        CleanupOpenXR(xr);
         return 1;
     }
 
@@ -2016,10 +2048,6 @@ int main(int argc, char** argv) {
       g_windowW = (uint32_t)(cs.width * bs);
       g_windowH = (uint32_t)(cs.height * bs);
       LOG_INFO("Window drawable: %ux%u", g_windowW, g_windowH); }
-
-    // Step 2: Initialize OpenXR
-    AppXrSession xr = {};
-    if (!InitializeOpenXR(xr)) { LOG_ERROR("OpenXR init failed"); return 1; }
 
     // Try to find sim_display_set_output_mode
     { void *rtHandle = NULL;

--- a/openxr_includes/openxr/XR_EXT_display_info.h
+++ b/openxr_includes/openxr/XR_EXT_display_info.h
@@ -1,5 +1,13 @@
-// Copyright 2025-2026, Leia Inc.
-// SPDX-License-Identifier: BSL-1.0
+// Copyright 2025-2026, The DisplayXR Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// PROVISIONAL — the XR_EXT_* identifiers in this header are NOT registered
+// with the Khronos OpenXR registry. They are provisional placeholders used
+// during DisplayXR incubation and will be re-registered — and may be renamed
+// (e.g. to a registered XR_<AUTHORID>_ prefix) — through the official Khronos
+// process on the EXT -> KHR path. Do not treat these names or numeric values
+// as stable. See GOVERNANCE.md.
+//
 /*!
  * @file
  * @brief  Header for XR_EXT_display_info extension
@@ -22,7 +30,7 @@ extern "C" {
 #endif
 
 #define XR_EXT_display_info 1
-#define XR_EXT_display_info_SPEC_VERSION 14
+#define XR_EXT_display_info_SPEC_VERSION 16
 #define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -54,11 +62,37 @@ typedef struct XrDisplayInfoEXT {
     uint32_t                    displayPixelHeight;         //!< Native display panel height in pixels (0 if unknown)
 } XrDisplayInfoEXT;
 
+// ---- v16: Display desktop position ----
+
+#define XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT ((XrStructureType)1000999210)
+
 /*!
- * @brief Display mode for XR_EXT_display_info 2D/3D switching.
+ * @brief Desktop position of the 3D display, returned by xrGetSystemProperties
+ * (v16 addition).
  *
- * @deprecated Use xrRequestDisplayRenderingModeEXT instead. Each rendering mode
- * carries a hardwareDisplay3D field that triggers physical switching automatically.
+ * When chained to XrSystemProperties (typically via XrDisplayInfoEXT's next
+ * pointer), the runtime fills in the 3D panel's top-left corner in OS
+ * virtual-desktop coordinates: top-down pixels with the origin at the primary
+ * monitor's top-left (Windows virtual-screen / X11 root-window convention).
+ * (0, 0) means the panel is the primary monitor or its position is unknown.
+ *
+ * Applications that create their own window (the handle/texture classes)
+ * should create it at this position so the content opens on the 3D panel
+ * rather than the primary monitor — the window-relative weave can only
+ * produce correct 3D on the panel itself. Hosted-class apps need not care:
+ * the runtime self-creates its window there. See runtime issue #715.
+ *
+ * @extends XrSystemProperties
+ */
+typedef struct XrDisplayDesktopPositionEXT {
+    XrStructureType             type;       //!< Must be XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT
+    void* XR_MAY_ALIAS          next;       //!< Pointer to next structure in chain
+    int32_t                     left;       //!< Panel left edge in virtual-desktop pixels
+    int32_t                     top;        //!< Panel top edge in virtual-desktop pixels
+} XrDisplayDesktopPositionEXT;
+
+/*!
+ * @brief Hardware display state for xrRequestDisplayModeEXT (v15 repurpose).
  */
 typedef enum XrDisplayModeEXT {
     XR_DISPLAY_MODE_2D_EXT = 0,
@@ -67,21 +101,29 @@ typedef enum XrDisplayModeEXT {
 } XrDisplayModeEXT;
 
 /*!
- * @brief Request display mode switch (2D/3D).
+ * @brief Request the HARDWARE display state alone for the current mode
+ * (v15 repurpose — was a deprecated mode-switching wrapper through v14).
  *
- * @deprecated Use xrRequestDisplayRenderingModeEXT instead. This function is a
- * thin wrapper that finds the first rendering mode matching the requested
- * hardware display state and delegates to xrRequestDisplayRenderingModeEXT.
+ * A rendering mode is a complete recipe: layout, view count, scales, and a
+ * default hardware state. xrRequestDisplayRenderingModeEXT requests a mode
+ * and the hardware state follows automatically. THIS function overrides the
+ * hardware state ALONE: the active rendering mode, the app's submitted
+ * content, and the display processor's atlas processing are untouched —
+ * only the physical 2D/3D element (e.g. the switchable lenticular lens)
+ * changes.
  *
- * Switches the display between 2D and 3D modes. In 3D mode, the display's
- * light field hardware is active for stereoscopic viewing. In 2D mode, the
- * display behaves as a conventional 2D panel.
+ * E.g. XR_DISPLAY_MODE_2D_EXT over an active 3D mode keeps the weave
+ * running with the lens off: the panel shows the woven atlas flat (blurry),
+ * and an app fading its parallax to zero converges back to a sharp image —
+ * the building block for app-authored 2D/3D transitions such as the MANUAL
+ * eye-tracking loss flow.
  *
- * The runtime automatically switches to 3D mode on xrBeginSession and back
- * to 2D mode on xrEndSession.
+ * The override holds until the next mode request (whose default hardware
+ * state then applies) or the next call to this function. A successful state
+ * flip is reported via XrEventDataHardwareDisplayStateChangedEXT.
  *
  * @param session A valid XrSession handle.
- * @param displayMode The desired display mode (2D or 3D).
+ * @param displayMode The desired hardware state (2D or 3D).
  * @return XR_SUCCESS on success.
  */
 typedef XrResult (XRAPI_PTR *PFN_xrRequestDisplayModeEXT)(XrSession session, XrDisplayModeEXT displayMode);
@@ -324,7 +366,7 @@ typedef struct XrEventDataHardwareDisplayStateChangedEXT {
     XrBool32                    hardwareDisplay3D;
 } XrEventDataHardwareDisplayStateChangedEXT;
 
-// xrSetSharedTextureOutputRectEXT moved to XR_EXT_win32_window_binding.h / XR_EXT_cocoa_window_binding.h (v12)
+// xrSetSharedTextureOutputRectEXT was removed (ADR-031); display-zones (XR_EXT_display_zones) is the sole region paradigm
 
 // ---- v14: Per-Mode Tracking Capability + Tracking-State Event (#441) ----
 

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -471,8 +471,8 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
-static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
-    LOG_INFO("Creating application window (%dx%d)", width, height);
+static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height, int32_t screenLeft, int32_t screenTop) {
+    LOG_INFO("Creating application window (%dx%d) at (%d, %d)", width, height, screenLeft, screenTop);
 
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
@@ -498,9 +498,13 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height) {
     RECT rect = { 0, 0, width, height };
     AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
 
+    // INV-1.3: open on the 3D panel (runtime#715 — handle apps otherwise open
+    // on the primary monitor on multi-monitor boxes). (screenLeft, screenTop)
+    // is the panel top-left in virtual-desktop pixels from
+    // XrDisplayDesktopPositionEXT; (0,0) = primary/unknown, a safe default.
     HWND hwnd = CreateWindowEx(WS_EX_NOREDIRECTIONBITMAP, WINDOW_CLASS, WINDOW_TITLE,
         WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT, CW_USEDEFAULT,
+        screenLeft, screenTop,
         rect.right - rect.left, rect.bottom - rect.top,
         nullptr, nullptr, hInstance, nullptr);
 
@@ -1550,13 +1554,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             LOG_ERROR("display3d self-test FAILED with %d check(s) — pick ray math has drifted", stFails);
     }
 
-    HWND hwnd = CreateAppWindow(hInstance, g_windowWidth, g_windowHeight);
-    if (!hwnd) {
-        LOG_ERROR("Failed to create window");
-        ShutdownLogging();
-        return 1;
-    }
-
     // Add DisplayXR to DLL search path
     {
         HKEY hKey;
@@ -1571,11 +1568,26 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         }
     }
 
-    // Initialize OpenXR
+    // Initialize OpenXR FIRST — xrGetSystemProperties needs only instance +
+    // system id, and returns the 3D panel desktop position the window below
+    // is created at (INV-1.3 ordering: instance → system → properties →
+    // window → session; runtime#715).
     XrSessionManager xr = {};
     g_xr = &xr;
     if (!InitializeOpenXR(xr)) {
         LOG_ERROR("OpenXR initialization failed");
+        g_xr = nullptr;
+        ShutdownLogging();
+        return 1;
+    }
+
+    // Create the app window on the 3D panel
+    int32_t panelLeft = 0, panelTop = 0;
+    GetDisplayDesktopPosition(panelLeft, panelTop);
+    HWND hwnd = CreateAppWindow(hInstance, g_windowWidth, g_windowHeight, panelLeft, panelTop);
+    if (!hwnd) {
+        LOG_ERROR("Failed to create window");
+        CleanupOpenXR(xr);
         g_xr = nullptr;
         ShutdownLogging();
         return 1;

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -19,6 +19,21 @@ static bool s_hasViewRigExt = false;
 
 bool XrViewRigExtAvailable() { return s_hasViewRigExt; }
 
+// INV-1.3 / runtime#715: 3D panel top-left in OS virtual-desktop pixels
+// (top-down, origin = primary monitor top-left), from
+// XrDisplayDesktopPositionEXT (XR_EXT_display_info spec v16). (0,0) =
+// primary/unknown — a safe default, and what an older runtime (which
+// ignores the unknown chain entry) yields via the zero-init below. Also
+// demo-side statics because XrSessionManager comes from displayxr::common.
+static int32_t s_displayDesktopLeft = 0;
+static int32_t s_displayDesktopTop = 0;
+
+void GetDisplayDesktopPosition(int32_t& left, int32_t& top)
+{
+    left = s_displayDesktopLeft;
+    top = s_displayDesktopTop;
+}
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -132,6 +147,11 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         XrSystemProperties sysProps = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoEXT displayInfo = {(XrStructureType)XR_TYPE_DISPLAY_INFO_EXT};
         XrEyeTrackingModeCapabilitiesEXT eyeCaps = {(XrStructureType)XR_TYPE_EYE_TRACKING_MODE_CAPABILITIES_EXT};
+        // INV-1.3: panel desktop position (display_info v16, runtime#715),
+        // consumed by CreateAppWindow so the window opens on the 3D panel.
+        XrDisplayDesktopPositionEXT desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_EXT;
+        eyeCaps.next = &desktopPos;
         displayInfo.next = &eyeCaps;
         sysProps.next = &displayInfo;
         XrResult diResult = xrGetSystemProperties(xr.instance, xr.systemId, &sysProps);
@@ -147,6 +167,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.displayPixelHeight = displayInfo.displayPixelHeight;
             xr.supportedEyeTrackingModes = (uint32_t)eyeCaps.supportedModes;
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
+            s_displayDesktopLeft = desktopPos.left;
+            s_displayDesktopTop = desktopPos.top;
+            LOG_INFO("Display desktop position: (%d, %d)", s_displayDesktopLeft, s_displayDesktopTop);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -19,6 +19,12 @@ bool InitializeOpenXR(XrSessionManager& xr);
 // because displayxr::common's XrSessionManager doesn't carry view-rig state yet.
 bool XrViewRigExtAvailable();
 
+// INV-1.3 / runtime#715: 3D panel top-left in virtual-desktop pixels from
+// XrDisplayDesktopPositionEXT (display_info v16), filled by InitializeOpenXR.
+// (0,0) = primary/unknown (safe default, incl. on older runtimes). Demo-side
+// for the same reason as XrViewRigExtAvailable().
+void GetDisplayDesktopPosition(int32_t& left, int32_t& top);
+
 // Get Vulkan graphics requirements and set up Vulkan instance/device per OpenXR spec
 bool GetVulkanGraphicsRequirements(XrSessionManager& xr);
 


### PR DESCRIPTION
## What

On multi-monitor boxes, handle apps open on the primary monitor instead of the 3D panel (DisplayXR/displayxr-runtime#715). XR_EXT_display_info spec v16 (runtime PR #720) adds `XrDisplayDesktopPositionEXT` — the panel's top-left in virtual-desktop pixels — so the app can create its window on the panel from the start.

- **Vendored header** `openxr_includes/openxr/XR_EXT_display_info.h` synced byte-for-byte to the canonical v16 copy from the runtime repo (additive only; no identifiers removed).
- **Windows** (`windows/main.cpp`, `windows/xr_session.{h,cpp}`): the display-info query now chains `XrDisplayDesktopPositionEXT`; WinMain reordered to the INV-1.3 ordering (instance → system → properties → window → session) and `CreateAppWindow` places the window at `(left, top)` instead of `CW_USEDEFAULT`. The position lives demo-side (`GetDisplayDesktopPosition`) because `XrSessionManager` comes from displayxr::common.
- **macOS** (`macos/main.mm`): same query + reorder; `CreateMacOSWindow` flips the top-down position into AppKit's bottom-up coordinates (per the runtime's `cube_handle_metal_macos` reference). `[g_window center]` dropped — it would undo the placement.
- **Linux**: untouched — hosted-NULL app, no app-created window.

## Opt-in / backward compatible

The struct is zero-initialized before the query. An **older runtime** ignores the unknown chain entry and leaves it untouched, so the app reads `(0, 0)` = primary/unknown — a safe create position and the effective previous behavior. A **v16 runtime** fills in the real panel position. No new extension is enabled; this rides the already-enabled `XR_EXT_display_info` chain.

## Testing

- macOS: clean `./scripts/build_macos.sh` passes.
- Windows/Linux: CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)