### PR TITLE
build(linux): demo .deb + CI publish (runtime #781 Phase 3)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,6 +21,14 @@ on:
       - 'linux'
       - 'linux-**'
       - 'feature/linux-**'
+    # Release tags: the Deb job attaches the demo .deb to the GitHub Release
+    # (the Linux meta-bundle fetches it — runtime #781 Phase 3).
+    tags:
+      - 'v*'
+
+# The Deb job attaches release assets on tags.
+permissions:
+  contents: write
 
 # Cancel any in-progress run for the same PR (or branch) when a new
 # push comes in. Only the latest commit's CI completes.
@@ -114,3 +122,56 @@ jobs:
         run: |
           test -x build/linux/gaussian_splatting_handle_vk_linux || {
             echo "::error::gaussian_splatting_handle_vk_linux was not produced"; exit 1; }
+
+  # Build the demo .deb and, on a v* tag, attach it to the GitHub Release — the
+  # asset the Linux meta-bundle fetches (runtime #781 Phase 3). Runs on every PR
+  # too (build-only) so a broken package_deb_linux.sh is caught before release.
+  # Single base (ubuntu-latest) on a VM, not the build matrix — one artifact.
+  Deb:
+    needs: DetectChanges
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.DetectChanges.outputs.docs_only == 'true'
+        run: echo "Doc-only change — skipping .deb build."
+
+      - uses: actions/checkout@v5
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        with:
+          fetch-depth: 0 # git describe needs tags for the .deb version
+
+      - name: Install dependencies
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake ninja-build pkg-config \
+            libvulkan-dev vulkan-validationlayers glslang-tools \
+            zlib1g-dev \
+            libx11-dev libxcb1-dev libx11-xcb-dev \
+            libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
+            libwayland-dev libxkbcommon-dev libegl1-mesa-dev libasound2-dev \
+            libxxf86vm-dev libxcb-glx0-dev \
+            dpkg-dev fakeroot
+
+      - name: Build + package the demo .deb
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          ./scripts/package_deb_linux.sh
+          ls -lh dist/*.deb
+
+      - name: Upload .deb artifact
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: displayxr-gaussiansplat-deb
+          path: dist/*.deb
+          if-no-files-found: error
+
+      - name: Attach .deb to the GitHub Release (tags only)
+        if: needs.DetectChanges.outputs.docs_only != 'true' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.deb
+          fail_on_unmatched_files: true

--- a/scripts/package_deb_linux.sh
+++ b/scripts/package_deb_linux.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Package the Linux demo as a Debian package (.deb) — runtime #781 Phase 3
+# (demo installers). Companion to build_linux.sh: builds the demo (if needed)
+# then wraps the binary + its OpenXR loader + assets into an installable .deb.
+#
+#   ./scripts/package_deb_linux.sh            # build (if needed) + package
+#   ./scripts/package_deb_linux.sh --no-build # package an existing build/
+#
+# Output: dist/<pkg>_<ver>_<arch>.deb
+#
+# Payload (installed layout):
+#   /usr/lib/displayxr-demos/<app>/<binary>          the demo executable
+#   /usr/lib/displayxr-demos/<app>/libopenxr_loader.so*  bundled OpenXR loader
+#   /usr/lib/displayxr-demos/<app>/butterfly.spz     bundled sample scene
+#   /usr/bin/<pkg>                                    launcher wrapper (on PATH)
+#   /usr/share/applications/<pkg>.desktop            menu entry
+#
+# The demo is an OpenXR app → Depends: displayxr-runtime. With the runtime .deb
+# installed, the loader resolves the runtime via /etc/xdg/openxr/1/active_runtime.json
+# automatically — no env vars. The wrapper sets LD_LIBRARY_PATH for the bundled
+# loader and OXR_ENABLE_VK_NATIVE_COMPOSITOR=1 (Linux vk_native path).
+#
+# --- Per-demo config (the ONLY part that differs between demos) -------------
+APP="gauss"                                         # short id (dir + component)
+PKG="displayxr-gaussiansplat"                       # .deb package + wrapper name
+REPO_SLUG="displayxr-demo-gaussiansplat"            # GitHub repo (Homepage)
+DISPLAY_NAME="DisplayXR Gaussian Splat Viewer"
+DESCRIPTION="Real-time 3D Gaussian splat (.spz/.ply) viewer for glasses-free 3D displays."
+BINARY="gaussian_splatting_handle_vk_linux"         # build/linux/<BINARY>
+DESKTOP_CATEGORIES="Graphics;Viewer;"
+# The demo auto-loads a scene from its own executable directory (ExecutableDir()
+# → butterfly.spz next to the binary), NOT an assets/ subdir — so we bundle the
+# single sample scene file directly beside the binary rather than a dir tree.
+SCENE_FILE="macos/assets/butterfly.spz"             # repo-relative sample, "" if none
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
+DIST_DIR="${DIST_DIR:-$ROOT/dist}"
+OPENXR_DIR="${OPENXR_DIR:-/tmp/openxr-install}"
+
+NO_BUILD=0
+for a in "$@"; do case "$a" in
+  --no-build) NO_BUILD=1 ;;
+  *) echo "Unknown option: $a (supported: --no-build)" >&2; exit 2 ;;
+esac; done
+
+command -v dpkg-deb >/dev/null 2>&1 || { echo "error: dpkg-deb not found — Debian/Ubuntu host/container only." >&2; exit 1; }
+
+BIN="$BUILD_DIR/linux/$BINARY"
+if [ ! -x "$BIN" ]; then
+  [ "$NO_BUILD" = 0 ] || { echo "error: $BIN not built and --no-build set." >&2; exit 1; }
+  echo "==> Building via scripts/build_linux.sh"
+  "$ROOT/scripts/build_linux.sh"
+fi
+[ -x "$BIN" ] || { echo "error: demo binary $BIN missing after build." >&2; exit 1; }
+
+# --- Version: git describe → Debian-legal upstream version (v* tags only) ---
+RAW="$(git -C "$ROOT" describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null || echo 0.0.0)"
+VERSION="$(echo "$RAW" | sed -e 's/^v//' -e 's/-dirty$/+dirty/' -e 's/-\([0-9]\+\)-g/+\1.g/')"
+case "$VERSION" in [0-9]*) : ;; *) VERSION="0.0.0+g$VERSION" ;; esac
+ARCH="$(dpkg --print-architecture)"
+
+STAGE="$DIST_DIR/${PKG}_${VERSION}_${ARCH}"
+APPDIR="$STAGE/usr/lib/displayxr-demos/$APP"
+echo "==> Staging $STAGE"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/DEBIAN" "$APPDIR" "$STAGE/usr/bin" "$STAGE/usr/share/applications"
+
+install -m 0755 "$BIN" "$APPDIR/$BINARY"
+
+# Bundle the OpenXR loader the demo links (built from source by build_linux.sh),
+# so the .deb doesn't depend on a distro loader whose version may differ from
+# the demo's pin. The wrapper puts $APPDIR on LD_LIBRARY_PATH.
+for f in "$OPENXR_DIR"/lib/libopenxr_loader.so*; do
+  [ -e "$f" ] && cp -a "$f" "$APPDIR/"
+done
+[ -e "$APPDIR/libopenxr_loader.so.1" ] || echo "warn: no bundled OpenXR loader — the demo may need a system libopenxr-loader1." >&2
+
+# Bundle the sample scene next to the binary (the demo auto-loads it from its own
+# executable directory).
+if [ -n "$SCENE_FILE" ] && [ -f "$ROOT/$SCENE_FILE" ]; then
+  install -m 0644 "$ROOT/$SCENE_FILE" "$APPDIR/$(basename "$SCENE_FILE")"
+else
+  [ -z "$SCENE_FILE" ] || echo "warn: sample scene $SCENE_FILE not found — the demo will fall back to a debug splat." >&2
+fi
+
+# Launcher wrapper on PATH.
+cat > "$STAGE/usr/bin/$PKG" <<EOF
+#!/bin/sh
+# DisplayXR demo launcher. The runtime .deb registers the OpenXR ActiveRuntime,
+# so no env vars are needed; we only wire the bundled loader + the Linux
+# vk_native compositor.
+DIR="/usr/lib/displayxr-demos/$APP"
+export LD_LIBRARY_PATH="\$DIR:\${LD_LIBRARY_PATH:-}"
+export OXR_ENABLE_VK_NATIVE_COMPOSITOR="\${OXR_ENABLE_VK_NATIVE_COMPOSITOR:-1}"
+exec "\$DIR/$BINARY" "\$@"
+EOF
+chmod 0755 "$STAGE/usr/bin/$PKG"
+
+# Desktop menu entry.
+cat > "$STAGE/usr/share/applications/$PKG.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=$DISPLAY_NAME
+Comment=$DESCRIPTION
+Exec=$PKG
+Terminal=false
+Categories=$DESKTOP_CATEGORIES
+EOF
+
+# --- Depends: displayxr-runtime (OpenXR runtime + DP) + the binary's + the
+# loader's DT_NEEDED system libs (usr-merge-safe; excludes 32-bit multiarch). --
+compute_lib_depends() {
+  local sonames so pkg pkgs=""
+  sonames="$(objdump -p "$APPDIR/$BINARY" "$APPDIR"/libopenxr_loader.so* 2>/dev/null | awk '/NEEDED/{print $2}' | sort -u)"
+  for so in $sonames; do
+    # skip the bundled loader itself
+    case "$so" in libopenxr_loader.so*) continue ;; esac
+    pkg="$(dpkg -S "$so" 2>/dev/null \
+           | awk -F': ' -v s="$so" '$2 ~ /^\/(usr\/)?lib(32|64)?\// && $2 !~ /(i386-linux-gnu|\/lib32\/|\/libx32\/)/ {n=split($2,a,"/"); if (a[n]==s){p=$1; sub(/:.*/,"",p); print p; exit}}')"
+    [ -n "$pkg" ] && pkgs="$pkgs $pkg"
+  done
+  echo "libc6 $pkgs" | tr ' ' '\n' | sed '/^$/d' | sort -u | paste -sd, - | sed 's/,/, /g'
+}
+LIB_DEPENDS="$(compute_lib_depends)"
+DEPENDS="displayxr-runtime, $LIB_DEPENDS"
+echo "==> Depends: $DEPENDS"
+INSTALLED_KB="$(du -sk "$STAGE/usr" | cut -f1)"
+
+cat > "$STAGE/DEBIAN/control" <<EOF
+Package: $PKG
+Version: $VERSION
+Section: graphics
+Priority: optional
+Architecture: $ARCH
+Depends: $DEPENDS
+Installed-Size: $INSTALLED_KB
+Maintainer: The DisplayXR Project <noreply@displayxr.dev>
+Homepage: https://github.com/DisplayXR/$REPO_SLUG
+Description: $DISPLAY_NAME
+ $DESCRIPTION
+ .
+ A DisplayXR demo OpenXR app for glasses-free 3D displays. Requires the
+ DisplayXR runtime (Depends: displayxr-runtime); runs on whichever display
+ processor is active (sim-display fallback, or the Leia SR plug-in when
+ installed). Launch from the menu or run '$PKG'.
+EOF
+
+mkdir -p "$DIST_DIR"
+DEB="$DIST_DIR/${PKG}_${VERSION}_${ARCH}.deb"
+if command -v fakeroot >/dev/null 2>&1; then
+  fakeroot dpkg-deb --build --root-owner-group "$STAGE" "$DEB"
+else
+  dpkg-deb --build --root-owner-group "$STAGE" "$DEB"
+fi
+
+echo ""
+echo "==> $DEB"
+dpkg-deb --info "$DEB" | sed 's/^/    /'
+dpkg-deb --contents "$DEB" | sed 's/^/    /'


