### PR TITLE
feat(fit): width-aware auto-fit via shared AutoFitVHeight — cap 80% of viewport in both axes

### DIFF
--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -800,20 +800,38 @@ load_butterfly(struct android_app *app)
 
 	// Auto-frame (W7): recenter on the robust scene centroid (so the splat
 	// straddles the display plane at the origin) and derive the virtual
-	// display height from the scene's screen-facing extent — the screen
-	// roughly spans the scene with a small margin, mirroring the desktop
-	// auto-fit semantics (vHeight = scene height).
+	// display height so the scene caps at 80% of the view in BOTH axes.
+	// The block below mirrors displayxr-common auto_fit.h AutoFitVHeight
+	// (the desktop legs call the header directly; the Android CMake does not
+	// pull displayxr-common, so the rule is inlined here). Viewport = the
+	// per-view swapchain rect, valid by now (gs_init runs before this and
+	// g_gs_ready gates entry). getRobustSceneBounds bakes NO comfort margin,
+	// so the fill fraction is the shared default 0.80 — unlike the desktop
+	// legs, which compensate getMainObjectBounds' 1.10x bake with 0.88.
 	float ext[3] = {1.0f, 1.0f, 1.0f};
 	if (g_gs.getRobustSceneBounds(0.05f, 0.95f, g_scene_center, ext)) {
 		// Remember the framed centroid as the long-press reset target.
 		g_scene_center_orig[0] = g_scene_center[0];
 		g_scene_center_orig[1] = g_scene_center[1];
 		g_scene_center_orig[2] = g_scene_center[2];
-		float face = ext[0] > ext[1] ? ext[0] : ext[1];  // width/height extent
-		g_rig_vh.store(face * 1.1f, std::memory_order_relaxed);
-		LOGI("scene center=(%.2f,%.2f,%.2f) extent=(%.2f,%.2f,%.2f) rig_vh=%.2f",
+		const float kFill = 0.8f;
+		const float vp_w = (float)g_views[0].width;
+		const float vp_h = (float)g_views[0].height;
+		float vh = ext[1] / kFill;
+		if (ext[0] > 0.0f && vp_w > 0.0f && vp_h > 0.0f) {
+			const float vh_w = ext[0] / (kFill * (vp_w / vp_h));
+			if (vh_w > vh) {
+				vh = vh_w;
+			}
+		}
+		if (vh > 1e-3f) {
+			g_rig_vh.store(vh, std::memory_order_relaxed);
+		}
+		LOGI("scene center=(%.2f,%.2f,%.2f) extent=(%.2f,%.2f,%.2f) "
+		     "viewport=%ux%u rig_vh=%.2f",
 		     g_scene_center[0], g_scene_center[1], g_scene_center[2],
-		     ext[0], ext[1], ext[2], g_rig_vh.load(std::memory_order_relaxed));
+		     ext[0], ext[1], ext[2], g_views[0].width, g_views[0].height,
+		     g_rig_vh.load(std::memory_order_relaxed));
 	}
 	g_scene_loaded.store(true, std::memory_order_relaxed);
 	return true;

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -804,10 +804,17 @@ load_butterfly(struct android_app *app)
 	// The block below mirrors displayxr-common auto_fit.h AutoFitVHeight
 	// (the desktop legs call the header directly; the Android CMake does not
 	// pull displayxr-common, so the rule is inlined here). Viewport = the
