### PR TITLE
feat(linux,#76): upgrade the build-green harness to a real handle app

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -6,10 +6,10 @@
 # CMakeLists.txt already added ../common and ../3dgs_common (exposing the
 # sr_common_base and gs_renderer targets) and ../openxr_includes.
 #
-# Build-green scope: compile gaussian_splatting_handle_vk_linux on
-# ubuntu-latest. Window arm is hosted-NULL (the runtime self-creates the
-# window); the app links no windowing toolkit. The generic COMPUTE splat
-# renderer (GsRenderer) is selected on desktop x86_64 by gs_renderer_select.h.
+# Handle app (#76): the app owns a decorated X11 window centered on the 3D
+# panel and passes it via XR_DXR_xlib_window_binding (hosted-NULL fallback when
+# no X server, which keeps the CI runner build-green). Renderer selection via
+# GS_RENDERER below.
 
 cmake_minimum_required(VERSION 3.21)
 
@@ -19,6 +19,12 @@ endif()
 
 find_package(Vulkan REQUIRED)
 message(STATUS "Found Vulkan: ${Vulkan_LIBRARY}")
+
+# X11 window + Xrandr panel query (handle app).
+find_package(X11 REQUIRED)
+if(NOT X11_Xrandr_LIB)
+    message(FATAL_ERROR "libXrandr not found (apt install libxrandr-dev) — needed for 3D-panel window centering.")
+endif()
 
 # OpenXR loader — CMake package (from CMAKE_PREFIX_PATH, e.g. the from-source
 # loader in scripts/build_linux.sh) → system library → fatal.
@@ -59,6 +65,8 @@ target_link_libraries(gaussian_splatting_handle_vk_linux PRIVATE
     gs_renderer
     OpenXR::openxr_loader
     Vulkan::Vulkan
+    X11::X11
+    ${X11_Xrandr_LIB}
     ${CMAKE_DL_LIBS}
 )
 

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -2,47 +2,47 @@
 // SPDX-License-Identifier: Apache-2.0
 /*!
  * @file
- * @brief  Linux Vulkan OpenXR 3D Gaussian Splatting viewer (build-green port).
+ * @brief  Linux Vulkan OpenXR 3D Gaussian Splatting viewer (handle app, X11 window).
  *
- * Linux leg of displayxr-demo-gaussiansplat, issue #60 (M8 Linux epic,
- * meta runtime #699). Mirrors the macOS/Windows legs' OpenXR + Vulkan +
- * gs_renderer flow, but is deliberately a headless-driver harness:
+ * Linux leg of displayxr-demo-gaussiansplat (#60 build-green harness, upgraded
+ * to a real handle app by #76). Mirrors the macOS/Windows legs' OpenXR +
+ * Vulkan + gs_renderer flow.
  *
- *   * Window arm = HOSTED-NULL. The app passes NO window binding, so the
- *     runtime self-creates a window at native resolution. Desktop Linux
- *     app-provided-window support (XR_DXR_xlib_window_binding, runtime
- *     Phase 3a) is intentionally NOT wired here — see TODO(Phase 3) below.
- *     Faithful app-owned windowing + input + HUD is the on-screen pass,
- *     gated on the Linux runtime + a GPU + an X server (build-green only
- *     here — see docs/guides/linux-demo-port.md in the runtime repo).
+ * WINDOWING — HANDLE app (matching the binary name and the other platforms):
+ * the app owns a decorated X11 window centered on the 3D panel and passes it
+ * via XR_DXR_xlib_window_binding, so the runtime weaves window-relative
+ * (runtime#729/#730) and the app receives keyboard input. The window defaults
+ * to 1920x1080 centered on the panel (XR_DXR_display_info desktop rect, else
+ * Xrandr); GAUSS_WINDOW="WxH+X+Y" overrides (X,Y absolute virtual-desktop px).
+ * When no X server is available (or window creation fails) the app falls back
+ * to the previous hosted-NULL path — which also keeps this compiling and
+ * startable on the build-green CI runner.
  *
- *   * Renderer = the generic COMPUTE splat path (GsRenderer), selected on
- *     desktop x86_64 by gs_renderer_select.h. The Adreno/TBDR graphics path
- *     (gs_adreno_renderer) is the Android/Apple-Silicon default and is not
- *     used on Linux desktop.
+ * INPUT — Ctrl+O opens a zenity file-selection dialog (async fork/exec, no
+ * hard dependency: absent zenity logs and no-ops) and loads the chosen
+ * .spz/.ply scene. The camera is otherwise the auto-orbit the harness always
+ * had; the runtime supplies per-view rig poses via XR_DXR_view_rig.
  *
- * The frame loop is real (locate views → renderEye per tile → EndFrame) so
- * the build is not hollow: it exercises the whole gs_renderer link surface.
- * An auto-orbit camera stands in for the mouse/keyboard input the desktop
- * legs carry. ESC/window controls are the on-screen pass's job.
+ * Renderer: selected by linux/CMakeLists.txt (GS_RENDERER, default GRAPHICS —
+ * the graphics-pipeline splat path; COMPUTE = the legacy generic path).
  */
 
 #include <vulkan/vulkan.h>
+
+// X11 window + input (handle app) — before the OpenXR platform header so the
+// xlib binding struct sees the real Display/Window types.
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/Xatom.h>
+#include <X11/keysym.h>
+#include <X11/extensions/Xrandr.h>
 
 #define XR_USE_GRAPHICS_API_VULKAN
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <openxr/XR_DXR_display_info.h>
 #include <openxr/XR_DXR_view_rig.h>
-
-// TODO(Phase 3): swap the hosted-NULL window arm for the real desktop-Linux
-// app-provided-window binding — XR_DXR_xlib_window_binding has landed in the
-// runtime (Phase 3a, #660) with a working example at
-// test_apps/cube_handle_vk_linux. Faithful ports pass a Display*/Window at
-// xrCreateSession (as the cocoa/win32 legs pass their handles). Until the
-// on-screen pass, hosted-NULL keeps the build-green harness runtime-agnostic
-// and hardware-free. NOTE: the xlib binding header is not yet vendored in this
-// repo's openxr_includes/ — vendor it (from displayxr-extensions) when wiring.
+#include <openxr/XR_DXR_xlib_window_binding.h>
 
 #include <cmath>
 #include <csignal>
@@ -55,11 +55,14 @@
 #include <utility>
 #include <vector>
 
-#include <unistd.h>
+#include <fcntl.h>
 #include <limits.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 #include <time.h>
+#include <unistd.h>
 
-#include "gs_renderer_select.h"   // GsActiveRenderer = compute path on desktop x86_64
+#include "gs_renderer_select.h"   // GsActiveRenderer (GS_RENDERER in linux/CMakeLists.txt)
 
 // ============================================================================
 // Logging
@@ -93,6 +96,10 @@
 
 static volatile bool g_running = true;
 static GsActiveRenderer g_gsRenderer;
+
+// Tile basis for a handle app: the app window (window × viewScale, #729-style).
+// Falls back to the display size on the hosted-NULL path.
+static uint32_t g_windowW = 1920, g_windowH = 1080;
 
 static void SignalHandler(int sig) {
     (void)sig;
@@ -233,10 +240,19 @@ struct AppXrSession {
 
     bool hasDisplayInfoExt = false;
     bool hasViewRigExt = false;
+    bool hasXlibBindingExt = false;
     float displayWidthM = 0, displayHeightM = 0;
     float nominalViewerZ = 0.5f;
     uint32_t displayPixelWidth = 0, displayPixelHeight = 0;
+    int32_t displayScreenLeft = 0;     // 3D-panel top-left in virtual-desktop px (INV-1.3)
+    int32_t displayScreenTop = 0;
 
+    // App-owned X11 window (handle app). Null display = hosted-NULL fallback.
+    Display* xDisplay = nullptr;
+    ::Window xWindow = 0;
+    unsigned int xWinW = 0, xWinH = 0;
+
+    PFN_xrRequestDisplayRenderingModeDXR pfnRequestDisplayRenderingModeEXT = nullptr;
     PFN_xrEnumerateDisplayRenderingModesDXR pfnEnumerateDisplayRenderingModesEXT = nullptr;
 
     uint32_t renderingModeCount = 0;
@@ -262,6 +278,7 @@ static bool InitializeOpenXR(AppXrSession& xr) {
         if (strcmp(ext.extensionName, XR_KHR_VULKAN_ENABLE_EXTENSION_NAME) == 0) hasVulkan = true;
         if (strcmp(ext.extensionName, XR_DXR_DISPLAY_INFO_EXTENSION_NAME) == 0) xr.hasDisplayInfoExt = true;
         if (strcmp(ext.extensionName, XR_DXR_VIEW_RIG_EXTENSION_NAME) == 0) xr.hasViewRigExt = true;
+        if (strcmp(ext.extensionName, XR_DXR_XLIB_WINDOW_BINDING_EXTENSION_NAME) == 0) xr.hasXlibBindingExt = true;
     }
     if (!hasVulkan) { LOG_ERROR("XR_KHR_vulkan_enable not available"); return false; }
 
@@ -269,6 +286,7 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     enabled.push_back(XR_KHR_VULKAN_ENABLE_EXTENSION_NAME);
     if (xr.hasDisplayInfoExt) enabled.push_back(XR_DXR_DISPLAY_INFO_EXTENSION_NAME);
     if (xr.hasViewRigExt) enabled.push_back(XR_DXR_VIEW_RIG_EXTENSION_NAME);
+    if (xr.hasXlibBindingExt) enabled.push_back(XR_DXR_XLIB_WINDOW_BINDING_EXTENSION_NAME);
 
     XrInstanceCreateInfo ci = {XR_TYPE_INSTANCE_CREATE_INFO};
     strncpy(ci.applicationInfo.applicationName, "SR3DGSOpenXRExtLinux",
@@ -291,6 +309,9 @@ static bool InitializeOpenXR(AppXrSession& xr) {
     if (xr.hasDisplayInfoExt) {
         XrSystemProperties sp = {XR_TYPE_SYSTEM_PROPERTIES};
         XrDisplayInfoDXR di = {(XrStructureType)XR_TYPE_DISPLAY_INFO_DXR};
+        XrDisplayDesktopPositionDXR desktopPos = {};
+        desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_DXR;
+        di.next = &desktopPos;
         sp.next = &di;
         if (XR_SUCCEEDED(xrGetSystemProperties(xr.instance, xr.systemId, &sp))) {
             xr.displayWidthM = di.displaySizeMeters.width;
@@ -298,7 +319,11 @@ static bool InitializeOpenXR(AppXrSession& xr) {
             xr.nominalViewerZ = di.nominalViewerPositionInDisplaySpace.z;
             xr.displayPixelWidth = di.displayPixelWidth;
             xr.displayPixelHeight = di.displayPixelHeight;
+            xr.displayScreenLeft = desktopPos.left;
+            xr.displayScreenTop = desktopPos.top;
         }
+        xrGetInstanceProcAddr(xr.instance, "xrRequestDisplayRenderingModeDXR",
+            (PFN_xrVoidFunction*)&xr.pfnRequestDisplayRenderingModeEXT);
         xrGetInstanceProcAddr(xr.instance, "xrEnumerateDisplayRenderingModesDXR",
             (PFN_xrVoidFunction*)&xr.pfnEnumerateDisplayRenderingModesEXT);
     }
@@ -408,8 +433,6 @@ static bool CreateVulkanDevice(VkPhysicalDevice pd, uint32_t qfi,
 
 static bool CreateSession(AppXrSession& xr, VkInstance vkInstance, VkPhysicalDevice pd,
     VkDevice dev, uint32_t qfi) {
-    // Hosted-NULL: Vulkan binding only, no window-binding struct chained → the
-    // runtime self-creates a window at native resolution.
     XrGraphicsBindingVulkanKHR vkBinding = {XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR};
     vkBinding.instance = vkInstance;
     vkBinding.physicalDevice = pd;
@@ -417,9 +440,23 @@ static bool CreateSession(AppXrSession& xr, VkInstance vkInstance, VkPhysicalDev
     vkBinding.queueFamilyIndex = qfi;
     vkBinding.queueIndex = 0;
 
+    // Handle app: pass the app-owned X11 window via XR_DXR_xlib_window_binding
+    // so the runtime weaves window-relative (runtime#729/#730). Falls back to
+    // hosted-NULL (no window binding — the runtime self-creates a window at
+    // native resolution) when CreateAppWindow didn't run.
+    XrXlibWindowBindingCreateInfoDXR xlibBinding = {XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_DXR};
+    xlibBinding.next = &vkBinding;
+    xlibBinding.xDisplay = xr.xDisplay;
+    xlibBinding.window = xr.xWindow;
+    xlibBinding.transparentBackgroundEnabled = XR_FALSE;
+    const bool useAppWindow =
+        (xr.hasXlibBindingExt && xr.xDisplay != nullptr && xr.xWindow != 0);
+
     XrSessionCreateInfo si = {XR_TYPE_SESSION_CREATE_INFO};
-    si.next = &vkBinding; si.systemId = xr.systemId;
+    si.next = useAppWindow ? (const void*)&xlibBinding : (const void*)&vkBinding;
+    si.systemId = xr.systemId;
     XR_CHECK(xrCreateSession(xr.instance, &si, &xr.session));
+    LOG_INFO("Session created (%s)", useAppWindow ? "app-owned window, handle app" : "hosted-NULL");
 
     if (xr.pfnEnumerateDisplayRenderingModesEXT && xr.session != XR_NULL_HANDLE) {
         uint32_t modeCount = 0;
@@ -577,6 +614,275 @@ static void CleanupOpenXR(AppXrSession& xr) {
     if (xr.localSpace) xrDestroySpace(xr.localSpace);
     if (xr.session) xrDestroySession(xr.session);
     if (xr.instance) xrDestroyInstance(xr.instance);
+    // Tear down the app-owned X11 window after the runtime has released it.
+    if (xr.xWindow != 0 && xr.xDisplay != nullptr) XDestroyWindow(xr.xDisplay, xr.xWindow);
+    if (xr.xDisplay != nullptr) XCloseDisplay(xr.xDisplay);
+    xr.xWindow = 0;
+    xr.xDisplay = nullptr;
+}
+
+// ============================================================================
+// App-owned X11 window (handle app)
+// ============================================================================
+
+static const unsigned int kDefaultWindowW = 1920;
+static const unsigned int kDefaultWindowH = 1080;
+static Atom g_wmDeleteAtom = None;
+
+// Find the target panel rect (virtual-desktop px). Prefer the RandR PRIMARY
+// output; else the largest connected NON-eDP/LVDS output (the 3D display is an
+// external panel, not the laptop's built-in). Same helper as the other demos.
+static bool GetPanelRect(Display* dpy, ::Window root, int& x, int& y, int& w, int& h) {
+    XRRScreenResources* res = XRRGetScreenResources(dpy, root);
+    if (res == nullptr) return false;
+
+    auto tryOutput = [&](RROutput out) -> bool {
+        XRROutputInfo* oi = XRRGetOutputInfo(dpy, res, out);
+        if (oi == nullptr) return false;
+        bool ok = false;
+        if (oi->connection == RR_Connected && oi->crtc != 0) {
+            XRRCrtcInfo* ci = XRRGetCrtcInfo(dpy, res, oi->crtc);
+            if (ci != nullptr && ci->width > 0 && ci->height > 0) {
+                x = ci->x; y = ci->y; w = (int)ci->width; h = (int)ci->height;
+                ok = true;
+            }
+            if (ci != nullptr) XRRFreeCrtcInfo(ci);
+        }
+        XRRFreeOutputInfo(oi);
+        return ok;
+    };
+
+    bool found = false;
+    RROutput primary = XRRGetOutputPrimary(dpy, root);
+    if (primary != 0 && tryOutput(primary)) {
+        found = true;
+    }
+    if (!found) {
+        long bestArea = 0;
+        for (int i = 0; i < res->noutput; i++) {
+            XRROutputInfo* oi = XRRGetOutputInfo(dpy, res, res->outputs[i]);
+            if (oi == nullptr) continue;
+            const bool isBuiltin = oi->name != nullptr &&
+                (strncasecmp(oi->name, "eDP", 3) == 0 || strncasecmp(oi->name, "LVDS", 4) == 0);
+            if (oi->connection == RR_Connected && oi->crtc != 0 && !isBuiltin) {
+                XRRCrtcInfo* ci = XRRGetCrtcInfo(dpy, res, oi->crtc);
+                if (ci != nullptr && ci->width > 0 && ci->height > 0) {
+                    const long area = (long)ci->width * (long)ci->height;
+                    if (area > bestArea) {
+                        bestArea = area;
+                        x = ci->x; y = ci->y; w = (int)ci->width; h = (int)ci->height;
+                        found = true;
+                    }
+                }
+                if (ci != nullptr) XRRFreeCrtcInfo(ci);
+            }
+            XRRFreeOutputInfo(oi);
+        }
+    }
+    XRRFreeScreenResources(res);
+    return found;
+}
+
+// Create a normal decorated X11 window (opaque, default visual), landscape
+// 1920x1080 centered on the 3D panel — the app passes it via
+// XR_DXR_xlib_window_binding so the runtime weaves window-relative. Override
+// with GAUSS_WINDOW="WxH+X+Y" (X,Y absolute virtual-desktop px; WxH alone
+// re-centers). Returns false (xDisplay left null) when no X server is
+// available, so the caller falls back to hosted-NULL (also the CI-safe path).
+static bool CreateAppWindow(AppXrSession& xr) {
+    Display* dpy = XOpenDisplay(nullptr);
+    if (dpy == nullptr) {
+        LOG_INFO("XOpenDisplay failed (no X server) — using hosted-NULL windowing");
+        return false;
+    }
+    int screen = DefaultScreen(dpy);
+    ::Window root = RootWindow(dpy, screen);
+
+    XSetWindowAttributes attrs = {};
+    attrs.background_pixel = BlackPixel(dpy, screen);
+    attrs.event_mask = StructureNotifyMask | KeyPressMask;
+
+    unsigned int w = kDefaultWindowW, h = kDefaultWindowH;
+    int px = 0, py = 0;
+    int prx = 0, pry = 0, prw = 0, prh = 0;
+    if (xr.displayPixelWidth > 0 && xr.displayPixelHeight > 0) {
+        // Authoritative: XR_DXR_display_info reports the 3D panel's desktop
+        // rect. Prefer it — on a multi-monitor box the RandR PRIMARY is often
+        // NOT the 3D panel.
+        prx = xr.displayScreenLeft;
+        pry = xr.displayScreenTop;
+        prw = (int)xr.displayPixelWidth;
+        prh = (int)xr.displayPixelHeight;
+        px = prx + (prw - (int)w) / 2;
+        py = pry + (prh - (int)h) / 2;
+        LOG_INFO("3D panel (display_info) %dx%d at (%d,%d) — centering %ux%u window at (%d,%d)",
+                 prw, prh, prx, pry, w, h, px, py);
+    } else if (GetPanelRect(dpy, root, prx, pry, prw, prh)) {
+        px = prx + (prw - (int)w) / 2;
+        py = pry + (prh - (int)h) / 2;
+        LOG_INFO("Panel rect (Xrandr) %dx%d at (%d,%d) — centering %ux%u window at (%d,%d)",
+                 prw, prh, prx, pry, w, h, px, py);
+    } else {
+        const int sw = DisplayWidth(dpy, screen), sh = DisplayHeight(dpy, screen);
+        px = (sw - (int)w) / 2;
+        py = (sh - (int)h) / 2;
+        LOG_INFO("Xrandr panel query failed — centering %ux%u on default screen %dx%d at (%d,%d)",
+                 w, h, sw, sh, px, py);
+    }
+
+    // GAUSS_WINDOW="WxH+X+Y" override (X,Y absolute virtual-desktop px); WxH
+    // alone re-centers on the same panel/screen origin.
+    if (const char* wenv = getenv("GAUSS_WINDOW")) {
+        unsigned int ow = 0, oh = 0; int ox = 0, oy = 0;
+        int n = sscanf(wenv, "%ux%u+%d+%d", &ow, &oh, &ox, &oy);
+        if (n >= 2 && ow > 0 && oh > 0) {
+            w = ow; h = oh;
+            if (n >= 4) {
+                px = ox; py = oy;
+                LOG_INFO("GAUSS_WINDOW override: %ux%u at absolute (%d,%d)", w, h, px, py);
+            } else {
+                if (prw > 0 && prh > 0) { px = prx + (prw - (int)w) / 2; py = pry + (prh - (int)h) / 2; }
+                LOG_INFO("GAUSS_WINDOW override: %ux%u (re-centered at %d,%d)", w, h, px, py);
+            }
+        }
+    }
+
+    ::Window win = XCreateWindow(dpy, root, px, py, w, h, 0, CopyFromParent, InputOutput,
+                                 CopyFromParent, CWBackPixel | CWEventMask, &attrs);
+    if (win == 0) {
+        LOG_ERROR("XCreateWindow failed — using hosted-NULL windowing");
+        XCloseDisplay(dpy);
+        return false;
+    }
+    XStoreName(dpy, win, "DisplayXR Gaussian Splat Viewer");
+
+    // Close button → clean exit (ClientMessage in the event pump).
+    g_wmDeleteAtom = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
+    if (g_wmDeleteAtom != None) XSetWMProtocols(dpy, win, &g_wmDeleteAtom, 1);
+
+    // WM_NORMAL_HINTS with USPosition|PPosition so the WM honors the
+    // create-time position instead of auto-placing (GNOME/Mutter).
+    {
+        XSizeHints hints = {};
+        hints.flags = USPosition | PPosition;
+        hints.x = px; hints.y = py;
+        XSetWMNormalHints(dpy, win, &hints);
+    }
+
+    XMapWindow(dpy, win);
+    XFlush(dpy);
+    // Re-assert the position after mapping — Mutter ignores the create-time
+    // x/y of a freshly-mapped toplevel but honors a post-map move.
+    XMoveWindow(dpy, win, px, py);
+    XFlush(dpy);
+
+    xr.xDisplay = dpy;
+    xr.xWindow = win;
+    xr.xWinW = w;
+    xr.xWinH = h;
+    LOG_INFO("Created %ux%u app window at (%d,%d) — XR_DXR_xlib_window_binding", w, h, px, py);
+    return true;
+}
+
+// ============================================================================
+// File-open dialog (Ctrl+O) — async zenity picker + X11 event pump
+// ============================================================================
+
+// Non-blocking zenity file-selection: fork/exec with a pipe, polled every
+// frame so the XR frame loop never stalls. zenity is NOT a hard dependency —
+// when absent the child exits 127 and we log a hint. Windows-parity semantics:
+// pick a .spz/.ply → g_gsRenderer.loadScene.
+static pid_t g_pickerPid = -1;
+static int g_pickerFd = -1;
+static std::string g_pickerBuf;
+
+static void StartFilePicker() {
+    if (g_pickerPid > 0) return; // dialog already open
+    int fds[2];
+    if (pipe(fds) != 0) { LOG_WARN("file picker: pipe() failed"); return; }
+    pid_t pid = fork();
+    if (pid < 0) { close(fds[0]); close(fds[1]); LOG_WARN("file picker: fork() failed"); return; }
+    if (pid == 0) {
+        // Child: zenity prints the chosen path on stdout.
+        dup2(fds[1], STDOUT_FILENO);
+        close(fds[0]); close(fds[1]);
+        std::string startDir = ExecutableDir(); // bundled butterfly.spz lives here
+        if (!startDir.empty() && startDir.back() != '/') startDir += '/';
+        std::string filenameArg = "--filename=" + startDir;
+        const char* argv[] = {"zenity", "--file-selection", "--title=Open 3DGS scene",
+                              filenameArg.c_str(),
+                              "--file-filter=3DGS scenes | *.spz *.ply *.SPZ *.PLY",
+                              "--file-filter=All files | *", nullptr};
+        execvp("zenity", const_cast<char* const*>(argv));
+        _exit(127); // zenity not installed
+    }
+    close(fds[1]);
+    fcntl(fds[0], F_SETFL, O_NONBLOCK);
+    g_pickerPid = pid;
+    g_pickerFd = fds[0];
+    g_pickerBuf.clear();
+    LOG_INFO("file picker: zenity dialog opened");
+}
+
+static void PollFilePicker() {
+    if (g_pickerPid <= 0) return;
+    // Drain whatever the child has written so far.
+    char buf[512];
+    ssize_t n;
+    while ((n = read(g_pickerFd, buf, sizeof(buf))) > 0) g_pickerBuf.append(buf, (size_t)n);
+    int status = 0;
+    pid_t r = waitpid(g_pickerPid, &status, WNOHANG);
+    if (r != g_pickerPid) return; // still open
+    while ((n = read(g_pickerFd, buf, sizeof(buf))) > 0) g_pickerBuf.append(buf, (size_t)n);
+    close(g_pickerFd);
+    g_pickerFd = -1; g_pickerPid = -1;
+
+    const int code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    if (code == 127) { LOG_WARN("file picker: zenity not installed (apt install zenity)"); return; }
+    if (code != 0) { LOG_INFO("file picker: cancelled"); return; }
+    // Trim the trailing newline zenity appends.
+    while (!g_pickerBuf.empty() && (g_pickerBuf.back() == '\n' || g_pickerBuf.back() == '\r'))
+        g_pickerBuf.pop_back();
+    if (g_pickerBuf.empty()) return;
+    LOG_INFO("Loading scene: %s", g_pickerBuf.c_str());
+    if (g_gsRenderer.loadScene(g_pickerBuf.c_str()))
+        LOG_INFO("Loaded %s (%u gaussians)", g_pickerBuf.c_str(), g_gsRenderer.gaussianCount());
+    else
+        LOG_WARN("file picker: load failed for %s", g_pickerBuf.c_str());
+}
+
+// Pump the app window's X11 events: Ctrl+O = open-scene dialog, close button =
+// clean exit, ConfigureNotify = track live window size.
+static void PumpXEvents(AppXrSession& xr) {
+    if (xr.xDisplay == nullptr) return;
+    while (XPending(xr.xDisplay) > 0) {
+        XEvent ev;
+        XNextEvent(xr.xDisplay, &ev);
+        switch (ev.type) {
+        case KeyPress: {
+            KeySym sym = XLookupKeysym(&ev.xkey, 0);
+            // Ctrl+O = open a scene (uniform across demos + platforms, #74).
+            // Strict: Ctrl must be held (bare O does nothing).
+            if ((sym == XK_o || sym == XK_O) && (ev.xkey.state & ControlMask)) StartFilePicker();
+            break;
+        }
+        case ConfigureNotify:
+            if (ev.xconfigure.width > 0 && ev.xconfigure.height > 0) {
+                xr.xWinW = (unsigned int)ev.xconfigure.width;
+                xr.xWinH = (unsigned int)ev.xconfigure.height;
+                g_windowW = xr.xWinW;
+                g_windowH = xr.xWinH;
+            }
+            break;
+        case ClientMessage:
+            if (g_wmDeleteAtom != None && (Atom)ev.xclient.data.l[0] == g_wmDeleteAtom) {
+                LOG_INFO("Window closed — exiting");
+                g_running = false;
+            }
+            break;
+        default: break;
+        }
+    }
 }
 
 // ============================================================================
@@ -584,10 +890,12 @@ static void CleanupOpenXR(AppXrSession& xr) {
 // ============================================================================
 
 int main(int argc, char** argv) {
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
     signal(SIGINT, SignalHandler);
     signal(SIGTERM, SignalHandler);
 
-    LOG_INFO("DisplayXR Gaussian Splat Viewer (Linux build-green harness)");
+    LOG_INFO("=== DisplayXR Gaussian Splat Viewer (Vulkan, Linux) ===");
 
     // Default rendering mode from SIM_DISPLAY_OUTPUT (matches the macOS leg).
     AppXrSession xr = {};
@@ -599,6 +907,12 @@ int main(int argc, char** argv) {
       } }
 
     if (!InitializeOpenXR(xr)) { LOG_ERROR("OpenXR init failed"); return 1; }
+
+    // Handle app: own an X11 window on the 3D panel (display_info queried in
+    // InitializeOpenXR gives the panel rect). Falls back to hosted-NULL when
+    // no X server is available (also the CI-safe path — CI never runs this).
+    CreateAppWindow(xr);
+
     if (!GetVulkanGraphicsRequirements(xr)) { CleanupOpenXR(xr); return 1; }
 
     VkInstance vkInstance = VK_NULL_HANDLE;
@@ -640,6 +954,16 @@ int main(int argc, char** argv) {
                            xr.swapchain.width, xr.swapchain.height))
         LOG_WARN("3DGS renderer init failed");
 
+    // Tile basis: the app window when we own one (window × scaleXY, #729-style);
+    // else the full panel (hosted-NULL renders display-sized).
+    if (xr.xWinW > 0 && xr.xWinH > 0) {
+        g_windowW = xr.xWinW;
+        g_windowH = xr.xWinH;
+    } else {
+        if (xr.displayPixelWidth > 0) g_windowW = xr.displayPixelWidth;
+        if (xr.displayPixelHeight > 0) g_windowH = xr.displayPixelHeight;
+    }
+
     // Auto-load bundled butterfly.spz (copied next to the exe by CMake).
     { std::string scene = ExecutableDir() + "/butterfly.spz";
       if (argc > 1) scene = argv[1];
@@ -666,6 +990,13 @@ int main(int argc, char** argv) {
 
     while (g_running && !xr.exitRequested) {
         PollEvents(xr);
+        PumpXEvents(xr);   // Ctrl+O = open dialog; close button = exit
+        PollFilePicker();  // async zenity result → loadScene
+
+        // Assert the app's default 3D rendering mode once the session is running.
+        if (xr.sessionRunning && xr.pfnRequestDisplayRenderingModeEXT && xr.session != XR_NULL_HANDLE)
+            xr.pfnRequestDisplayRenderingModeEXT(xr.session, xr.currentRenderingMode);
+
         if (!xr.sessionRunning) {
             struct timespec ts = {0, 10 * 1000 * 1000}; nanosleep(&ts, nullptr);
             continue;
@@ -724,11 +1055,13 @@ int main(int argc, char** argv) {
                     ? xr.renderingModeTileColumns[mode] : (monoMode ? 1u : 2u);
                 int eyeCount = monoMode ? 1 : (int)modeViewCount;
 
+                // Render tile = window × recommendedViewScaleXY (never the
+                // swapchain/display size) — the handle-app tiling rule
+                // (runtime#729, multiview-tiling.md).
                 float scaleX = xr.renderingModeCount > 0 ? xr.renderingModeScaleX[mode] : 1.0f;
                 float scaleY = xr.renderingModeCount > 0 ? xr.renderingModeScaleY[mode] : 1.0f;
-                uint32_t renderW = (uint32_t)((double)xr.swapchain.width * (tileColumns > 0 ? scaleX : 1.0));
-                uint32_t renderH = (uint32_t)((double)xr.swapchain.height * scaleY);
-                if (tileColumns > 0) renderW = (uint32_t)((double)xr.swapchain.width / (double)tileColumns);
+                uint32_t renderW = (uint32_t)((double)g_windowW * scaleX);
+                uint32_t renderH = (uint32_t)((double)g_windowH * scaleY);
                 if (renderW == 0) renderW = 1;
                 if (renderH == 0) renderH = 1;
 

--- a/openxr_includes/openxr/XR_DXR_xlib_window_binding.h
+++ b/openxr_includes/openxr/XR_DXR_xlib_window_binding.h
@@ -47,7 +47,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_xlib_window_binding 1
-#define XR_DXR_xlib_window_binding_SPEC_VERSION 1
+#define XR_DXR_xlib_window_binding_SPEC_VERSION 2
 #define XR_DXR_XLIB_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_xlib_window_binding"
 
 // Value from the DisplayXR provisional 1004999xxx block — decade 1004999200–209
@@ -91,6 +91,16 @@ typedef struct XrXlibWindowBindingCreateInfoDXR {
     const void* XR_MAY_ALIAS    next;      //!< Pointer to next structure in chain
     Display*                    xDisplay;  //!< Xlib display connection (XOpenDisplay)
     XR_XLIB_WINDOW_TYPE_        window;    //!< X11 Window (XID) owned by the app
+    //! When XR_TRUE, the runtime configures the bound window for transparent
+    //! desktop composition: pixels the app writes with full opacity appear
+    //! opaque on screen, and pixels written transparent (alpha = 0) compose
+    //! through to the desktop underneath. On X11 the runtime selects a 32-bit
+    //! ARGB visual and a non-opaque swapchain compositeAlpha; a compositing
+    //! window manager (e.g. GNOME/Mutter, KWin, picom) must be running for the
+    //! desktop to show through. Only honored when both xDisplay and window are
+    //! valid. Sibling of XrWin32WindowBindingCreateInfoDXR::transparentBackgroundEnabled
+    //! (SPEC_VERSION 2).
+    XrBool32                    transparentBackgroundEnabled;
 } XrXlibWindowBindingCreateInfoDXR;
 
 #undef XR_XLIB_WINDOW_TYPE_


### PR DESCRIPTION
Closes #76. Linux leg of the 3-demo Linux port wave (modelviewer #60 / avatar #45 pattern).

- **App-owned decorated X11 window**, 1920x1080 centered on the 3D panel (`XR_DXR_display_info` desktop rect, Xrandr fallback), passed via **`XR_DXR_xlib_window_binding`** (vendored header synced to SPEC_VERSION 2); `GAUSS_WINDOW="WxH+X+Y"` override (X,Y absolute virtual-desktop px). Hosted-NULL fallback when no X server keeps CI build-green.
- **Handle-app tiling**: render tile = window × recommendedViewScaleXY (was swapchain/display-sized; runtime#729 rule).
- **X11 event pump + Ctrl+O** async zenity scene picker (.spz/.ply, zenity is not a hard dep) → `loadScene` — closes the gauss gap left by #75 (which covered Win/macOS only). Close button = clean exit; per-frame rendering-mode assert.
- `linux/CMakeLists.txt` links X11 + Xrandr (CI already installs libxrandr-dev).

The .deb already stages `butterfly.spz` flat next to the binary, so the installed app auto-loads a scene unchanged.

Hardware validation (installed runtime stack, zero env vars, weaving + perf on desktop NVIDIA) to follow on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5w249N3tHjpdGsFPKnQHN