### PR TITLE
fix(#833): union the last view's coverage in the punch-through region (common v2.6.1)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.6.0
+    GIT_TAG v2.6.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -1635,8 +1635,14 @@ static void RenderThreadFunc(
                                     s_punchInit = g_punch.init(vkDevice, physDevice, queueFamilyIndex);
                                 }
                                 if (s_punchInit) {
+                                    // Union the LAST view's tile too — a view-0-only
+                                    // region clips the other views' parallax edges
+                                    // once content moves off ZDP (butterfly bug).
+                                    const uint32_t lastV = (uint32_t)(eyeCount - 1);
                                     g_punch.update(graphicsQueue, (*swapchainVkImages)[imageIndex],
-                                                   renderW, renderH, hwnd, windowW, windowH, nullptr, 0);
+                                                   renderW, renderH, hwnd, windowW, windowH, nullptr, 0,
+                                                   (lastV % cols) * renderW, (lastV / cols) * renderH,
+                                                   eyeCount > 1);
                                 }
                             } else if (g_punch.shaped()) {
                                 g_punch.disable(hwnd);


### PR DESCRIPTION
A view-0-only region clips the other views' parallax edges once content moves off ZDP (butterfly after WASD — David repro). Passes the last view's tile offset; `dxr::ClickThroughRegion` v2.6.1 ORs both footprints in the same cmd/fence (no extra waits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)