### PR TITLE
chore(deps): bump displayxr-common to v2.5.0

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.1.0
+    GIT_TAG v2.5.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)


### PR DESCRIPTION
Brings this repo's `displayxr-common` pin up to current (`v2.5.0`, = `main` HEAD of that repo).

**Why now:** an audit of every `displayxr-common` consumer found this repo several tags behind, so it was building against a stale copy of the shared library.

**Safety analysis (no behaviour change expected):**
- Every API change in the bumped range is a **new defaulted trailing parameter** (`projectionNext`, `extraLayers`, `extraLayerCount`) — existing call sites compile unchanged. Common is built from source via FetchContent, so ABI is not a factor.
- The v2.3.0 `RecenterControl` move (out of the demos' `model_common`, into common) collides with nothing here — this repo carries **no** local `recenter_control.*` / `toast.*` / `zone_default.*` copy.
- `zone_default.cpp` (new in v2.4.0) needs `XR_DXR_display_zones.h`; this repo's vendored `openxr_includes` already ships it with all required symbols (`XrDisplayZoneDXR`, `XrDisplayRigDXR`, `XrCameraRigDXR`, `XR_TYPE_DISPLAY_ZONE_DXR`, `XR_TYPE_EVENT_DATA_DISPLAY_ZONE_METRICS_CHANGED_DXR`).

Relying on the Windows/macOS/Linux/Android build jobs to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Y7bAdR1cFTNxadD5moCtk