### PR TITLE
Port XR_DXR_mcp_tools agent tools to the Windows build

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.0.0
+    GIT_TAG v2.1.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -36,8 +36,12 @@
 
 #include <atomic>
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -136,6 +140,11 @@ static float g_fitVHeight   = kFallbackVirtualDisplayHeightM;
 static float g_fitYaw       = 0.0f;
 static std::atomic<bool> g_fitValid{false};
 
+// Latest computed frames-per-second, published each frame by the render thread
+// (after UpdatePerformanceStats) so the XR_DXR_mcp_tools get_status handler can
+// report it without reaching into the render thread's local PerformanceStats.
+static std::atomic<float> g_currentFps{0.0f};
+
 // Compute robust scene bounds (5th–95th percentile per axis) and stage
 // new display-rig pose + vHeight on g_inputState. Display orientation is
 // kept identity (forward = world −Z): splats have no canonical front, and
@@ -195,6 +204,328 @@ static void ApplyAutoFitForLoadedScene_locked() {
             high_resolution_clock::now().time_since_epoch()).count() * 1e-6;
         g_inputState.animationActive = false;
     }
+}
+
+// ============================================================================
+// Agent tools (XR_DXR_mcp_tools, #66) — dispatch, wired to the Windows viewer
+// ============================================================================
+//
+// Windows port of the macOS build's HandleMcpToolCall. RegisterAgentTools()
+// (windows/xr_session.cpp) declares the appId + tools; this runs a registered
+// tool call and answers it. It executes on the render thread (called from
+// PollEventsGs), so it mutates g_inputState under g_inputMutex and touches the
+// renderer/scene state under g_sceneMutex — the same locks the render loop uses.
+// The tool set, descriptions, schemas, and result JSON key shapes are identical
+// to macOS (macos/main.mm).
+
+static constexpr float kMcpRad2Deg   = 57.2957795f;
+static constexpr float kMcpDeg2Rad   = 0.0174532925f;
+static constexpr float kMcpMaxPitchRad = 1.5f;  // same clamp as mouse drag
+
+// Find the value position of `"key" :` in a flat JSON object. Returns nullptr if
+// absent. Does not handle keys nested inside sub-objects or string values — the
+// registered schemas keep all arguments top-level.
+static const char* JsonFindValue(const char* json, const char* key) {
+    char quoted[96];
+    snprintf(quoted, sizeof(quoted), "\"%s\"", key);
+    const char* p = json;
+    while ((p = strstr(p, quoted)) != nullptr) {
+        const char* q = p + strlen(quoted);
+        while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') q++;
+        if (*q == ':') {
+            q++;
+            while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') q++;
+            return q;
+        }
+        p = q;
+    }
+    return nullptr;
+}
+
+static bool JsonGetNumber(const char* json, const char* key, double* out) {
+    const char* v = JsonFindValue(json, key);
+    if (!v) return false;
+    char* end = nullptr;
+    double d = strtod(v, &end);
+    if (end == v) return false;
+    *out = d;
+    return true;
+}
+
+static bool JsonGetBool(const char* json, const char* key, bool* out) {
+    const char* v = JsonFindValue(json, key);
+    if (!v) return false;
+    if (strncmp(v, "true", 4) == 0)  { *out = true;  return true; }
+    if (strncmp(v, "false", 5) == 0) { *out = false; return true; }
+    return false;
+}
+
+// Extract + unescape a JSON string value. Handles the standard escapes and BMP
+// \uXXXX (encoded back to UTF-8; surrogate halves degrade to '?').
+static bool JsonGetString(const char* json, const char* key, std::string* out) {
+    const char* v = JsonFindValue(json, key);
+    if (!v || *v != '"') return false;
+    out->clear();
+    for (const char* c = v + 1; *c; c++) {
+        if (*c == '"') return true;
+        if (*c != '\\') { out->push_back(*c); continue; }
+        c++;
+        switch (*c) {
+            case '"':  out->push_back('"');  break;
+            case '\\': out->push_back('\\'); break;
+            case '/':  out->push_back('/');  break;
+            case 'n':  out->push_back('\n'); break;
+            case 't':  out->push_back('\t'); break;
+            case 'r':  out->push_back('\r'); break;
+            case 'b':  out->push_back('\b'); break;
+            case 'f':  out->push_back('\f'); break;
+            case 'u': {
+                unsigned cp = 0;
+                for (int i = 1; i <= 4; i++) {
+                    char h = c[i];
+                    if (!isxdigit((unsigned char)h)) return false;
+                    cp = cp * 16 + (unsigned)(isdigit((unsigned char)h) ? h - '0'
+                                                                        : (tolower(h) - 'a' + 10));
+                }
+                c += 4;
+                if (cp < 0x80) {
+                    out->push_back((char)cp);
+                } else if (cp < 0x800) {
+                    out->push_back((char)(0xC0 | (cp >> 6)));
+                    out->push_back((char)(0x80 | (cp & 0x3F)));
+                } else if (cp >= 0xD800 && cp <= 0xDFFF) {
+                    out->push_back('?'); // unpaired surrogate
+                } else {
+                    out->push_back((char)(0xE0 | (cp >> 12)));
+                    out->push_back((char)(0x80 | ((cp >> 6) & 0x3F)));
+                    out->push_back((char)(0x80 | (cp & 0x3F)));
+                }
+                break;
+            }
+            default: return false; // invalid escape
+        }
+    }
+    return false; // unterminated string
+}
+
+static std::string JsonEscape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (c < 0x20) {
+                    char b[8];
+                    snprintf(b, sizeof(b), "\\u%04x", c);
+                    out += b;
+                } else {
+                    out.push_back((char)c);
+                }
+        }
+    }
+    return out;
+}
+
+// Monotonic wall-clock seconds — matches the idle-timer stamp ApplyAutoFit uses.
+static double McpNowSec() {
+    using namespace std::chrono;
+    return (double)duration_cast<microseconds>(
+        high_resolution_clock::now().time_since_epoch()).count() * 1e-6;
+}
+
+// Camera sub-object shared by get_status and set_camera responses. Locks
+// g_inputMutex (the render loop / message pump both touch g_inputState); do NOT
+// call while already holding it.
+static std::string McpCameraJson() {
+    float px, py, pz, yaw, pitch, zoom;
+    {
+        std::lock_guard<std::mutex> lock(g_inputMutex);
+        px = g_inputState.cameraPosX;
+        py = g_inputState.cameraPosY;
+        pz = g_inputState.cameraPosZ;
+        yaw = g_inputState.yaw;
+        pitch = g_inputState.pitch;
+        zoom = g_inputState.viewParams.scaleFactor;
+    }
+    char buf[192];
+    snprintf(buf, sizeof(buf),
+        "{\"position\":[%.4f,%.4f,%.4f],\"yaw_deg\":%.2f,\"pitch_deg\":%.2f,\"zoom\":%.3f}",
+        px, py, pz, yaw * kMcpRad2Deg, pitch * kMcpRad2Deg, zoom);
+    return buf;
+}
+
+void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* call) {
+    if (!xr.pfnSubmitMCPToolResultEXT) return;
+
+    // Two-call idiom: the event's argsSize is the exact capacity needed
+    // (incl. NUL). A no-arg tool reports argsSize 0 — treat as "{}".
+    std::string args = "{}";
+    if (xr.pfnGetMCPToolCallArgsEXT && call->argsSize > 0) {
+        std::vector<char> buf(call->argsSize, '\0');
+        uint32_t needed = 0;
+        if (XR_SUCCEEDED(xr.pfnGetMCPToolCallArgsEXT(xr.session, call->callId,
+                (uint32_t)buf.size(), &needed, buf.data())))
+            args.assign(buf.data());
+    }
+    const char* a = args.c_str();
+
+    XrBool32 ok = XR_TRUE;
+    std::string result;
+    char buf[768];
+
+    if (strcmp(call->toolName, "load_splat") == 0) {
+        std::string path;
+        if (!JsonGetString(a, "path", &path) || path.empty()) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"missing required string arg 'path'\"}";
+        } else if (!ValidateSceneFile(path)) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"not a readable .ply/.spz scene: '" + JsonEscape(path) + "'\"}";
+        } else {
+            // On the render thread (same thread that drives per-frame Vulkan
+            // submits), so loadScene() is safe here — mirror the render loop's
+            // queued-load block: hold g_sceneMutex across loadScene + auto-fit.
+            std::lock_guard<std::mutex> lock(g_sceneMutex);
+            if (!g_gsRenderer.loadScene(path.c_str())) {
+                ok = XR_FALSE;
+                result = "{\"error\":\"failed to load '" + JsonEscape(path) + "' (corrupt or unsupported)\"}";
+            } else {
+                g_loadedFileName = GetPlyFilename(path);
+                ApplyAutoFitForLoadedScene_locked();
+                snprintf(buf, sizeof(buf), "\",\"splat_count\":%u}", g_gsRenderer.gaussianCount());
+                result = "{\"file\":\"" + JsonEscape(path) + buf;
+                LOG_INFO("Agent loaded scene: %s (%u splats)",
+                         g_loadedFileName.c_str(), g_gsRenderer.gaussianCount());
+            }
+        }
+    } else if (strcmp(call->toolName, "get_status") == 0) {
+        const char* modeName = (xr.renderingModeCount > 0 &&
+            xr.currentModeIndex < xr.renderingModeCount &&
+            xr.renderingModeNames[xr.currentModeIndex][0] != '\0')
+            ? xr.renderingModeNames[xr.currentModeIndex] : "unknown";
+        double fps = (double)g_currentFps.load(std::memory_order_relaxed);
+        std::string cameraJson = McpCameraJson();
+        float vHeight; bool autoOrbit; bool orbitingNow;
+        {
+            std::lock_guard<std::mutex> lock(g_inputMutex);
+            vHeight = g_inputState.viewParams.virtualDisplayHeight;
+            autoOrbit = g_inputState.animateEnabled;
+            orbitingNow = g_inputState.animationActive;
+        }
+        snprintf(buf, sizeof(buf),
+            "\",\"has_scene\":%s,\"splat_count\":%u,\"fps\":%.1f,\"camera\":%s,"
+            "\"virtual_display_height_m\":%.4f,"
+            "\"rendering_mode\":{\"index\":%u,\"name\":\"%s\"},"
+            "\"transparent_background\":%s,\"auto_orbit\":%s,\"orbiting_now\":%s,"
+            "\"session_running\":%s}",
+            g_gsRenderer.hasScene() ? "true" : "false",
+            g_gsRenderer.gaussianCount(), fps, cameraJson.c_str(),
+            vHeight, xr.currentModeIndex, modeName,
+            g_transparentBg.load() ? "true" : "false",
+            autoOrbit ? "true" : "false",
+            orbitingNow ? "true" : "false",
+            xr.sessionRunning ? "true" : "false");
+        result = "{\"file\":\"" + JsonEscape(g_loadedFileName) + buf;
+    } else if (strcmp(call->toolName, "set_camera") == 0) {
+        double v;
+        bool any = false;
+        {
+            std::lock_guard<std::mutex> lock(g_inputMutex);
+            if (JsonGetNumber(a, "position_x", &v)) { g_inputState.cameraPosX = (float)v; any = true; }
+            if (JsonGetNumber(a, "position_y", &v)) { g_inputState.cameraPosY = (float)v; any = true; }
+            if (JsonGetNumber(a, "position_z", &v)) { g_inputState.cameraPosZ = (float)v; any = true; }
+            if (JsonGetNumber(a, "yaw_deg", &v))    { g_inputState.yaw = (float)(v * kMcpDeg2Rad); any = true; }
+            if (JsonGetNumber(a, "pitch_deg", &v)) {
+                float p = (float)(v * kMcpDeg2Rad);
+                if (p > kMcpMaxPitchRad) p = kMcpMaxPitchRad;
+                if (p < -kMcpMaxPitchRad) p = -kMcpMaxPitchRad;
+                g_inputState.pitch = p;
+                any = true;
+            }
+            if (JsonGetNumber(a, "zoom", &v)) {
+                float z = (float)v;
+                if (z < 0.1f) z = 0.1f;
+                g_inputState.viewParams.scaleFactor = z;
+                any = true;
+            }
+            if (any) {
+                g_inputState.transitioning = false;  // agent pose wins over a running focus transition
+                g_inputState.lastInputTimeSec = McpNowSec();  // restart auto-orbit idle countdown
+                g_inputState.animationActive = false;
+            }
+        }
+        if (!any) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"no recognized args (position_x/y/z, yaw_deg, pitch_deg, zoom)\"}";
+        } else {
+            result = "{\"camera\":" + McpCameraJson() + "}";
+        }
+    } else if (strcmp(call->toolName, "orbit") == 0) {
+        double az = 0.0, el = 0.0;
+        bool hasAz = JsonGetNumber(a, "azimuth_deg", &az);
+        bool hasEl = JsonGetNumber(a, "elevation_deg", &el);
+        if (!hasAz && !hasEl) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"need azimuth_deg and/or elevation_deg\"}";
+        } else {
+            float yawDeg, pitchDeg;
+            {
+                std::lock_guard<std::mutex> lock(g_inputMutex);
+                g_inputState.yaw += (float)(az * kMcpDeg2Rad);
+                float p = g_inputState.pitch + (float)(el * kMcpDeg2Rad);
+                if (p > kMcpMaxPitchRad) p = kMcpMaxPitchRad;
+                if (p < -kMcpMaxPitchRad) p = -kMcpMaxPitchRad;
+                g_inputState.pitch = p;
+                g_inputState.transitioning = false;
+                g_inputState.lastInputTimeSec = McpNowSec();
+                g_inputState.animationActive = false;
+                yawDeg = g_inputState.yaw * kMcpRad2Deg;
+                pitchDeg = g_inputState.pitch * kMcpRad2Deg;
+            }
+            snprintf(buf, sizeof(buf), "{\"yaw_deg\":%.2f,\"pitch_deg\":%.2f}", yawDeg, pitchDeg);
+            result = buf;
+        }
+    } else if (strcmp(call->toolName, "reset_camera") == 0) {
+        {
+            std::lock_guard<std::mutex> lock(g_inputMutex);
+            g_inputState.resetViewRequested = true;  // applied by the render loop next frame
+        }
+        bool fitValid = g_fitValid.load();
+        snprintf(buf, sizeof(buf),
+            "{\"framed\":%s,\"position\":[%.4f,%.4f,%.4f],\"yaw_deg\":%.2f,"
+            "\"virtual_display_height_m\":%.4f}",
+            fitValid ? "true" : "false",
+            fitValid ? g_fitCenter[0] : 0.0f,
+            fitValid ? g_fitCenter[1] : 0.0f,
+            fitValid ? g_fitCenter[2] : 0.0f,
+            (fitValid ? g_fitYaw : 0.0f) * kMcpRad2Deg,
+            fitValid ? g_fitVHeight : kFallbackVirtualDisplayHeightM);
+        result = buf;
+    } else if (strcmp(call->toolName, "set_auto_orbit") == 0) {
+        bool enabled = false;
+        if (!JsonGetBool(a, "enabled", &enabled)) {
+            ok = XR_FALSE;
+            result = "{\"error\":\"missing required boolean arg 'enabled'\"}";
+        } else {
+            {
+                std::lock_guard<std::mutex> lock(g_inputMutex);
+                g_inputState.animateEnabled = enabled;
+                g_inputState.animationActive = false;
+                g_inputState.lastInputTimeSec = McpNowSec(); // don't snap-start on enable
+            }
+            result = enabled ? "{\"auto_orbit\":true}" : "{\"auto_orbit\":false}";
+        }
+    } else {
+        ok = XR_FALSE;
+        result = std::string("{\"error\":\"unhandled tool '") + call->toolName + "'\"}";
+    }
+
+    xr.pfnSubmitMCPToolResultEXT(xr.session, call->callId, ok, result.c_str());
 }
 
 // Fullscreen state
