### PR TITLE
installer: never block the bundle chain on a pre-flight modal

### DIFF
--- a/installer/DisplayXRGaussianSplatInstaller.nsi
+++ b/installer/DisplayXRGaussianSplatInstaller.nsi
@@ -83,6 +83,27 @@ ShowUninstDetails show
 !include "WordFunc.nsh"
 !insertmacro VersionCompare
 
+;--------------------------------
+; Abort a pre-flight check without ever showing a modal in silent mode.
+;
+; NSIS does NOT suppress MessageBox under /S — it shows and blocks forever.
+; The DisplayXR meta-bundle runs every child installer as
+; `ExecWait '<child> /S'` and aborts the chain on a non-zero exit, so a modal
+; here would hang the ENTIRE bundle against a window nobody can see. In silent
+; mode set a distinct exit code instead; the bundle already surfaces that as
+; "<component> installer exited with code $0. Aborting bundle."
+;
+; Codes: 3 = not 64-bit, 4 = runtime absent, 5 = runtime below the floor.
+; (2 is reserved — the INNER uninstaller-emitting pass exits 2 by design.)
+!macro AbortWithReason CODE MSG
+    ${If} ${Silent}
+        SetErrorLevel ${CODE}
+    ${Else}
+        MessageBox MB_ICONSTOP "${MSG}"
+    ${EndIf}
+    Abort
+!macroend
+
 ; Minimum runtime version. Bumped to 1.3.0 with the Ctrl+T transparent-bg
 ; toggle: the demo now creates the HWND with WS_EX_NOREDIRECTIONBITMAP and the
 ; session with transparentBackgroundEnabled=XR_TRUE unconditionally, which
@@ -124,8 +145,7 @@ Function .onInit
     Quit
 !endif
     ${IfNot} ${RunningX64}
-        MessageBox MB_ICONSTOP "DisplayXR requires 64-bit Windows."
-        Abort
+        !insertmacro AbortWithReason 3 "DisplayXR requires 64-bit Windows."
     ${EndIf}
 
     ; HKLM\Software\DisplayXR\Runtime\InstallPath is set by the runtime
@@ -137,8 +157,7 @@ Function .onInit
     ReadRegStr $1 HKLM "Software\DisplayXR\Runtime" "Version"
     SetRegView 32
     ${If} $0 == ""
-        MessageBox MB_ICONSTOP "DisplayXR runtime is not installed.$\r$\n$\r$\nInstall the DisplayXR runtime first, then re-run this installer.$\r$\n$\r$\nGet it from:$\r$\nhttps://github.com/DisplayXR/displayxr-runtime/releases"
-        Abort
+        !insertmacro AbortWithReason 4 "DisplayXR runtime is not installed.$\r$\n$\r$\nInstall the DisplayXR runtime first, then re-run this installer.$\r$\n$\r$\nGet it from:$\r$\nhttps://github.com/DisplayXR/displayxr-runtime/releases"
     ${EndIf}
 
     ; Enforce the minimum runtime version for the Vulkan transparent-window
@@ -147,8 +166,7 @@ Function .onInit
     ; itself) — the demo neither bundles nor depends on it being on PATH.
     ${VersionCompare} "$1" "${MIN_RUNTIME_VERSION}" $2
     ${If} $2 == 2
-        MessageBox MB_ICONSTOP "DisplayXR runtime $1 is too old.$\r$\n$\r$\nThis demo requires runtime ${MIN_RUNTIME_VERSION} or later.$\r$\n$\r$\nUpdate from:$\r$\nhttps://github.com/DisplayXR/displayxr-runtime/releases"
-        Abort
+        !insertmacro AbortWithReason 5 "DisplayXR runtime $1 is too old.$\r$\n$\r$\nThis demo requires runtime ${MIN_RUNTIME_VERSION} or later.$\r$\n$\r$\nUpdate from:$\r$\nhttps://github.com/DisplayXR/displayxr-runtime/releases"
     ${EndIf}
 FunctionEnd
 


### PR DESCRIPTION
## Problem

NSIS does **not** suppress `MessageBox` under `/S` — it displays and blocks forever.

The DisplayXR meta-bundle runs every child installer as `ExecWait '<child> /S'`. So a failed pre-flight check in this installer's `.onInit` did not "reject the install" — it **hung the entire bundle** against a window nobody can see, with no timeout and no indication of what happened.

Found while adding an ABI-pairing gate to the Leia SR plug-in installer ([leia-plugin#113](https://github.com/DisplayXR/displayxr-leia-plugin/pull/113)); the same latent hang is present in all five demo installers, so they're being fixed together.

## Change

Every `.onInit` failure now routes through an `AbortWithReason` macro:

```nsi
!macro AbortWithReason CODE MSG
    ${If} ${Silent}
        SetErrorLevel ${CODE}
    ${Else}
        MessageBox MB_ICONSTOP "${MSG}"
    ${EndIf}
    Abort
!macroend
```

Interactive runs are unchanged — same modal, same text. Silent runs set a distinct exit code, and the bundle already checks `$0 != 0` per child and reports `"<component> installer exited with code $0. Aborting bundle."` So the same condition now fails **loudly and legibly** instead of wedging.

| Code | Condition |
|---|---|
| 3 | not 64-bit |
| 4 | runtime absent |
| 5 | runtime below the minimum floor |

(2 is deliberately avoided — the INNER uninstaller-emitting pass exits 2 by design.)

**No change to which conditions abort**, and none to what an interactive user sees.

## Verification

NSIS 3.11, on a box with runtime 2.2.1:

- Compiles clean (payloads dummy-staged so `makensis` actually runs, not just a syntax skim).
- A build whose floor cannot be satisfied (99.0.0 vs installed 2.2.1) run with `/S` returns **exit 5 in ~1s** and leaves no process behind — previously this hung indefinitely.
- The interactive branch is the original code verbatim; not exercised here, since triggering a modal would block the test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNGe1hZ3SPeNLcqY3rv8tJ