### PR TITLE
feat(linux): default the Linux gauss leg to the graphics-pipeline renderer

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -62,6 +62,23 @@ target_link_libraries(gaussian_splatting_handle_vk_linux PRIVATE
     ${CMAKE_DL_LIBS}
 )
 
+# Splat renderer selection (mirrors windows/CMakeLists.txt, but the Linux leg
+# DEFAULTS TO GRAPHICS). The Linux target is the integrated-Intel-GPU (tile-based
+# Xe) path, where the graphics-pipeline renderer (GsAdrenoRenderer: splat.vert/
+# splat.frag) is the right fit — and the desktop head-to-head showed it also wins
+# on immediate-mode GPUs (cheaper radix sort: sorts N gaussians, not N×8
+# fragments). Note gs_renderer_select.h's own default on desktop x86_64 is
+# COMPUTE, so this GRAPHICS default is what flips the Linux leg to the graphics
+# shaders. Override with -DGS_RENDERER=COMPUTE (legacy) or AUTO (selector default).
+set(GS_RENDERER "GRAPHICS" CACHE STRING "Splat renderer: AUTO | COMPUTE | GRAPHICS (Linux default: GRAPHICS)")
+set_property(CACHE GS_RENDERER PROPERTY STRINGS AUTO COMPUTE GRAPHICS)
+if(GS_RENDERER STREQUAL "GRAPHICS")
+    target_compile_definitions(gaussian_splatting_handle_vk_linux PRIVATE GS_RENDERER_GRAPHICS=1)
+elseif(GS_RENDERER STREQUAL "COMPUTE")
+    target_compile_definitions(gaussian_splatting_handle_vk_linux PRIVATE GS_RENDERER_COMPUTE=1)
+endif()
+message(STATUS "gaussian_splatting_handle_vk_linux splat renderer: ${GS_RENDERER}")
+
 # Copy bundled default scene next to the exe (auto-loaded at startup). Shared
 # with the macОS leg — no need to duplicate the 3.9 MB asset under linux/.
 set(BUNDLED_SCENE "${CMAKE_SOURCE_DIR}/macos/assets/butterfly.spz")

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -646,8 +646,16 @@ int main(int argc, char** argv) {
       if (g_gsRenderer.loadScene(scene.c_str()))
           LOG_INFO("Loaded scene: %s (%u gaussians)", scene.c_str(), g_gsRenderer.gaussianCount());
       else {
+#if defined(GS_RENDERER_COMPUTE)
+          // Debug-scene fallback exists only on the compute renderer (GsRenderer).
           LOG_WARN("No scene at %s — loading debug splat", scene.c_str());
           g_gsRenderer.loadDebugScene(0.0f, 0.0f, 0.0f, 0.1f);
+#else
+          // Graphics renderer (GsAdrenoRenderer, the Linux default) has no
+          // loadDebugScene — it renders from a loaded .spz/.ply only.
+          LOG_ERROR("No scene at %s and the graphics renderer has no debug-scene "
+                    "fallback — pass a .spz/.ply path or bundle butterfly.spz", scene.c_str());
+#endif
       } }
 
     LOG_INFO("=== Entering main loop (auto-orbit; Ctrl+C to quit) ===");


### PR DESCRIPTION
## Default the Linux gauss leg to the graphics-pipeline renderer

The Linux target (issue #60) built the **compute** splat renderer (`GsRenderer`) by default. The intended Linux deployment is a desktop with an **integrated Intel GPU** (tile-based Xe), where the **graphics-pipeline** renderer (`GsAdrenoRenderer`: `splat.vert`/`splat.frag`) is the better fit — and the earlier desktop head-to-head showed it also wins on immediate-mode GPUs (radix sort is ~12× cheaper: it sorts N gaussians, not N×8 expanded fragments).

### Changes (Linux-only)
- **`linux/CMakeLists.txt`** — add the `GS_RENDERER` knob (`AUTO`|`COMPUTE`|`GRAPHICS`), mirroring `windows/CMakeLists.txt`, but **defaulting to `GRAPHICS`** for the Linux leg. Override with `-DGS_RENDERER=COMPUTE` (legacy) or `AUTO` (selector default).
- **`linux/main.cpp`** — guard the `loadDebugScene()` fallback behind `GS_RENDERER_COMPUTE`. `GsAdrenoRenderer` has no debug-scene (same as the macOS graphics leg); this was a latent compute-only call that only surfaced once graphics was selected.

**Windows / macOS / Android defaults are unchanged** — Windows stays `AUTO`.

### Verification
Built on WSL Ubuntu 26.04 (GCC 15.2, Vulkan 1.4.341) against DisplayXR v2.0.x:
- Configures with `-- gaussian_splatting_handle_vk_linux splat renderer: GRAPHICS`
- Compiles + links `gaussian_splatting_handle_vk_linux` (graphics path: `GsActiveRenderer == GsAdrenoRenderer`, `splat.vert`/`splat.frag` → SPIR-V)

On-screen run requires a real GPU + display (WSL's llvmpipe lacks the external semaphore/fence-FD interop the compositor↔app handoff needs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