@@ -304,7 +635,7 @@ static bool QueueSceneLoad(HWND hwnd, const std::string& path) {
 //
 // Path A — workspace + Tier 1 picker available:
 //     xrRequestFilePickerDXR fires async. The completion event is drained
-//     by PollEvents (common/xr_session_common.cpp) into xr.filePickerLast*;
+//     by PollEventsGs (windows/xr_session.cpp) into xr.filePickerLast*;
 //     the main loop dispatches to QueueSceneLoad on result arrival.
 //
 // Path B — workspace mode but no controller / no Tier 1 picker, OR running
@@ -723,6 +1054,7 @@ static void RenderThreadFunc(
         }
 
         UpdatePerformanceStats(perfStats);
+        g_currentFps.store(perfStats.fps, std::memory_order_relaxed);
         UpdateCameraMovement(inputSnapshot, perfStats.deltaTime, xr->displayHeightM);
 
         // On Space-reset: shared UpdateCameraMovement returns to (0,0,0) + default
@@ -756,10 +1088,12 @@ static void RenderThreadFunc(
             }
         }
 
-        PollEvents(*xr);
+        // Demo-owned event pump (mirrors the shared PollEvents but dispatches
+        // this app's XR_DXR_mcp_tools tools via HandleAgentToolCall, #66).
+        PollEventsGs(*xr);
 
         // #228 Tier 1: drain a spatial-picker result if one arrived this
