### PR TITLE
fix: accept dropped .ply / .spz scenes on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ A test scene, `butterfly.spz`, is bundled and auto-loads at startup.
 | `M` | Auto-orbit: slow turntable rotation when idle for > 10 s |
 | `F` | Flip scene Y-axis (fix for splats trained in the opposite Y convention) |
 | `V` | Cycle rendering modes advertised by the display runtime |
-| `L` or top-bar **Open…** | Load a different `.ply` / `.spz` file |
-| Drag-and-drop (macOS) | Load a `.ply` / `.spz` dropped onto the window |
+| `Ctrl+O` or top-bar **Open…** | Load a different `.ply` / `.spz` file |
+| Drag-and-drop (Windows, macOS) | Load a `.ply` / `.spz` dropped onto the window |
 | Space | Reset pose, zoom, depth, auto-orbit, flip |
 | Tab | Toggle HUD |
 | One-finger drag (Android) | Orbit the splat |

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -15,6 +15,7 @@
 #define _UNICODE
 #include <windows.h>
 #include <commdlg.h>
+#include <shellapi.h>   // DragAcceptFiles / DragQueryFileA / DragFinish (WM_DROPFILES)
 #include <shlwapi.h>
 #include <shlobj.h>
 #pragma comment(lib, "shlwapi.lib")
@@ -788,6 +789,27 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         OpenLoadDialog(hwnd);
         return 0;
 
+    case WM_DROPFILES: {
+        // Drop a .ply / .spz scene onto the window. macOS has had this since the
+        // Cocoa entry point was written; Windows never wired it. The path goes
+        // through the existing QueueSceneLoad — the same entry Ctrl+O and the
+        // #228 spatial picker use, with its ValidateSceneFile check and the
+        // mutex-guarded handoff to the render thread — so a drop is
+        // indistinguishable downstream.
+        HDROP drop = (HDROP)wParam;
+        const UINT count = DragQueryFileA(drop, 0xFFFFFFFF, nullptr, 0);
+        if (count > 0) {
+            char path[MAX_PATH] = {};
+            if (DragQueryFileA(drop, 0, path, MAX_PATH) > 0) {
+                if (count > 1)
+                    LOG_INFO("Drop: %u files, loading the first (%s)", count, path);
+                QueueSceneLoad(hwnd, std::string(path));
+            }
+        }
+        DragFinish(drop);
+        return 0;
+    }
+
     case dxr_capture::kFlashUserMsg:
         // Render thread requested a capture-flash; start it on this thread
         // (the message-pump thread that owns the HWND).
@@ -885,6 +907,11 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height, int32_t 
         LOG_ERROR("Failed to create window, error: %lu", GetLastError());
         return nullptr;
     }
+
+    // Accept dropped .ply / .spz scenes (WM_DROPFILES). This sets the
+    // WS_EX_ACCEPTFILES *extended* style, so it survives any later GWL_STYLE
+    // rewrite (borderless/fullscreen swaps touch the plain style only).
+    DragAcceptFiles(hwnd, TRUE);
 
     LOG_INFO("Window created: 0x%p", hwnd);
     return hwnd;


### PR DESCRIPTION
Companion to `displayxr-demo-modelviewer#78` — same gap, same fix.

macOS has had drag-and-drop since the Cocoa entry point was written; Windows never wired it. The README's `Drag-and-drop (macOS)` row was the only line that said so, and the gesture silently did nothing on the platform most users are on.

## Change

- `DragAcceptFiles(hwnd, TRUE)` at window creation. `WS_EX_ACCEPTFILES` is an **extended** style, so it survives any later `GWL_STYLE` rewrite.
- `WM_DROPFILES` → existing `QueueSceneLoad()`, the same entry `Ctrl+O` and the #228 spatial picker use. Keeps `ValidateSceneFile` and the mutex-guarded `g_pendingLoadPath` handoff, so a drop is **indistinguishable downstream**.
- Multi-file drop takes the first and logs the count.

## Docs

The controls table said `L` for open-file, but that was retired for the uniform `Ctrl+O` chord (see `windows/main.cpp:838`) — corrected, along with the drag-drop platform scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)