### PR TITLE
feat(transparency): keep window topmost while transparent (Ctrl+T)

### DIFF
--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -747,8 +747,12 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         SetWindowLong(hwnd, GWL_STYLE, (LONG)style);
         RECT want = {tl.x, tl.y, tl.x + client.right, tl.y + client.bottom};
         AdjustWindowRect(&want, style, FALSE);
-        SetWindowPos(hwnd, nullptr, want.left, want.top, want.right - want.left,
-                     want.bottom - want.top, SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE);
+        // Transparent mode floats above other apps (the avatar behavior):
+        // clicks punched through to a window behind activate it, but the
+        // scene stays on top. Ctrl+T off returns to the normal z-band.
+        SetWindowPos(hwnd, borderless ? HWND_TOPMOST : HWND_NOTOPMOST, want.left, want.top,
+                     want.right - want.left, want.bottom - want.top,
+                     SWP_FRAMECHANGED | SWP_NOACTIVATE);
         g_borderless.store(borderless);
         return 0;
     }


### PR DESCRIPTION
## What

Keep the window always on top of other apps while transparent mode (Ctrl+T) is active, matching the avatar demo's floating behavior.

## Why

In transparent mode, clicks punch through the shaped region to whatever window is behind; that window activates **above** the demo, so the floating scene drops behind other apps — defeating the content-over-desktop effect.

## How

The `kBorderlessMsg` style-swap handler previously passed `SWP_NOZORDER`, leaving the z-band untouched. It now ties the band to the toggle: `HWND_TOPMOST` on Ctrl+T on, `HWND_NOTOPMOST` back to the normal band on off. `SWP_NOACTIVATE` is kept so entering topmost never steals focus, and F11 fullscreen (`HWND_TOP`) preserves whichever band is active.

## Verified

Local build + live toggle check on the Leia SR box: `WS_EX_TOPMOST` present after Ctrl+T on, absent after Ctrl+T off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