-        // tick. PollEvents wrote the path + result code onto the session
+        // tick. PollEventsGs wrote the path + result code onto the session
         // manager; we route it through the same QueueSceneLoad path the
         // Win32 GetOpenFileNameA branch uses. The render thread picks the
         // queued path up via g_pendingLoadPath.

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -211,9 +211,12 @@ static void ApplyAutoFitForLoadedScene_locked() {
 // ============================================================================
 //
 // Windows port of the macOS build's HandleMcpToolCall. RegisterAgentTools()
-// (windows/xr_session.cpp) declares the appId + tools; this runs a registered
-// tool call and answers it. It executes on the render thread (called from
-// PollEventsGs), so it mutates g_inputState under g_inputMutex and touches the
+// (windows/xr_session.cpp) declares the appId + tools and installs this as
+// xr.mcpToolHandler; displayxr-common's shared PollEvents (v2.1.0 / #18) then
+// fetches the call args, invokes this to map (toolName, argsJson) -> resultJson,
+// and submits the result — so this must NOT call xrGetMCPToolCallArgsDXR /
+// xrSubmitMCPToolResultDXR itself. It runs on the render thread (from
+// PollEvents), so it mutates g_inputState under g_inputMutex and touches the
 // renderer/scene state under g_sceneMutex — the same locks the render loop uses.
 // The tool set, descriptions, schemas, and result JSON key shapes are identical
 // to macOS (macos/main.mm).
@@ -359,32 +362,25 @@ static std::string McpCameraJson() {
     return buf;
 }
 
-void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* call) {
-    if (!xr.pfnSubmitMCPToolResultEXT) return;
+std::string HandleAgentToolCall(XrSessionManager& xr, const std::string& toolName,
+                                const std::string& argsJson, bool& success) {
+    // PollEvents already fetched the JSON args (empty string == no args) and
+    // will submit whatever we return. A no-arg tool gets ""; the flat-JSON
+    // helpers below simply find no keys, matching the old "{}" default.
+    const char* a = argsJson.c_str();
+    const char* toolName_c = toolName.c_str();
 
-    // Two-call idiom: the event's argsSize is the exact capacity needed
-    // (incl. NUL). A no-arg tool reports argsSize 0 — treat as "{}".
-    std::string args = "{}";
-    if (xr.pfnGetMCPToolCallArgsEXT && call->argsSize > 0) {
-        std::vector<char> buf(call->argsSize, '\0');
-        uint32_t needed = 0;
-        if (XR_SUCCEEDED(xr.pfnGetMCPToolCallArgsEXT(xr.session, call->callId,
-                (uint32_t)buf.size(), &needed, buf.data())))
-            args.assign(buf.data());
-    }
-    const char* a = args.c_str();
-
-    XrBool32 ok = XR_TRUE;
+    bool ok = true;
     std::string result;
     char buf[768];
 
-    if (strcmp(call->toolName, "load_splat") == 0) {
+    if (strcmp(toolName_c, "load_splat") == 0) {
         std::string path;
         if (!JsonGetString(a, "path", &path) || path.empty()) {
-            ok = XR_FALSE;
+            ok = false;
             result = "{\"error\":\"missing required string arg 'path'\"}";
         } else if (!ValidateSceneFile(path)) {
-            ok = XR_FALSE;
+            ok = false;
             result = "{\"error\":\"not a readable .ply/.spz scene: '" + JsonEscape(path) + "'\"}";
         } else {
             // On the render thread (same thread that drives per-frame Vulkan
@@ -392,7 +388,7 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
             // queued-load block: hold g_sceneMutex across loadScene + auto-fit.
             std::lock_guard<std::mutex> lock(g_sceneMutex);
             if (!g_gsRenderer.loadScene(path.c_str())) {
-                ok = XR_FALSE;
+                ok = false;
                 result = "{\"error\":\"failed to load '" + JsonEscape(path) + "' (corrupt or unsupported)\"}";
             } else {
                 g_loadedFileName = GetPlyFilename(path);
@@ -403,7 +399,7 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
                          g_loadedFileName.c_str(), g_gsRenderer.gaussianCount());
             }
         }
-    } else if (strcmp(call->toolName, "get_status") == 0) {
+    } else if (strcmp(toolName_c, "get_status") == 0) {
         const char* modeName = (xr.renderingModeCount > 0 &&
             xr.currentModeIndex < xr.renderingModeCount &&
             xr.renderingModeNames[xr.currentModeIndex][0] != '\0')
@@ -431,7 +427,7 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
             orbitingNow ? "true" : "false",
             xr.sessionRunning ? "true" : "false");
         result = "{\"file\":\"" + JsonEscape(g_loadedFileName) + buf;
-    } else if (strcmp(call->toolName, "set_camera") == 0) {
+    } else if (strcmp(toolName_c, "set_camera") == 0) {
         double v;
         bool any = false;
         {
@@ -460,17 +456,17 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
             }
         }
         if (!any) {
-            ok = XR_FALSE;
+            ok = false;
             result = "{\"error\":\"no recognized args (position_x/y/z, yaw_deg, pitch_deg, zoom)\"}";
         } else {
             result = "{\"camera\":" + McpCameraJson() + "}";
         }
-    } else if (strcmp(call->toolName, "orbit") == 0) {
+    } else if (strcmp(toolName_c, "orbit") == 0) {
         double az = 0.0, el = 0.0;
         bool hasAz = JsonGetNumber(a, "azimuth_deg", &az);
         bool hasEl = JsonGetNumber(a, "elevation_deg", &el);
         if (!hasAz && !hasEl) {
-            ok = XR_FALSE;
+            ok = false;
             result = "{\"error\":\"need azimuth_deg and/or elevation_deg\"}";
         } else {
             float yawDeg, pitchDeg;
@@ -490,7 +486,7 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
             snprintf(buf, sizeof(buf), "{\"yaw_deg\":%.2f,\"pitch_deg\":%.2f}", yawDeg, pitchDeg);
             result = buf;
         }
-    } else if (strcmp(call->toolName, "reset_camera") == 0) {
+    } else if (strcmp(toolName_c, "reset_camera") == 0) {
         {
             std::lock_guard<std::mutex> lock(g_inputMutex);
             g_inputState.resetViewRequested = true;  // applied by the render loop next frame
@@ -506,10 +502,10 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
             (fitValid ? g_fitYaw : 0.0f) * kMcpRad2Deg,
             fitValid ? g_fitVHeight : kFallbackVirtualDisplayHeightM);
         result = buf;
-    } else if (strcmp(call->toolName, "set_auto_orbit") == 0) {
+    } else if (strcmp(toolName_c, "set_auto_orbit") == 0) {
         bool enabled = false;
         if (!JsonGetBool(a, "enabled", &enabled)) {
-            ok = XR_FALSE;
+            ok = false;
             result = "{\"error\":\"missing required boolean arg 'enabled'\"}";
         } else {
             {
@@ -521,11 +517,12 @@ void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* 
             result = enabled ? "{\"auto_orbit\":true}" : "{\"auto_orbit\":false}";
         }
     } else {
-        ok = XR_FALSE;
-        result = std::string("{\"error\":\"unhandled tool '") + call->toolName + "'\"}";
+        ok = false;
+        result = std::string("{\"error\":\"unhandled tool '") + toolName + "'\"}";
     }
 
-    xr.pfnSubmitMCPToolResultEXT(xr.session, call->callId, ok, result.c_str());
+    success = ok;
+    return result;
 }
 
 // Fullscreen state