### PR DESCRIPTION
## Summary
Adds a Linux `.deb` installer for the Gaussian Splat demo, mirroring the just-created reference in `displayxr-demo-modelviewer` (runtime #781 Phase 3 — demo installers).

- **`scripts/package_deb_linux.sh`** — copied from the modelviewer reference; only the per-demo config block is adapted:
  - `APP=gauss`, `PKG=displayxr-gaussiansplat`, `DISPLAY_NAME="DisplayXR Gaussian Splat Viewer"`
  - `BINARY=gaussian_splatting_handle_vk_linux`
  - `DESKTOP_CATEGORIES="Graphics;Viewer;"`
  - Homepage points at `displayxr-demo-gaussiansplat` (decoupled from `APP` via `REPO_SLUG`, since the component id `gauss` ≠ the repo slug).
  - Bundles the OpenXR loader (from `/tmp/openxr-install`) + the sample scene.
- **`.github/workflows/build-linux.yml`** — added `push: tags: ['v*']`, `permissions: contents: write`, and a `Deb` job (mirrors the modelviewer job; deps are this repo's Install-dependencies list + `dpkg-dev fakeroot`; artifact `displayxr-gaussiansplat-deb`). Builds the `.deb` on every PR (catch a broken packager early) and attaches it to the GitHub Release on `v*` tags.

## Asset bundling — deviation from the reference
The modelviewer reference bundles a top-level `assets/` dir into `$APPDIR/assets`. This repo has **no top-level `assets/`**, and the Linux binary auto-loads its scene from its **own executable directory** (`ExecutableDir()` → `butterfly.spz` next to the exe, `linux/main.cpp:644`), not from an `assets/` subdir. So instead of `ASSETS_SUBDIR`, the config uses `SCENE_FILE="macos/assets/butterfly.spz"` and installs that single ~4 MB file directly beside the binary in `$APPDIR/` — matching the runtime lookup. If absent the demo falls back to a debug splat (non-fatal).

## Validation
- `bash -n scripts/package_deb_linux.sh` — OK
- YAML parse of the workflow — OK
- No local Docker/`.deb` build was run (per task); CI validates.

## CI expectation
The tri-LTS `Build` job already builds `gaussian_splatting_handle_vk_linux` on `main`, so the compile is expected green. The new `Deb` job reuses the same build + a standard `dpkg-deb` wrap, so it should pass. Caveat: gauss is GPU-compute-heavy and Linux is the least-exercised target — if a toolchain regression has landed since the last green run, the compile step (shared with the existing job) is where it would surface, not the packaging step.

Refs DisplayXR/displayxr-runtime#781