-	// per-view swapchain rect, valid by now (gs_init runs before this and
-	// g_gs_ready gates entry). getRobustSceneBounds bakes NO comfort margin,
-	// so the fill fraction is the shared default 0.80 — unlike the desktop
-	// legs, which compensate getMainObjectBounds' 1.10x bake with 0.88.
+	// PANEL, whose aspect is reconstructed from the per-view swapchain rect
+	// (valid by now: gs_init runs before this and g_gs_ready gates entry).
+	// The per-view rect alone is the WRONG viewport: the runtime recommends
+	// display_pixels × the mode's view scale, and a 2-view mode tiles
+	// side-by-side with scale 0.5×1.0 — so per-view aspect is HALF the panel
+	// aspect. Multiplying the width back by the view count recovers the true
+	// panel aspect (the same grid-cancellation the modelviewer Android leg
+	// does with the mode's real tile counts, specialized to kViewCount = 2
+	// horizontal tiles). getRobustSceneBounds bakes NO comfort margin, so the
+	// fill fraction is the shared default 0.80 — unlike the desktop legs,
+	// which compensate getMainObjectBounds' 1.10x bake with 0.88.
 	float ext[3] = {1.0f, 1.0f, 1.0f};
 	if (g_gs.getRobustSceneBounds(0.05f, 0.95f, g_scene_center, ext)) {
 		// Remember the framed centroid as the long-press reset target.
@@ -815,7 +822,7 @@ load_butterfly(struct android_app *app)
 		g_scene_center_orig[1] = g_scene_center[1];
 		g_scene_center_orig[2] = g_scene_center[2];
 		const float kFill = 0.8f;
-		const float vp_w = (float)g_views[0].width;
+		const float vp_w = (float)(g_views[0].width * kViewCount);
 		const float vp_h = (float)g_views[0].height;
 		float vh = ext[1] / kFill;
 		if (ext[0] > 0.0f && vp_w > 0.0f && vp_h > 0.0f) {
@@ -828,9 +835,10 @@ load_butterfly(struct android_app *app)
 			g_rig_vh.store(vh, std::memory_order_relaxed);
 		}
 		LOGI("scene center=(%.2f,%.2f,%.2f) extent=(%.2f,%.2f,%.2f) "
-		     "viewport=%ux%u rig_vh=%.2f",
+		     "viewport=%.0fx%.0f (panel, %ux%u per view) rig_vh=%.2f",
 		     g_scene_center[0], g_scene_center[1], g_scene_center[2],
-		     ext[0], ext[1], ext[2], g_views[0].width, g_views[0].height,
+		     ext[0], ext[1], ext[2], vp_w, vp_h,
+		     g_views[0].width, g_views[0].height,
 		     g_rig_vh.load(std::memory_order_relaxed));
 	}
 	g_scene_loaded.store(true, std::memory_order_relaxed);

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.6.1
+    GIT_TAG v2.7.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -60,6 +60,7 @@
 #include "gs_renderer_select.h"   // GsActiveRenderer = graphics on Apple Silicon (default)
 #include "gs_scene_loader.h"
 #include "atlas_capture.h"
+#include "auto_fit.h"             // dxr::AutoFitVHeight (shared width-aware load-time framing)
 
 // ============================================================================
 // Logging