@@ -635,7 +632,7 @@ static bool QueueSceneLoad(HWND hwnd, const std::string& path) {
 //
 // Path A — workspace + Tier 1 picker available:
 //     xrRequestFilePickerDXR fires async. The completion event is drained
-//     by PollEventsGs (windows/xr_session.cpp) into xr.filePickerLast*;
+//     by the shared PollEvents (displayxr-common) into xr.filePickerLast*;
 //     the main loop dispatches to QueueSceneLoad on result arrival.
 //
 // Path B — workspace mode but no controller / no Tier 1 picker, OR running
@@ -1088,12 +1085,13 @@ static void RenderThreadFunc(
             }
         }
 
-        // Demo-owned event pump (mirrors the shared PollEvents but dispatches
-        // this app's XR_DXR_mcp_tools tools via HandleAgentToolCall, #66).
-        PollEventsGs(*xr);
+        // Shared event pump. XR_DXR_mcp_tools calls are dispatched to this
+        // app's HandleAgentToolCall via xr.mcpToolHandler (installed in
+        // RegisterAgentTools; displayxr-common v2.1.0 / #18, #66).
+        PollEvents(*xr);
 
         // #228 Tier 1: drain a spatial-picker result if one arrived this
-        // tick. PollEventsGs wrote the path + result code onto the session
+        // tick. PollEvents wrote the path + result code onto the session
         // manager; we route it through the same QueueSceneLoad path the
         // Win32 GetOpenFileNameA branch uses. The render thread picks the
         // queued path up via g_pendingLoadPath.

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -84,6 +84,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         if (strcmp(ext.extensionName, XR_DXR_VIEW_RIG_EXTENSION_NAME) == 0) {
             s_hasViewRigExt = true;
         }
