### PR TITLE
refactor: uniform Ctrl+O for scene-open (retire bare L)

### DIFF
--- a/macos/main.mm
+++ b/macos/main.mm
@@ -14,7 +14,7 @@
  * - XR_DXR_display_info: Kooima projection, display metrics
  * - V key cycles rendering modes via xrRequestDisplayRenderingModeDXR
  * - 0-3 keys select rendering mode directly
- * - L key or button click: NSOpenPanel to load .ply/.spz scenes
+ * - Ctrl+O or button click: NSOpenPanel to load .ply/.spz scenes
  * - Tab: toggle HUD overlay, Space: reset camera, ESC: quit
  */
 
@@ -611,6 +611,13 @@ static void OpenLoadDialog() {
     NSString *chars = [event charactersIgnoringModifiers];
     if ([chars length] == 0) return;
     unichar ch = [chars characterAtIndex:0];
+    // Ctrl+O = open a scene. Literal Ctrl (NOT Cmd) on every platform — uniform
+    // with the Win/Linux demos AND the mediaplayer (SDL SDL_KMOD_CTRL). Strict:
+    // Ctrl must be held. (Was bare L — retired for the uniform chord.)
+    if ((ch == 'o' || ch == 'O') && ([event modifierFlags] & NSEventModifierFlagControl)) {
+        g_input.loadRequested = true;
+        return;
+    }
     switch (ch) {
         case 'w': case 'W': g_input.keyW = true; break;
         case 'a': case 'A': g_input.keyA = true; break;
@@ -644,9 +651,7 @@ static void OpenLoadDialog() {
                 g_input.eyeTrackingModeToggleRequested = true;
             }
             break;
-        case 'l': case 'L':
-            g_input.loadRequested = true;
-            break;
+        // (scene open moved to Ctrl+O — see the modifier check above the switch)
         case '-': case '_': {
             // Edit steadyIpdFactor (the ModeSwitch ramp target); seed ipdFactor
             // in lockstep for the idle/non-ramp render path.
@@ -2612,7 +2617,7 @@ int main(int argc, char** argv) {
                     double fps = (g_avgFrameTime > 0) ? 1.0 / g_avgFrameTime : 0;
                     NSString *sceneInfo = g_gsRenderer.hasScene()
                         ? [NSString stringWithFormat:@"Scene: %s", g_loadedFileName.c_str()]
-                        : @"No scene loaded (press L)";
+                        : @"No scene loaded (Ctrl+O)";
 
                     int depthPct = (int)(g_input.viewParams.ipdFactor * 100.0f + 0.5f);
                     const char *orbitLabel = g_input.animateEnabled

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -767,8 +767,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             ToggleFullscreen(hwnd);
             return 0;
         }
-        // L key = load shortcut
-        if (wParam == 'L') {
+        // Ctrl+O = open a scene (uniform across all demos + platforms, incl. the
+        // mediaplayer). Strict: Ctrl must be held. WM_USER+1 runs the picker on
+        // the message loop. (Was bare L — retired for the uniform chord.)
+        if (wParam == 'O' && (GetKeyState(VK_CONTROL) & 0x8000)) {
             PostMessage(hwnd, WM_USER + 1, 0, 0);
             return 0;
         }
@@ -999,7 +1001,7 @@ static void RenderThreadFunc(
             windowH = g_windowHeight;
         }
 
-        // Request main thread to open file dialog when L key or Load button was pressed.
+        // Request main thread to open file dialog when Ctrl+O or Load button was pressed.
         if (loadReq) {
             PostMessage(hwnd, WM_USER + 1, 0, 0);
         }
@@ -1603,7 +1605,7 @@ static void RenderThreadFunc(
                                         std::wstring fname(g_loadedFileName.begin(), g_loadedFileName.end());
                                         sceneText += L"\nLoaded: " + fname;
                                     } else {
-                                        sceneText += L"\nNo scene loaded (press L or click Load)";
+                                        sceneText += L"\nNo scene loaded (Ctrl+O or click Load)";
                                     }
                                 }
                                 modeText += sceneText;
@@ -1662,7 +1664,7 @@ static void RenderThreadFunc(
                                 }
                                 std::wstring helpText = L"[WASDEQ] Move | [LMB-drag] Rotate | [Scroll] Zoom\n"
                                     L"[DblClick] Focus | [-/=] Depth | [Space] Reset\n"
-                                    L"[M] Auto-Orbit | [V] Mode | [L] Load | [Tab] HUD | [ESC] Quit";
+                                    L"[M] Auto-Orbit | [V] Mode | [Ctrl+O] Load | [Tab] HUD | [ESC] Quit";
 
                                 // Top-bar buttons. Translate window-fraction click
                                 // regions into HUD-pixel coords scaled by the


### PR DESCRIPTION
Aligns scene-open with the demo family — strict literal Ctrl+O on Windows + macOS (retires bare L). Linux has no picker yet (handle-app port follow-up). Build-green only. https://github.com/DisplayXR/displayxr-demo-gaussiansplat/issues/74

🤖 Generated with [Claude Code](https://claude.com/claude-code)