### PR TITLE
feat(windows): migrate VK OpenXR session to XR_KHR_vulkan_enable2

### DIFF
--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -2017,17 +2017,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    // Get device extensions
-    std::vector<const char*> deviceExtensions;
-    std::vector<std::string> extensionStorage;
-    if (!GetVulkanDeviceExtensions(xr, vkInstance, physDevice, deviceExtensions, extensionStorage)) {
-        LOG_ERROR("Failed to get Vulkan device extensions");
-        vkDestroyInstance(vkInstance, nullptr);
-        CleanupOpenXR(xr);
-        ShutdownLogging();
-        return 1;
-    }
-
     // Find graphics queue family
     uint32_t queueFamilyIndex = 0;
     if (!FindGraphicsQueueFamily(physDevice, queueFamilyIndex)) {
@@ -2041,7 +2030,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // Create logical device
     VkDevice vkDevice = VK_NULL_HANDLE;
     VkQueue graphicsQueue = VK_NULL_HANDLE;
-    if (!CreateVulkanDevice(physDevice, queueFamilyIndex, deviceExtensions, vkDevice, graphicsQueue)) {
+    if (!CreateVulkanDevice(xr, physDevice, queueFamilyIndex, vkDevice, graphicsQueue)) {
         LOG_ERROR("Vulkan device creation failed");
         vkDestroyInstance(vkInstance, nullptr);
         CleanupOpenXR(xr);

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -66,7 +66,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
 
     for (const auto& ext : extensions) {
         LOG_DEBUG("  %s (v%u)", ext.extensionName, ext.extensionVersion);
-        if (strcmp(ext.extensionName, XR_KHR_VULKAN_ENABLE_EXTENSION_NAME) == 0) {
+        if (strcmp(ext.extensionName, XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME) == 0) {
             hasVulkan = true;
         }
         if (strcmp(ext.extensionName, XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME) == 0) {
@@ -89,7 +89,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         }
     }
 
-    LOG_INFO("XR_KHR_vulkan_enable: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_KHR_vulkan_enable2: %s", hasVulkan ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_win32_window_binding: %s", xr.hasWin32WindowBindingExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_display_info: %s", xr.hasDisplayInfoExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_workspace_file_dialog: %s", xr.hasFileDialogExt ? "AVAILABLE" : "NOT FOUND");
@@ -98,12 +98,17 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_DXR_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
 
     if (!hasVulkan) {
-        LOG_ERROR("XR_KHR_vulkan_enable extension not available");
+        LOG_ERROR("XR_KHR_vulkan_enable2 extension not available");
         return false;
     }
 
+    // vulkan_enable2: the RUNTIME creates the VkInstance/VkDevice on our
+    // behalf (xrCreateVulkanInstanceKHR / xrCreateVulkanDeviceKHR), letting it
+    // append the instance/device extensions AND enable the device features it
+    // needs — notably VK_KHR_present_id/present_wait for late-weave pacing
+    // (INV-5.9), with zero app-side feature code.
     std::vector<const char*> enabledExtensions;
-    enabledExtensions.push_back(XR_KHR_VULKAN_ENABLE_EXTENSION_NAME);
+    enabledExtensions.push_back(XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME);
     if (xr.hasWin32WindowBindingExt) {
         enabledExtensions.push_back(XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME);
     }
@@ -258,18 +263,21 @@ bool InitializeOpenXR(XrSessionManager& xr) {
 bool GetVulkanGraphicsRequirements(XrSessionManager& xr) {
     LOG_INFO("Getting Vulkan graphics requirements...");
 
-    PFN_xrGetVulkanGraphicsRequirementsKHR xrGetVulkanGraphicsRequirementsKHR = nullptr;
-    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrGetVulkanGraphicsRequirementsKHR",
-        (PFN_xrVoidFunction*)&xrGetVulkanGraphicsRequirementsKHR);
-    if (XR_FAILED(result) || !xrGetVulkanGraphicsRequirementsKHR) {
-        LOG_ERROR("Failed to get xrGetVulkanGraphicsRequirementsKHR function pointer");
+    // vulkan_enable2 alias — the un-suffixed xrGetVulkanGraphicsRequirementsKHR
+    // entry point is gated on XR_KHR_vulkan_enable (v1) being enabled, so
+    // xrGetInstanceProcAddr rejects it on an enable2-only instance.
+    PFN_xrGetVulkanGraphicsRequirements2KHR xrGetVulkanGraphicsRequirements2KHR = nullptr;
+    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrGetVulkanGraphicsRequirements2KHR",
+        (PFN_xrVoidFunction*)&xrGetVulkanGraphicsRequirements2KHR);
+    if (XR_FAILED(result) || !xrGetVulkanGraphicsRequirements2KHR) {
+        LOG_ERROR("Failed to get xrGetVulkanGraphicsRequirements2KHR function pointer");
         return false;
     }
 
-    XrGraphicsRequirementsVulkanKHR graphicsReq = {XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR};
-    result = xrGetVulkanGraphicsRequirementsKHR(xr.instance, xr.systemId, &graphicsReq);
+    XrGraphicsRequirementsVulkan2KHR graphicsReq = {XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN2_KHR};
+    result = xrGetVulkanGraphicsRequirements2KHR(xr.instance, xr.systemId, &graphicsReq);
     if (XR_FAILED(result)) {
-        LogXrResult("xrGetVulkanGraphicsRequirementsKHR", result);
+        LogXrResult("xrGetVulkanGraphicsRequirements2KHR", result);
         return false;
     }
 
@@ -287,40 +295,14 @@ bool GetVulkanGraphicsRequirements(XrSessionManager& xr) {
 }
 
 bool CreateVulkanInstance(XrSessionManager& xr, VkInstance& vkInstance) {
-    LOG_INFO("Creating Vulkan instance with OpenXR required extensions...");
+    LOG_INFO("Creating Vulkan instance via xrCreateVulkanInstanceKHR (vulkan_enable2)...");
 
-    // Get required Vulkan instance extensions from the runtime
-    PFN_xrGetVulkanInstanceExtensionsKHR xrGetVulkanInstanceExtensionsKHR = nullptr;
-    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrGetVulkanInstanceExtensionsKHR",
-        (PFN_xrVoidFunction*)&xrGetVulkanInstanceExtensionsKHR);
-    if (XR_FAILED(result) || !xrGetVulkanInstanceExtensionsKHR) {
-        LOG_ERROR("Failed to get xrGetVulkanInstanceExtensionsKHR");
+    PFN_xrCreateVulkanInstanceKHR xrCreateVulkanInstanceKHR = nullptr;
+    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrCreateVulkanInstanceKHR",
+        (PFN_xrVoidFunction*)&xrCreateVulkanInstanceKHR);
+    if (XR_FAILED(result) || !xrCreateVulkanInstanceKHR) {
+        LOG_ERROR("Failed to get xrCreateVulkanInstanceKHR");
         return false;
-    }
-
-    uint32_t bufferSize = 0;
-    xrGetVulkanInstanceExtensionsKHR(xr.instance, xr.systemId, 0, &bufferSize, nullptr);
-    std::string extensionsStr(bufferSize, '\0');
-    xrGetVulkanInstanceExtensionsKHR(xr.instance, xr.systemId, bufferSize, &bufferSize, extensionsStr.data());
-
-    // Parse space-separated extension names
-    std::vector<const char*> extensionPtrs;
-    std::vector<std::string> extensionNames;
-    {
-        size_t start = 0;
-        while (start < extensionsStr.size()) {
-            size_t end = extensionsStr.find(' ', start);
-            if (end == std::string::npos) end = extensionsStr.size();
-            std::string name = extensionsStr.substr(start, end - start);
-            if (!name.empty() && name[0] != '\0') {
-                extensionNames.push_back(name);
-            }
-            start = end + 1;
-        }
-    }
-    for (auto& name : extensionNames) {
-        extensionPtrs.push_back(name.c_str());
-        LOG_INFO("  Required VkInstance extension: %s", name.c_str());
     }
 
     VkApplicationInfo appInfo = {};
@@ -331,36 +313,45 @@ bool CreateVulkanInstance(XrSessionManager& xr, VkInstance& vkInstance) {
     appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
     appInfo.apiVersion = VK_API_VERSION_1_2;  // 3DGS.cpp needs Vulkan 1.2+
 
+    // The runtime appends whatever instance extensions it needs.
     VkInstanceCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     createInfo.pApplicationInfo = &appInfo;
-    createInfo.enabledExtensionCount = (uint32_t)extensionPtrs.size();
-    createInfo.ppEnabledExtensionNames = extensionPtrs.data();
 
-    VkResult vkResult = vkCreateInstance(&createInfo, nullptr, &vkInstance);
-    if (vkResult != VK_SUCCESS) {
-        LOG_ERROR("vkCreateInstance failed: %d", vkResult);
+    XrVulkanInstanceCreateInfoKHR xrCreateInfo = {XR_TYPE_VULKAN_INSTANCE_CREATE_INFO_KHR};
+    xrCreateInfo.systemId = xr.systemId;
+    xrCreateInfo.pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
+    xrCreateInfo.vulkanCreateInfo = &createInfo;
+
+    VkResult vkResult = VK_SUCCESS;
+    result = xrCreateVulkanInstanceKHR(xr.instance, &xrCreateInfo, &vkInstance, &vkResult);
+    if (XR_FAILED(result) || vkResult != VK_SUCCESS) {
+        LOG_ERROR("xrCreateVulkanInstanceKHR failed: xr=%d vk=%d", result, vkResult);
         return false;
     }
 
-    LOG_INFO("Vulkan instance created");
+    LOG_INFO("Vulkan instance created (runtime-managed extensions)");
     return true;
 }
 
 bool GetVulkanPhysicalDevice(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice& physDevice) {
-    LOG_INFO("Getting Vulkan physical device from OpenXR runtime...");
+    LOG_INFO("Getting Vulkan physical device via xrGetVulkanGraphicsDevice2KHR...");
 
-    PFN_xrGetVulkanGraphicsDeviceKHR xrGetVulkanGraphicsDeviceKHR = nullptr;
-    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrGetVulkanGraphicsDeviceKHR",
-        (PFN_xrVoidFunction*)&xrGetVulkanGraphicsDeviceKHR);
-    if (XR_FAILED(result) || !xrGetVulkanGraphicsDeviceKHR) {
-        LOG_ERROR("Failed to get xrGetVulkanGraphicsDeviceKHR");
+    PFN_xrGetVulkanGraphicsDevice2KHR xrGetVulkanGraphicsDevice2KHR = nullptr;
+    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrGetVulkanGraphicsDevice2KHR",
+        (PFN_xrVoidFunction*)&xrGetVulkanGraphicsDevice2KHR);
+    if (XR_FAILED(result) || !xrGetVulkanGraphicsDevice2KHR) {
+        LOG_ERROR("Failed to get xrGetVulkanGraphicsDevice2KHR");
         return false;
     }
 
-    result = xrGetVulkanGraphicsDeviceKHR(xr.instance, xr.systemId, vkInstance, &physDevice);
+    XrVulkanGraphicsDeviceGetInfoKHR getInfo = {XR_TYPE_VULKAN_GRAPHICS_DEVICE_GET_INFO_KHR};
+    getInfo.systemId = xr.systemId;
+    getInfo.vulkanInstance = vkInstance;
+
+    result = xrGetVulkanGraphicsDevice2KHR(xr.instance, &getInfo, &physDevice);
     if (XR_FAILED(result)) {
-        LogXrResult("xrGetVulkanGraphicsDeviceKHR", result);
+        LogXrResult("xrGetVulkanGraphicsDevice2KHR", result);
         return false;
     }
 
@@ -371,67 +362,6 @@ bool GetVulkanPhysicalDevice(XrSessionManager& xr, VkInstance vkInstance, VkPhys
         VK_VERSION_MAJOR(props.apiVersion),
         VK_VERSION_MINOR(props.apiVersion),
         VK_VERSION_PATCH(props.apiVersion));
-
-    return true;
-}
-
-bool GetVulkanDeviceExtensions(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice physDevice,
-    std::vector<const char*>& deviceExtensions, std::vector<std::string>& extensionStorage)
-{
-    PFN_xrGetVulkanDeviceExtensionsKHR xrGetVulkanDeviceExtensionsKHR = nullptr;
-    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrGetVulkanDeviceExtensionsKHR",
-        (PFN_xrVoidFunction*)&xrGetVulkanDeviceExtensionsKHR);
-    if (XR_FAILED(result) || !xrGetVulkanDeviceExtensionsKHR) {
-        LOG_ERROR("Failed to get xrGetVulkanDeviceExtensionsKHR");
-        return false;
-    }
-
-    uint32_t bufferSize = 0;
-    xrGetVulkanDeviceExtensionsKHR(xr.instance, xr.systemId, 0, &bufferSize, nullptr);
-
-    std::string extensionsStr(bufferSize, '\0');
-    xrGetVulkanDeviceExtensionsKHR(xr.instance, xr.systemId, bufferSize, &bufferSize, extensionsStr.data());
-
-    // Parse space-separated extension names
-    std::vector<std::string> requested;
-    {
-        size_t start = 0;
-        while (start < extensionsStr.size()) {
-            size_t end = extensionsStr.find(' ', start);
-            if (end == std::string::npos) end = extensionsStr.size();
-            std::string name = extensionsStr.substr(start, end - start);
-            if (!name.empty() && name[0] != '\0') {
-                requested.push_back(name);
-            }
-            start = end + 1;
-        }
-    }
-
-    // Query which extensions the device actually supports
-    uint32_t availCount = 0;
-    vkEnumerateDeviceExtensionProperties(physDevice, nullptr, &availCount, nullptr);
-    std::vector<VkExtensionProperties> availExts(availCount);
-    vkEnumerateDeviceExtensionProperties(physDevice, nullptr, &availCount, availExts.data());
-
-    // Filter: only request extensions the device actually exposes
-    // (extensions promoted to Vulkan core may not be listed)
-    extensionStorage.clear();
-    deviceExtensions.clear();
-    for (auto& name : requested) {
-        bool available = false;
-        for (auto& ext : availExts) {
-            if (name == ext.extensionName) { available = true; break; }
-        }
-        if (available) {
-            extensionStorage.push_back(name);
-            LOG_INFO("  Required VkDevice extension: %s", name.c_str());
-        } else {
-            LOG_INFO("  Skipping promoted-to-core extension: %s", name.c_str());
-        }
-    }
-    for (auto& name : extensionStorage) {
-        deviceExtensions.push_back(name.c_str());
-    }
 
     return true;
 }
@@ -455,10 +385,19 @@ bool FindGraphicsQueueFamily(VkPhysicalDevice physDevice, uint32_t& queueFamilyI
     return false;
 }
 
-bool CreateVulkanDevice(VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
-    const std::vector<const char*>& deviceExtensions,
+bool CreateVulkanDevice(XrSessionManager& xr, VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
     VkDevice& device, VkQueue& graphicsQueue)
 {
+    LOG_INFO("Creating Vulkan device via xrCreateVulkanDeviceKHR (vulkan_enable2)...");
+
+    PFN_xrCreateVulkanDeviceKHR xrCreateVulkanDeviceKHR = nullptr;
+    XrResult result = xrGetInstanceProcAddr(xr.instance, "xrCreateVulkanDeviceKHR",
+        (PFN_xrVoidFunction*)&xrCreateVulkanDeviceKHR);
+    if (XR_FAILED(result) || !xrCreateVulkanDeviceKHR) {
+        LOG_ERROR("Failed to get xrCreateVulkanDeviceKHR");
+        return false;
+    }
+
     float queuePriority = 1.0f;
     VkDeviceQueueCreateInfo queueInfo = {};
     queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
@@ -466,41 +405,35 @@ bool CreateVulkanDevice(VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
     queueInfo.queueCount = 1;
     queueInfo.pQueuePriorities = &queuePriority;
 
-    // Query supported features before requesting them
-    VkPhysicalDeviceVulkan12Features supported12 = {};
-    supported12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-    VkPhysicalDeviceFeatures2 supportedFeatures2 = {};
-    supportedFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    supportedFeatures2.pNext = &supported12;
-    vkGetPhysicalDeviceFeatures2(physDevice, &supportedFeatures2);
-
-    // Enable features required by 3DGS compute shaders (only if available)
-    // (shaderInt64 / Int64Atomics no longer needed — the 3dgs sort uses
-    // 32-bit packed keys.)
+    // Feature required by the 3DGS compute shaders. pEnabledFeatures passes
+    // through xrCreateVulkanDeviceKHR untouched. (shaderInt64 / Int64Atomics
+    // no longer needed — the 3dgs sort uses 32-bit packed keys.)
     VkPhysicalDeviceFeatures features = {};
     features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
 
-    VkPhysicalDeviceVulkan12Features features12 = {};
-    features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-    // Required for the DisplayXR shell IPC path: the runtime imports the
-    // service's per-client cross-process workspace_sync_fence as a VK
-    // timeline semaphore so the service can ID3D11DeviceContext4::Wait on
-    // our render completion. Without this, every view ships with a stale
-    // fence value and the service skips the blit (manifest: black window).
-    features12.timelineSemaphore = supported12.timelineSemaphore;
-
+    // The runtime appends its required device extensions AND enables the
+    // features it needs — timelineSemaphore (the shell IPC path's
+    // cross-process workspace_sync_fence import) and present_id/present_wait
+    // for late-weave pacing (INV-5.9). No app-side extension/feature ceremony:
+    // in particular do NOT chain VkPhysicalDeviceVulkan12Features here — the
+    // runtime chains its own VkPhysicalDeviceTimelineSemaphoreFeatures, and
+    // mixing the two structs in one chain is invalid (VUID 02830).
     VkDeviceCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-    createInfo.pNext = &features12;
     createInfo.queueCreateInfoCount = 1;
     createInfo.pQueueCreateInfos = &queueInfo;
-    createInfo.enabledExtensionCount = (uint32_t)deviceExtensions.size();
-    createInfo.ppEnabledExtensionNames = deviceExtensions.data();
     createInfo.pEnabledFeatures = &features;
 
-    VkResult vkResult = vkCreateDevice(physDevice, &createInfo, nullptr, &device);
-    if (vkResult != VK_SUCCESS) {
-        LOG_ERROR("vkCreateDevice failed: %d", vkResult);
+    XrVulkanDeviceCreateInfoKHR xrCreateInfo = {XR_TYPE_VULKAN_DEVICE_CREATE_INFO_KHR};
+    xrCreateInfo.systemId = xr.systemId;
+    xrCreateInfo.pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
+    xrCreateInfo.vulkanPhysicalDevice = physDevice;
+    xrCreateInfo.vulkanCreateInfo = &createInfo;
+
+    VkResult vkResult = VK_SUCCESS;
+    result = xrCreateVulkanDeviceKHR(xr.instance, &xrCreateInfo, &device, &vkResult);
+    if (XR_FAILED(result) || vkResult != VK_SUCCESS) {
+        LOG_ERROR("xrCreateVulkanDeviceKHR failed: xr=%d vk=%d", result, vkResult);
         return false;
     }
 

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -35,15 +35,14 @@ bool CreateVulkanInstance(XrSessionManager& xr, VkInstance& vkInstance);
 bool GetVulkanPhysicalDevice(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice& physDevice);
 
 // Get required device extensions from the runtime
-bool GetVulkanDeviceExtensions(XrSessionManager& xr, VkInstance vkInstance, VkPhysicalDevice physDevice,
-    std::vector<const char*>& deviceExtensions, std::vector<std::string>& extensionStorage);
+// (vulkan_enable2: device extensions are appended by the runtime in
+// xrCreateVulkanDeviceKHR — no app-side extension query needed.)
 
 // Find a graphics queue family
 bool FindGraphicsQueueFamily(VkPhysicalDevice physDevice, uint32_t& queueFamilyIndex);
 
 // Create Vulkan logical device with required extensions
-bool CreateVulkanDevice(VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
-    const std::vector<const char*>& deviceExtensions,
+bool CreateVulkanDevice(XrSessionManager& xr, VkPhysicalDevice physDevice, uint32_t queueFamilyIndex,
     VkDevice& device, VkQueue& graphicsQueue);
 
 // Create OpenXR session with Vulkan binding + win32_window_binding


### PR DESCRIPTION
Migrates the Windows VK OpenXR session path from `XR_KHR_vulkan_enable` (v1) to `XR_KHR_vulkan_enable2`, mirroring the runtime's `cube_handle_vk_win` reference migration (displayxr-runtime#838).

## Why

Under enable2 the **runtime** creates the VkDevice and chains `VK_KHR_present_id`/`present_wait` itself, so the runtime's late-weave presentation pacing (weave ~1 refresh before scanout instead of ~6, displayxr-runtime#838/#840) engages with **zero app-side feature code** (INV-5.9 in `docs/guides/displayxr-app-rules.md`).

## What changed (`windows/` only; `linux/` untouched)

- `xrCreateInstance` detects/requests `XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME` (log strings updated).
- Graphics requirements via `xrGetVulkanGraphicsRequirements2KHR` — the un-suffixed v1 name is gated on `XR_KHR_vulkan_enable` in the runtime's `xrGetInstanceProcAddr` and returns FUNCTION_UNSUPPORTED on an enable2-only instance (verified against a live run log).
- `VkInstance` via `xrCreateVulkanInstanceKHR` (runtime appends instance extensions; app keeps its `VkApplicationInfo`, incl. `VK_API_VERSION_1_2` for 3DGS.cpp; `pfnGetInstanceProcAddr = vkGetInstanceProcAddr`).
- Physical device via `xrGetVulkanGraphicsDevice2KHR` + `XrVulkanGraphicsDeviceGetInfoKHR`.
- `VkDevice` via `xrCreateVulkanDeviceKHR`; the whole `xrGetVulkanDeviceExtensionsKHR` query/parse/promoted-to-core-filter plumbing is deleted (`GetVulkanDeviceExtensions` removed from xr_session + main.cpp call site).
- The app-side `VkPhysicalDeviceVulkan12Features{timelineSemaphore}` chain is dropped: the runtime auto-appends `VK_KHR_timeline_semaphore` and chains `VkPhysicalDeviceTimelineSemaphoreFeatures` itself on this path, and mixing that struct with `VkPhysicalDeviceVulkan12Features` in one chain is invalid Vulkan (VUID 02830). The shell-IPC `workspace_sync_fence` import keeps working via the runtime-enabled feature.
- `shaderStorageImageWriteWithoutFormat` (needed by the 3DGS compute shaders) stays, via `pEnabledFeatures`, which `xrCreateVulkanDeviceKHR` passes through untouched.
- `XrGraphicsBindingVulkanKHR` (and the win32 window binding chain) unchanged.

## Testing

- Local Windows build via `scripts/build-with-deps.bat`: clean compile + link (`build\windows\gaussian_splatting_handle_vk_win.exe`).
- Runtime behavior (late-weave engagement, splat rendering, shell IPC) needs an on-hardware eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)