+        if (strcmp(ext.extensionName, XR_DXR_MCP_TOOLS_EXTENSION_NAME) == 0) {
+            xr.hasMcpToolsExt = true;
+        }
     }
 
     LOG_INFO("XR_KHR_vulkan_enable: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
@@ -92,6 +95,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_DXR_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_atlas_capture: %s", xr.hasAtlasCaptureExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_view_rig: %s", s_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_DXR_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasVulkan) {
         LOG_ERROR("XR_KHR_vulkan_enable extension not available");
@@ -114,6 +118,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
     if (s_hasViewRigExt) {
         enabledExtensions.push_back(XR_DXR_VIEW_RIG_EXTENSION_NAME);
+    }
+    if (xr.hasMcpToolsExt) {
+        enabledExtensions.push_back(XR_DXR_MCP_TOOLS_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -211,6 +218,26 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         xrGetInstanceProcAddr(xr.instance, "xrCaptureAtlasDXR",
             (PFN_xrVoidFunction*)&xr.pfnCaptureAtlasEXT);
         LOG_INFO("xrCaptureAtlasDXR: %s", xr.pfnCaptureAtlasEXT ? "resolved" : "NULL");
+    }
+
+    // XR_DXR_mcp_tools (#66): resolve the agent-tool entry points. Defensive —
+    // any NULL leaves RegisterAgentTools()/PollEventsGs() inert, so the viewer
+    // runs identically when the extension or the MCP capability gate is absent.
+    // (The struct's PFN fields keep their historical EXT-suffixed NAMES; the
+    // TYPES + entry-point strings are the current DXR ones.)
+    if (xr.hasMcpToolsExt) {
+        xrGetInstanceProcAddr(xr.instance, "xrSetMCPAppInfoDXR",
+            (PFN_xrVoidFunction*)&xr.pfnSetMCPAppInfoEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrRegisterMCPToolDXR",
+            (PFN_xrVoidFunction*)&xr.pfnRegisterMCPToolEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrGetMCPToolCallArgsDXR",
+            (PFN_xrVoidFunction*)&xr.pfnGetMCPToolCallArgsEXT);
+        xrGetInstanceProcAddr(xr.instance, "xrSubmitMCPToolResultDXR",
+            (PFN_xrVoidFunction*)&xr.pfnSubmitMCPToolResultEXT);
+        LOG_INFO("XR_DXR_mcp_tools entry points: %s",
+            (xr.pfnSetMCPAppInfoEXT && xr.pfnRegisterMCPToolEXT &&
+             xr.pfnGetMCPToolCallArgsEXT && xr.pfnSubmitMCPToolResultEXT)
+                ? "resolved" : "NULL");
     }
 
     uint32_t viewCount = 0;
@@ -553,6 +580,222 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
                 }
             }
         }