@@ -140,10 +141,14 @@ struct InputState {
 // percentile-based extent — see ApplyAutoFitForLoadedScene().
 static constexpr float kDefaultVirtualDisplayHeightM = 1.5f;
 
-// Comfort margin is baked into getMainObjectBounds (which picks a different
-// multiplier for single-object vs scene-with-central-object). Keep this at
-// 1.0 to mean "no extra margin on top of what the bounds method returned".
-static constexpr float kAutoFitVerticalComfort = 1.0f;
+// Fill fraction handed to dxr::AutoFitVHeight. The shared rule's default is
+// 0.80 (asset spans 80% of the viewport on its binding axis), but
+// getMainObjectBounds already bakes a 1.10x comfort margin into all three
+// extent axes, so the extents we pass are 1.10x the true object size. Pass
+// 0.88 = 0.80 x 1.10 to cancel that and net an 80% cap of the TRUE object.
+// (Do not "fix" this by unbaking the comfort in getMainObjectBounds — that
+// multiplier differs single-object vs scene and is shared with other legs.)
+static constexpr float kAutoFitFill = 0.88f;
 
 // Cached auto-fit result for the currently loaded scene. Reused by Reset
 // so 'Space' returns to the framed pose rather than world origin.
@@ -1921,6 +1926,24 @@ static bool FileExists(const std::string& p) {
     return stat(p.c_str(), &st) == 0 && S_ISREG(st.st_mode);
 }
 
+// Viewport the auto-fit width rule frames against: the live content-view
+// bounds when the window exists (g_windowW/H are the drawable size sampled
+// once at startup and never refreshed on resize), else those startup dims.
+// Only the aspect ratio matters to dxr::AutoFitVHeight, so the backing scale
+// factor is irrelevant — it cancels.
+static void GetAutoFitViewport(float& outW, float& outH) {
+    if (g_window) {
+        NSSize cs = [[g_window contentView] bounds].size;
+        if (cs.width > 0.0 && cs.height > 0.0) {
+            outW = (float)cs.width;
+            outH = (float)cs.height;
+            return;
+        }
+    }
+    outW = (float)g_windowW;
+    outH = (float)g_windowH;
+}
+
 // Compute robust scene bounds (5th–95th percentile per axis) and set the
 // display rig pose + vHeight to frame the scene. Display orientation is
 // kept identity (forward = world −Z): splats have no canonical front, and
@@ -1935,7 +1958,13 @@ static void ApplyAutoFitForLoadedScene() {
         g_fitCenter[0] = center[0];
         g_fitCenter[1] = center[1];
         g_fitCenter[2] = center[2];
-        float vh = extent[1] * kAutoFitVerticalComfort;
+        // Shared width-aware rule (displayxr-common common/auto_fit.h):
+        // vHeight = max(H, W / aspect) / fill — the scene caps at `fill` of
+        // the viewport in BOTH axes, so a wide scene no longer overflows
+        // horizontally. See kAutoFitFill for why fill is 0.88, not 0.80.
+        float viewportW = 0.0f, viewportH = 0.0f;
+        GetAutoFitViewport(viewportW, viewportH);
+        float vh = dxr::AutoFitVHeight(extent[0], extent[1], viewportW, viewportH, kAutoFitFill);
         if (!(vh > 1e-3f)) vh = kDefaultVirtualDisplayHeightM; // degenerate scene
         g_fitVHeight = vh;
 
@@ -1946,9 +1975,14 @@ static void ApplyAutoFitForLoadedScene() {
         g_fitYaw = 0.0f;
 
         g_fitValid = true;
-        LOG_INFO("Auto-fit: center=(%.3f, %.3f, %.3f) extent=(%.3f, %.3f, %.3f) vHeight=%.3f yaw=%.0fdeg",
+        const float aspect = (viewportH > 0.0f) ? (viewportW / viewportH) : 0.0f;
+        const bool widthBound = (aspect > 0.0f) && (extent[0] / aspect > extent[1]);
+        LOG_INFO("Auto-fit: center=(%.3f, %.3f, %.3f) extent=(%.3f, %.3f, %.3f) "
+                 "viewport=%.0fx%.0f aspect=%.3f bound=%s fill=%.2f vHeight=%.3f yaw=%.0fdeg",
                  center[0], center[1], center[2],
-                 extent[0], extent[1], extent[2], vh, g_fitYaw * 57.2957795f);
+                 extent[0], extent[1], extent[2],
+                 viewportW, viewportH, aspect, widthBound ? "width" : "height",
+                 kAutoFitFill, vh, g_fitYaw * 57.2957795f);
     } else {
         g_fitValid = false;
     }

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -34,6 +34,7 @@
 #include "hud_renderer.h"
 #include "text_overlay.h"
 #include "atlas_capture.h"
+#include "auto_fit.h"         // dxr::AutoFitVHeight (shared width-aware load-time framing)
 #include "vk_overlay_kit.h"   // dxr::CachedLayerUploader (#837 — no per-frame HUD upload+wait)
 #include "vk_clickthrough_region.h" // dxr::ClickThroughRegion (#833 — transparent-mode punch-through)
 #include "win_window_drag.h"        // dxr::RmbWindowDrag (move the borderless overlay)
@@ -104,6 +105,10 @@ static std::atomic<bool> g_running{true};
 static XrSessionManager* g_xr = nullptr;
 static UINT g_windowWidth = 1280;
 static UINT g_windowHeight = 720;
+// Published once the app window exists so the auto-fit viewport can be read
+// live (GetClientRect) instead of trusting the WM_SIZE-updated statics — the
+// bundled auto-load runs before ShowWindow.
+static HWND g_appWindow = nullptr;
 
 // 3DGS state
 static GsActiveRenderer g_gsRenderer;
@@ -141,10 +146,14 @@ static std::mutex g_sceneMutex;
 // Fallback vHeight when no scene is loaded or auto-fit hits a degenerate
 // extent. Matches macOS demo's kDefaultVirtualDisplayHeightM (1.5m).
 static constexpr float kFallbackVirtualDisplayHeightM = 1.5f;
-// Comfort margin is baked into getMainObjectBounds (which picks a different
-// multiplier for single-object vs scene-with-central-object). Keep this at
-// 1.0 to mean "no extra margin on top of what the bounds method returned".
-static constexpr float kAutoFitVerticalComfort = 1.0f;
+// Fill fraction handed to dxr::AutoFitVHeight. The shared rule's default is
+// 0.80 (asset spans 80% of the viewport on its binding axis), but
+// getMainObjectBounds already bakes a 1.10x comfort margin into all three
+// extent axes, so the extents we pass are 1.10x the true object size. Pass
+// 0.88 = 0.80 x 1.10 to cancel that and net an 80% cap of the TRUE object.
+// (Do not "fix" this by unbaking the comfort in getMainObjectBounds — that
+// multiplier differs single-object vs scene and is shared with other legs.)
+static constexpr float kAutoFitFill = 0.88f;
 
 // Cached auto-fit pose for the currently loaded scene. Reused by Reset
 // so 'Space' returns to the framed pose rather than world origin.
@@ -157,6 +166,21 @@ static std::atomic<bool> g_fitValid{false};
 // (after UpdatePerformanceStats) so the XR_DXR_mcp_tools get_status handler can
 // report it without reaching into the render thread's local PerformanceStats.
 static std::atomic<float> g_currentFps{0.0f};
+
+// Viewport the auto-fit width rule frames against: the live window client
+// rect when the window exists, else the last WM_SIZE dims. Only the aspect
+// ratio matters to dxr::AutoFitVHeight, so pixels are fine.
+static void GetAutoFitViewport(float& outW, float& outH) {
+    RECT client = {};
+    if (g_appWindow && GetClientRect(g_appWindow, &client) &&
+        client.right > client.left && client.bottom > client.top) {
+        outW = (float)(client.right - client.left);
+        outH = (float)(client.bottom - client.top);
+        return;
+    }
+    outW = (float)g_windowWidth;
+    outH = (float)g_windowHeight;
+}
 
 // Compute robust scene bounds (5th–95th percentile per axis) and stage
 // new display-rig pose + vHeight on g_inputState. Display orientation is
@@ -172,7 +196,13 @@ static void ApplyAutoFitForLoadedScene_locked() {
         g_fitCenter[0] = center[0];
         g_fitCenter[1] = center[1];
         g_fitCenter[2] = center[2];
-        float vh = extent[1] * kAutoFitVerticalComfort;
+        // Shared width-aware rule (displayxr-common common/auto_fit.h):
+        // vHeight = max(H, W / aspect) / fill — the scene caps at `fill` of
+        // the viewport in BOTH axes, so a wide scene no longer overflows
+        // horizontally. See kAutoFitFill for why fill is 0.88, not 0.80.
+        float viewportW = 0.0f, viewportH = 0.0f;
+        GetAutoFitViewport(viewportW, viewportH);
+        float vh = dxr::AutoFitVHeight(extent[0], extent[1], viewportW, viewportH, kAutoFitFill);
         // Degenerate scene (all splats in a thin slice) — fall back to a
         // sensible vHeight rather than failing the fit. Mirrors macOS:1399.
         if (!(vh > 1e-3f)) vh = kFallbackVirtualDisplayHeightM;
@@ -183,9 +213,14 @@ static void ApplyAutoFitForLoadedScene_locked() {
         // macOS:1407 — the user can drag with LMB if a particular asset's
         // authored orientation is off.
         g_fitYaw = 0.0f;
-        LOG_INFO("Auto-fit: center=(%.3f, %.3f, %.3f) extent=(%.3f, %.3f, %.3f) vHeight=%.3f yaw=%.0fdeg",
+        const float aspect = (viewportH > 0.0f) ? (viewportW / viewportH) : 0.0f;
+        const bool widthBound = (aspect > 0.0f) && (extent[0] / aspect > extent[1]);
+        LOG_INFO("Auto-fit: center=(%.3f, %.3f, %.3f) extent=(%.3f, %.3f, %.3f) "
+                 "viewport=%.0fx%.0f aspect=%.3f bound=%s fill=%.2f vHeight=%.3f yaw=%.0fdeg",
                  center[0], center[1], center[2],
-                 extent[0], extent[1], extent[2], vh, g_fitYaw * 57.2957795f);
+                 extent[0], extent[1], extent[2],
+                 viewportW, viewportH, aspect, widthBound ? "width" : "height",
+                 kAutoFitFill, vh, g_fitYaw * 57.2957795f);
     }
     g_fitValid.store(ok);
 
@@ -2057,6 +2092,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         ShutdownLogging();
         return 1;
     }
+    // Publish for GetAutoFitViewport (the bundled auto-load fits before ShowWindow).
+    g_appWindow = hwnd;
 
     // Try to load sim_display_set_output_mode
     {


### PR DESCRIPTION
## The rule

Adopts displayxr-common **v2.7.0**'s header-only `common/auto_fit.h`
(`dxr::AutoFitVHeight`). The desktop legs framed **height only**
(`vh = extent[1]`), so a wide scene overflowed the window horizontally. The
shared rule caps the asset at `fill` of the viewport in **both** axes:

    vHeight = max(H, W / aspect) / fill,   aspect = viewportW / viewportH

Only the viewport *aspect* matters; a zero-size viewport degrades to the old
height-only fit, and a non-positive height extent returns 0 so the existing
`kFallbackVirtualDisplayHeightM` guard still fires unchanged.

## Why fill = 0.88 and not 0.80 on desktop

`GsRenderer::getMainObjectBounds` already bakes a **1.10x comfort margin**
into all three extent axes (`3dgs_common/gs_renderer.cpp`, `kComfort`), so the
extents the desktop legs pass in are 1.10x the true object size. Passing the
shared 0.80 default would net a ~73% cap. Passing **0.88 = 0.80 x 1.10**
cancels the bake and nets a true 80% cap of the actual object.

The baked comfort in `gs_renderer` is deliberately **left alone** — it picks a
different multiplier for single-object vs scene-with-central-object and is
shared with the pick/reset paths, so unbaking it there would be a wider
behavior change than this PR wants.

## Viewport source

Both desktop legs read the viewport **live** rather than trusting cached dims:

- Windows: `GetClientRect` on the app HWND (newly published as `g_appWindow`),
  falling back to the `WM_SIZE`-maintained statics. Needed because the bundled
  `butterfly.spz` auto-load fits **before** `ShowWindow`.
- macOS: `[[g_window contentView] bounds]`, falling back to `g_windowW/H` —
  those are sampled once at startup and never refreshed on resize. Backing
  scale factor is irrelevant since it cancels in the aspect.

## Per-leg status

| Leg | Change |
|---|---|
| `windows/main.cpp` | Calls `dxr::AutoFitVHeight(..., 0.88f)`. `kAutoFitVerticalComfort` removed (now redundant). |
| `macos/main.mm` | Same. |
| `android/.../main.cpp` | Was already width-aware but **aspect-blind** (`face = max(w,h); vh = face * 1.1`). Now aspect-correct against the per-view swapchain rect. Rule is **inlined** with a pointer comment because the Android CMake does not pull displayxr-common. It reads `getRobustSceneBounds`, which bakes **no** comfort, so it uses the plain **0.80** fill. |
| `linux/main.cpp` | **Unchanged** — it has no auto-fit at all (hard-coded `virtualDisplayHeight = 1.5f`). |

Call sites (MCP `load_scene`, bundled auto-load, picker drain) are structurally
untouched; `g_fitVHeight` and the fallback guard are unchanged.

## Framing change

This visibly reframes assets. Anything wider than `viewportAspect x` its own
height now pulls **back** (larger vHeight) to fit horizontally; tall assets are
unchanged apart from the exact 80%-of-true-size normalization. Android in
particular tightens from an effective ~91% fill to 80%.

## Logs

The fit line now reports both extents, the viewport and its aspect, which axis
bound the fit, and the fill fraction — so a surprising framing is diagnosable
from the log alone.

## Verification

- Windows leg builds clean: `scripts\build-with-deps.bat x64` →
  `build\windows\gaussian_splatting_handle_vk_win.exe` rebuilt (mtime verified).
- FetchContent confirmed checked out at `v2.7.0` with `common/auto_fit.h`
  present.
- **Hardware eyeball pending** — not launched per instruction. Wants a look at
  a wide scene on the Leia SR panel to confirm the new framing reads right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
