### PR TITLE
ci: bump the pinned Vulkan SDK to 1.4.309.0 - LunarG retired 1.3.283.0

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -90,7 +90,28 @@ jobs:
         # under $VULKAN_SDK\Bin.
         uses: humbletim/install-vulkan-sdk@v1.2
         with:
-          version: 1.3.283.0
+          # PIN WILL ROT. LunarG serves only the ~16 newest SDK releases and
+          # deletes the installers for older ones. 1.3.283.0 started returning a
+          # hard 404 on 2026-08-17 and broke this workflow with
+          # "curl failed with error code: 22"; re-running cannot help.
+          # See DisplayXR/displayxr-runtime#1029.
+          #
+          # Do NOT "fix" this with `version: latest`. From SDK 1.4.313.0 onward
+          # LunarG repackaged the Windows installer, and this action's naive
+          # `7z x vulkan_sdk.exe` then yields only Bin/ - no Include/, no Lib/.
+          # The action still reports GREEN (it only runs glslangValidator
+          # --version), and the build fails later at find_package(Vulkan) /
+          # Vulkan::Vulkan. 1.4.309.0 is the NEWEST version that still unpacks a
+          # complete SDK (verified by download + 7z).
+          #
+          # When this 404s, pick a newer version from
+          #   https://vulkan.lunarg.com/sdk/versions/windows.json
+          # and verify BOTH that it downloads AND that it unpacks Include/+Lib/:
+          #   curl -I https://sdk.lunarg.com/sdk/download/<ver>/windows/vulkan_sdk.exe
+          # Better: drop the LunarG SDK for vcpkg, as displayxr-runtime already
+          # has (vulkan-headers + vulkan-loader + glslang[tools]) - immutable
+          # pins, cannot rot. Tracked in displayxr-runtime#1029.
+          version: 1.4.309.0
           cache: true
 
       - if: needs.DetectChanges.outputs.docs_only != 'true'


### PR DESCRIPTION
Unbreaks Windows CI. LunarG **retired the Vulkan SDK 1.3.283.0 installer** - the URL `humbletim/install-vulkan-sdk@v1.2` downloads now returns a hard 404, so the *Install Vulkan SDK* step fails with `curl failed with error code: 22` and **re-running cannot help**.

**Change:** one line - `version: 1.3.283.0` -> `version: 1.4.309.0`, plus a comment recording why the pin rots and how to re-pick one. Nothing else touched.

**Why 1.4.309.0 specifically** (not `latest`, not the newest available): from SDK **1.4.313.0** onward LunarG repackaged the Windows installer, and this action's naive `7z x vulkan_sdk.exe` yields **`Bin/` only** - no `Include/`, no `Lib/`. The action still reports GREEN (it only runs `glslangValidator --version`), and the build then fails at `find_package(Vulkan)` / `Vulkan::Vulkan`. Verified by downloading and unpacking each candidate:

| SDK | URL | 7z payload |
|---|---|---|
| 1.3.283.0 | **404 (retired)** | - |
| 1.4.304.0 | 200 | full (`Bin/`+`Include/`+`Lib/`) |
| **1.4.309.0** | **200** | **full** |
| 1.4.313.2 / 1.4.321.1 / 1.4.335.0 / 1.4.357.0 (`latest`) | 200 | **`Bin/` only** |

**This pin will rot again** - 1.4.309.0 is #12 of the 16 versions LunarG still serves. The permanent fix is to drop the LunarG SDK for vcpkg, as `displayxr-runtime` already did; that was deliberately **not** attempted here (it needs a root `vcpkg.json` + a `CMAKE_TOOLCHAIN_FILE` threaded into the cmake invocation, and several demos have their own dependency machinery a second vcpkg toolchain could collide with).

Tracking issue with the full analysis + recommendations: DisplayXR/displayxr-runtime#1029

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DKfVYJBmuWSLApa7a2yQPa