+    }
+
+    // XR_DXR_mcp_tools (#66): declare app identity + register the agent tools
+    // now that the session exists. Inert (logs + returns) when the extension or
+    // MCP capability gate is absent.
+    RegisterAgentTools(xr);
+
+    return true;
+}
+
+// ============================================================================
+// Agent tools (XR_DXR_mcp_tools, #66) — Windows port of the macOS integration
+// ============================================================================
+//
+// The viewer's controls are registered as MCP tools on the per-process MCP
+// server the runtime hosts; agents reach them via the displayxr-mcp adapter.
+// Registration is declared here (per-app appId + static tool schemas); the
+// per-call dispatch lives in main.cpp (HandleAgentToolCall), where the app's
+// live viewer state — renderer, camera rig, fit pose — is reachable.
+//
+// NOTE ON THE EVENT PUMP: displayxr-common's shared PollEvents() answers the
+// MCP tool-call event with a hardcoded cube tool set (set_spin/get_status) and
+// replies "unhandled tool" for anything else, so this demo cannot route its own
+// tools through it. Instead main.cpp drives PollEventsGs() (below) — a faithful
+// copy of the shared PollEvents that delegates the MCP case to this app's
+// HandleAgentToolCall(). This mirrors the macOS build, which likewise owns its
+// event loop. Re-sync PollEventsGs() if the shared PollEvents event handling
+// changes.
+
+// The appId MUST equal the manifest `id` (linter INV-10.1):
+// windows/displayxr/gaussian_splatting_handle_vk_win.displayxr.json → "gaussiansplat".
+static const char* kMcpAppId = "gaussiansplat";
+
+void RegisterAgentTools(XrSessionManager& xr) {
+    if (!xr.hasMcpToolsExt || !xr.pfnSetMCPAppInfoEXT || !xr.pfnRegisterMCPToolEXT ||
+        !xr.pfnGetMCPToolCallArgsEXT || !xr.pfnSubmitMCPToolResultEXT) {
+        return; // no agent surface — viewer runs identically
+    }
+
+    XrMCPAppInfoDXR appInfo = {XR_TYPE_MCP_APP_INFO_DXR};
+    strncpy(appInfo.appId, kMcpAppId, sizeof(appInfo.appId) - 1);
+    XrResult ar = xr.pfnSetMCPAppInfoEXT(xr.session, &appInfo);
+    if (XR_FAILED(ar)) {
+        // XR_ERROR_FEATURE_UNSUPPORTED = MCP capability gate off — expected.
+        LOG_INFO("xrSetMCPAppInfoDXR('%s'): %d — no agent surface", kMcpAppId, (int)ar);
+        return;
+    }
+
+    auto reg = [&](const char* name, const char* desc, const char* schema) {
+        XrMCPToolInfoDXR tool = {XR_TYPE_MCP_TOOL_INFO_DXR};
+        tool.name = name;
+        tool.description = desc;
+        tool.inputSchemaJson = schema;
+        XrResult tr = xr.pfnRegisterMCPToolEXT(xr.session, &tool);
+        if (XR_FAILED(tr)) LOG_WARN("xrRegisterMCPToolDXR('%s') failed: %d", name, (int)tr);
+    };
+
+    // Descriptions + schemas are copied verbatim from the macOS build so the
+    // agent-facing contract is identical across platforms.
+    reg("load_splat",
+        "Load a Gaussian-splat scene from a file path (.ply or .spz), replacing the "
+        "currently loaded scene and auto-framing the camera on the main object. "
+        "Returns the loaded file and its splat count; an error result if the file "
+        "cannot be read or parsed.",
+        "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\","
+        "\"description\":\"Path to the .ply or .spz scene file (absolute recommended).\"}},"
+        "\"required\":[\"path\"]}");
+
+    reg("get_status",
+        "Read the viewer's live state: loaded scene file and splat count, frames per "
+        "second, camera pose (world position in meters, yaw/pitch in degrees, zoom), "
+        "virtual display height in meters, active rendering mode, transparent-background "
+        "and auto-orbit flags, and whether the XR session is running. Requires no "
+        "arguments.",
+        "{\"type\":\"object\"}");
+
+    reg("set_camera",
+        "Set camera pose components absolutely; give any subset of the arguments and "
+        "the rest stay unchanged. position_x/y/z move the camera rig in world meters; "
+        "yaw_deg/pitch_deg aim it (pitch clamps to about +/-86 deg); zoom scales the "
+        "scene (1 = default, larger zooms in, minimum 0.1). Takes effect on the next "
+        "frame and is visually verifiable via capture_frame. Returns the applied "
+        "camera state.",
+        "{\"type\":\"object\",\"properties\":{"
+        "\"position_x\":{\"type\":\"number\"},"
+        "\"position_y\":{\"type\":\"number\"},"
+        "\"position_z\":{\"type\":\"number\"},"
+        "\"yaw_deg\":{\"type\":\"number\"},"
+        "\"pitch_deg\":{\"type\":\"number\"},"
+        "\"zoom\":{\"type\":\"number\",\"minimum\":0.1}}}");
+
+    reg("orbit",
+        "Rotate the camera by a relative amount: azimuth_deg yaws around the vertical "
+        "axis (positive matches the idle auto-orbit direction); elevation_deg tilts the "
+        "view up (positive) or down, clamped to about +/-86 deg. At least one argument "
+        "is required. Returns the new absolute yaw/pitch in degrees.",
+        "{\"type\":\"object\",\"properties\":{"
+        "\"azimuth_deg\":{\"type\":\"number\",\"description\":\"Relative yaw in degrees.\"},"
+        "\"elevation_deg\":{\"type\":\"number\",\"description\":\"Relative pitch in degrees.\"}}}");
+
+    reg("reset_camera",
+        "Reset the camera to the auto-framed pose of the loaded scene (or the world "
+        "origin if none is loaded): recenters position, levels pitch, restores default "
+        "zoom and depth. Applied on the next frame. Returns the pose being restored.",
+        "{\"type\":\"object\"}");
+
+    reg("set_auto_orbit",
+        "Enable or disable the idle auto-orbit turntable (when enabled, the view slowly "
+        "yaws after 10 seconds without input). Disable it before scripted camera moves "
+        "or captures that must hold still. Returns the new state.",
+        "{\"type\":\"object\",\"properties\":{\"enabled\":{\"type\":\"boolean\"}},"
+        "\"required\":[\"enabled\"]}");
+
+    LOG_INFO("Agent tools registered (appId=%s)", kMcpAppId);
+}
+
+bool PollEventsGs(XrSessionManager& xr) {
+    // Faithful copy of displayxr-common PollEvents() with the MCP tool-call case
+    // delegated to this app's HandleAgentToolCall() (see the NOTE above for why
+    // the shared PollEvents cannot be reused for app-specific tools).
+    XrEventDataBuffer event = {XR_TYPE_EVENT_DATA_BUFFER};
+
+    while (xrPollEvent(xr.instance, &event) == XR_SUCCESS) {
+        switch (event.type) {
+        case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
+            auto* stateEvent = (XrEventDataSessionStateChanged*)&event;
+            XrSessionState oldState = xr.sessionState;
+            xr.sessionState = stateEvent->state;
+
+            LOG_INFO("Session state changed: %s -> %s",
+                GetSessionStateString(oldState),
+                GetSessionStateString(xr.sessionState));
+
+            switch (xr.sessionState) {
+            case XR_SESSION_STATE_READY: {
+                LOG_INFO("Session READY - calling xrBeginSession...");
+                XrSessionBeginInfo beginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
+                beginInfo.primaryViewConfigurationType = xr.viewConfigType;
+                XrResult result = xrBeginSession(xr.session, &beginInfo);
+                LogXrResult("xrBeginSession", result);
+                if (XR_SUCCEEDED(result)) {
+                    xr.sessionRunning = true;
+                    LOG_INFO("Session is now running");
+                }
+                break;
+            }
+            case XR_SESSION_STATE_STOPPING:
+                LOG_INFO("Session STOPPING - calling xrEndSession...");
+                xrEndSession(xr.session);
+                xr.sessionRunning = false;
+                LOG_INFO("Session stopped");
+                break;
+            case XR_SESSION_STATE_EXITING:
+                LOG_INFO("Session EXITING - requesting exit");
+                xr.exitRequested = true;
+                break;
+            case XR_SESSION_STATE_LOSS_PENDING:
+                LOG_WARN("Session LOSS_PENDING - requesting exit");
+                xr.exitRequested = true;
+                break;
+            default:
+                break;
+            }
+            break;
+        }
+        case XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING:
+            LOG_WARN("Instance loss pending - requesting exit");
+            xr.exitRequested = true;
+            break;
+        case (XrStructureType)XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_DXR: {
+            auto* modeEvent = (XrEventDataRenderingModeChangedDXR*)&event;
+            LOG_INFO("Rendering mode changed: %u -> %u",
+                modeEvent->previousModeIndex, modeEvent->currentModeIndex);
+            xr.currentModeIndex = modeEvent->currentModeIndex;
+            break;
+        }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_DXR: {
+            auto* etEvent = (XrEventDataEyeTrackingStateChangedDXR*)&event;
+            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
+                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
+                (uint32_t)etEvent->activeMode);
+            xr.isEyeTracking = (etEvent->isTracking == XR_TRUE);
+            xr.activeEyeTrackingMode = (uint32_t)etEvent->activeMode;
+            break;
+        }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_DXR: {
+            auto* pickEvent = (XrEventDataFilePickerCompleteDXR*)&event;
+            if (pickEvent->requestId == xr.filePickerRequestId) {
+                xr.filePickerLastResult = pickEvent->result;
+                strncpy(xr.filePickerLastPath, pickEvent->path, sizeof(xr.filePickerLastPath) - 1);
+                xr.filePickerLastPath[sizeof(xr.filePickerLastPath) - 1] = '\0';
+                xr.filePickerInFlight = false;
+                xr.filePickerHasResult = true;
+                LOG_INFO("[#228] File picker complete: requestId=%llu result=%d path=\"%s\"",
+                    (unsigned long long)pickEvent->requestId,
+                    (int)pickEvent->result,
+                    pickEvent->path);
+            } else {
+                LOG_WARN("[#228] Ignoring file picker event for stale requestId=%llu (current=%llu)",
+                    (unsigned long long)pickEvent->requestId,
+                    (unsigned long long)xr.filePickerRequestId);
+            }
+            break;
+        }
+        case (XrStructureType)XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_DXR: {
+            // Agent invoked one of our registered tools — dispatch to the
+            // app-state-aware handler in main.cpp. Only apps that registered
+            // tools ever receive this event.
+            HandleAgentToolCall(xr, (const XrEventDataMCPToolCallDXR*)&event);
+            break;
+        }
+        default:
+            LOG_DEBUG("Received event type: %d", event.type);
+            break;
+        }
+        event = {XR_TYPE_EVENT_DATA_BUFFER};
     }
 
     return true;

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -221,8 +221,9 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     }
 
     // XR_DXR_mcp_tools (#66): resolve the agent-tool entry points. Defensive —
-    // any NULL leaves RegisterAgentTools()/PollEventsGs() inert, so the viewer
-    // runs identically when the extension or the MCP capability gate is absent.
+    // any NULL leaves RegisterAgentTools() (and thus the shared PollEvents' MCP
+    // dispatch) inert, so the viewer runs identically when the extension or the
+    // MCP capability gate is absent.
     // (The struct's PFN fields keep their historical EXT-suffixed NAMES; the
     // TYPES + entry-point strings are the current DXR ones.)
     if (xr.hasMcpToolsExt) {
@@ -600,14 +601,13 @@ bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice
 // per-call dispatch lives in main.cpp (HandleAgentToolCall), where the app's
 // live viewer state — renderer, camera rig, fit pose — is reachable.
 //
-// NOTE ON THE EVENT PUMP: displayxr-common's shared PollEvents() answers the
-// MCP tool-call event with a hardcoded cube tool set (set_spin/get_status) and
-// replies "unhandled tool" for anything else, so this demo cannot route its own
-// tools through it. Instead main.cpp drives PollEventsGs() (below) — a faithful
-// copy of the shared PollEvents that delegates the MCP case to this app's
-// HandleAgentToolCall(). This mirrors the macOS build, which likewise owns its
-// event loop. Re-sync PollEventsGs() if the shared PollEvents event handling
-// changes.
+// NOTE ON THE EVENT PUMP: displayxr-common v2.1.0 (#18) added an app-supplied
+// hook — XrSessionManager::mcpToolHandler — that the shared PollEvents invokes
+// for every XrEventDataMCPToolCallDXR (PollEvents fetches the args and submits
+// the result; the handler just maps name+args -> JSON). RegisterAgentTools()
+// installs HandleAgentToolCall() there, so this demo no longer forks PollEvents
+// (the old PollEventsGs copy is gone) and the main loop drives the shared
+// PollEvents() directly.
 
 // The appId MUST equal the manifest `id` (linter INV-10.1):
 // windows/displayxr/gaussian_splatting_handle_vk_win.displayxr.json → "gaussiansplat".
@@ -693,110 +693,13 @@ void RegisterAgentTools(XrSessionManager& xr) {
         "{\"type\":\"object\",\"properties\":{\"enabled\":{\"type\":\"boolean\"}},"
         "\"required\":[\"enabled\"]}");
 
+    // Install the app's tool-call handler on the shared PollEvents hook
+    // (displayxr-common v2.1.0 / #18). PollEvents fetches args + submits the
+    // result; HandleAgentToolCall only maps (toolName, argsJson) -> resultJson.
+    xr.mcpToolHandler = [&xr](const std::string& toolName,
+                              const std::string& argsJson, bool& success) {
+        return HandleAgentToolCall(xr, toolName, argsJson, success);
+    };
+
     LOG_INFO("Agent tools registered (appId=%s)", kMcpAppId);
-}
-
-bool PollEventsGs(XrSessionManager& xr) {
-    // Faithful copy of displayxr-common PollEvents() with the MCP tool-call case
-    // delegated to this app's HandleAgentToolCall() (see the NOTE above for why
-    // the shared PollEvents cannot be reused for app-specific tools).
-    XrEventDataBuffer event = {XR_TYPE_EVENT_DATA_BUFFER};
-
-    while (xrPollEvent(xr.instance, &event) == XR_SUCCESS) {
-        switch (event.type) {
-        case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
-            auto* stateEvent = (XrEventDataSessionStateChanged*)&event;
-            XrSessionState oldState = xr.sessionState;
-            xr.sessionState = stateEvent->state;
-
-            LOG_INFO("Session state changed: %s -> %s",
-                GetSessionStateString(oldState),
-                GetSessionStateString(xr.sessionState));
-
-            switch (xr.sessionState) {
-            case XR_SESSION_STATE_READY: {
-                LOG_INFO("Session READY - calling xrBeginSession...");
-                XrSessionBeginInfo beginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
-                beginInfo.primaryViewConfigurationType = xr.viewConfigType;
-                XrResult result = xrBeginSession(xr.session, &beginInfo);
-                LogXrResult("xrBeginSession", result);
-                if (XR_SUCCEEDED(result)) {
-                    xr.sessionRunning = true;
-                    LOG_INFO("Session is now running");
-                }
-                break;
-            }
-            case XR_SESSION_STATE_STOPPING:
-                LOG_INFO("Session STOPPING - calling xrEndSession...");
-                xrEndSession(xr.session);
-                xr.sessionRunning = false;
-                LOG_INFO("Session stopped");
-                break;
-            case XR_SESSION_STATE_EXITING:
-                LOG_INFO("Session EXITING - requesting exit");
-                xr.exitRequested = true;
-                break;
-            case XR_SESSION_STATE_LOSS_PENDING:
-                LOG_WARN("Session LOSS_PENDING - requesting exit");
-                xr.exitRequested = true;
-                break;
-            default:
-                break;
-            }
-            break;
-        }
-        case XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING:
-            LOG_WARN("Instance loss pending - requesting exit");
-            xr.exitRequested = true;
-            break;
-        case (XrStructureType)XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_DXR: {
-            auto* modeEvent = (XrEventDataRenderingModeChangedDXR*)&event;
-            LOG_INFO("Rendering mode changed: %u -> %u",
-                modeEvent->previousModeIndex, modeEvent->currentModeIndex);
-            xr.currentModeIndex = modeEvent->currentModeIndex;
-            break;
-        }
-        case (XrStructureType)XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_DXR: {
-            auto* etEvent = (XrEventDataEyeTrackingStateChangedDXR*)&event;
-            LOG_INFO("Eye tracking state changed: isTracking=%s mode=%u",
-                etEvent->isTracking == XR_TRUE ? "YES" : "NO",
-                (uint32_t)etEvent->activeMode);
-            xr.isEyeTracking = (etEvent->isTracking == XR_TRUE);
-            xr.activeEyeTrackingMode = (uint32_t)etEvent->activeMode;
-            break;
-        }
-        case (XrStructureType)XR_TYPE_EVENT_DATA_FILE_PICKER_COMPLETE_DXR: {
-            auto* pickEvent = (XrEventDataFilePickerCompleteDXR*)&event;
-            if (pickEvent->requestId == xr.filePickerRequestId) {
-                xr.filePickerLastResult = pickEvent->result;
-                strncpy(xr.filePickerLastPath, pickEvent->path, sizeof(xr.filePickerLastPath) - 1);
-                xr.filePickerLastPath[sizeof(xr.filePickerLastPath) - 1] = '\0';
-                xr.filePickerInFlight = false;
-                xr.filePickerHasResult = true;
-                LOG_INFO("[#228] File picker complete: requestId=%llu result=%d path=\"%s\"",
-                    (unsigned long long)pickEvent->requestId,
-                    (int)pickEvent->result,
-                    pickEvent->path);
-            } else {
-                LOG_WARN("[#228] Ignoring file picker event for stale requestId=%llu (current=%llu)",
-                    (unsigned long long)pickEvent->requestId,
-                    (unsigned long long)xr.filePickerRequestId);
-            }
-            break;
-        }
-        case (XrStructureType)XR_TYPE_EVENT_DATA_MCP_TOOL_CALL_DXR: {
-            // Agent invoked one of our registered tools — dispatch to the
-            // app-state-aware handler in main.cpp. Only apps that registered
-            // tools ever receive this event.
-            HandleAgentToolCall(xr, (const XrEventDataMCPToolCallDXR*)&event);
-            break;
-        }
-        default:
-            LOG_DEBUG("Received event type: %d", event.type);
-            break;
-        }
-        event = {XR_TYPE_EVENT_DATA_BUFFER};
-    }
-
-    return true;
 }

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -50,19 +50,19 @@ bool CreateVulkanDevice(VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
 bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice physDevice,
     VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, HWND hwnd);
 
-// XR_DXR_mcp_tools (#66): declare the app's identity + register its agent tools
-// on the per-process MCP server the runtime hosts. Called by CreateSession once
-// the session exists; inert when the extension / MCP capability gate is absent.
+// XR_DXR_mcp_tools (#66): declare the app's identity, register its agent tools
+// on the per-process MCP server the runtime hosts, and install the app's MCP
+// tool-call handler on xr.mcpToolHandler (consumed by displayxr-common's shared
+// PollEvents, v2.1.0 / common #18). Called by CreateSession once the session
+// exists; inert when the extension / MCP capability gate is absent.
 void RegisterAgentTools(XrSessionManager& xr);
 
-// Demo-owned event pump — a faithful copy of displayxr-common's PollEvents that
-// delegates the XR_DXR_mcp_tools tool-call event to HandleAgentToolCall (the
-// shared PollEvents hardcodes the cube tool set and can't dispatch app tools).
-// The main render loop calls this INSTEAD of the shared PollEvents.
-bool PollEventsGs(XrSessionManager& xr);
-
-// Dispatch one agent tool call and answer it. Defined in windows/main.cpp, where
-// the app's live viewer state (renderer, camera rig, fit pose) is reachable.
-// Runs on the render thread (from PollEventsGs), so it touches shared state under
-// the same mutexes the render loop uses.
-void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* call);
+// Map one agent tool call (name + JSON args) to its JSON result. Defined in
+// windows/main.cpp, where the app's live viewer state (renderer, camera rig,
+// fit pose) is reachable. Installed as xr.mcpToolHandler by RegisterAgentTools
+// and invoked by the shared PollEvents on the render thread, so it touches
+// shared state under the same mutexes the render loop uses. It must NOT call
+// xrGetMCPToolCallArgsDXR / xrSubmitMCPToolResultDXR — PollEvents does both.
+// Set `success` false to fail the call to the agent; return the result payload.
+std::string HandleAgentToolCall(XrSessionManager& xr, const std::string& toolName,
+                                const std::string& argsJson, bool& success);

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -49,3 +49,20 @@ bool CreateVulkanDevice(VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
 // Create OpenXR session with Vulkan binding + win32_window_binding
 bool CreateSession(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice physDevice,
     VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, HWND hwnd);
+
+// XR_DXR_mcp_tools (#66): declare the app's identity + register its agent tools
+// on the per-process MCP server the runtime hosts. Called by CreateSession once
+// the session exists; inert when the extension / MCP capability gate is absent.
+void RegisterAgentTools(XrSessionManager& xr);
+
+// Demo-owned event pump — a faithful copy of displayxr-common's PollEvents that
+// delegates the XR_DXR_mcp_tools tool-call event to HandleAgentToolCall (the
+// shared PollEvents hardcodes the cube tool set and can't dispatch app tools).
+// The main render loop calls this INSTEAD of the shared PollEvents.
+bool PollEventsGs(XrSessionManager& xr);
+
+// Dispatch one agent tool call and answer it. Defined in windows/main.cpp, where
+// the app's live viewer state (renderer, camera rig, fit pose) is reachable.
+// Runs on the render thread (from PollEventsGs), so it touches shared state under
+// the same mutexes the render loop uses.
+void HandleAgentToolCall(XrSessionManager& xr, const XrEventDataMCPToolCallDXR* call);


### PR DESCRIPTION
Closes #66.

Ports the macOS build's `XR_DXR_mcp_tools` (app-defined agent/MCP tools) integration to the Windows Vulkan build, so the Gaussian-splat demo exposes a voice/agent control surface under the Windows shell. Mirrors `macos/main.mm` and the mediaplayer demo's adoption (`displayxr-demo-mediaplayer/src/xr/XrSession.cpp`).

## Tools ported (appId `gaussiansplat`)
Same set, names, descriptions, and JSON schemas as macOS (copied verbatim):

| Tool | Args | Windows state it drives |
|---|---|---|
| `load_splat` | `path` (string) | `g_gsRenderer.loadScene()` + auto-fit; returns file + `splat_count` |
| `get_status` | — | renderer (`hasScene`/`gaussianCount`), `g_currentFps`, camera pose, vHeight, active rendering mode, transparent-bg + auto-orbit flags, session-running |
| `set_camera` | `position_x/y/z`, `yaw_deg`, `pitch_deg`, `zoom` | `g_inputState` camera rig (pitch clamp ±~86°, zoom min 0.1) |
| `orbit` | `azimuth_deg`, `elevation_deg` | relative yaw/pitch on `g_inputState` |
| `reset_camera` | — | sets `resetViewRequested` (render loop restores auto-fit pose) |
| `set_auto_orbit` | `enabled` (bool) | `g_inputState.animateEnabled` idle turntable |

Result JSON key shapes are identical to macOS.

## Wiring
- **Extension enable + PFN resolution** — `windows/xr_session.cpp` `InitializeOpenXR` detects `XR_DXR_mcp_tools`, enables it at `xrCreateInstance`, and resolves the 4 DXR entry points into the (historically EXT-named) `XrSessionManager` PFN fields. Defensive: any NULL leaves registration + dispatch inert.
- **Registration** — `RegisterAgentTools()` calls `xrSetMCPAppInfoDXR("gaussiansplat")` + registers the 6 tools after session creation (from `CreateSession`).
- **Event dispatch** — `HandleAgentToolCall()` (in `windows/main.cpp`, where the live viewer state lives) fetches args via the two-call idiom and answers via `xrSubmitMCPToolResultDXR`.

## One structural note (why a demo-owned event pump)
displayxr-common v2.0.0's shared `PollEvents()` hardcodes the **cube** reference tool set (`set_spin`/`get_status`) and replies `"unhandled tool"` for anything else — it has no app-handler hook, so this demo's tools cannot route through it. The demo therefore drives `PollEventsGs()` — a faithful copy of the shared `PollEvents` that delegates only the MCP tool-call case to `HandleAgentToolCall`. This is the same "app owns its event loop" shape macOS already uses. `PollEventsGs()` must be re-synced if the shared event handling changes (noted in-code).

## Correctness / portability
- MSVC/Win32-clean C++17; no POSIX-only calls, nothing behind `#ifdef __APPLE__`.
- No-op when the extension / MCP capability gate is absent.
- Handler runs on the render thread (from `PollEventsGs`), so `loadScene()` is safe and shared state is touched under the render loop's existing `g_inputMutex` / `g_sceneMutex` (lock order preserved: scene → input).
- Manifest `id` already equals appId `gaussiansplat` (INV-10.1) — no manifest change needed; `check_displayxr_app.py` clean.

## Not verified
Cannot compile the Windows build on this macOS host (no MSVC/Vulkan/WIL). Structurally matched to the mediaplayer + macOS references; relies on the repo's Windows CI to compile-check.

## Wiring gaps / TODOs
- `get_status` FPS is published via a new `g_currentFps` atomic (the render thread's `PerformanceStats` is loop-local); value is a ~1 s rolling average, same as the HUD.
- `PollEventsGs` duplicates the shared `PollEvents` state machine — a follow-up could add an app-supplied MCP handler hook to displayxr-common and drop the copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)