### PR TITLE
fix(android): add vendor-service <queries> so the demo runs in-process

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           # plug-in / SDK / OEM the ecosystem integrates with - like naming NVIDIA in
           # CUDA code. A line containing any of these tokens is permitted.
           FORBIDDEN="le""ia"
-          ALLOW='cnsdk|leia_cnsdk|libdxrp050_leia_cnsdk|leiasdk|leiasr|displayxr-leia|leia-plugin|leiaplugin|leia_plugin|leia_tag|leia-sr|leia sr|leia hardware|leia display|leia dp|leia android dp|leia sdk|leia plug|leia panel|leia weave|leia face|leia viewer|leia-viewer|leia convention|leia lif|leia heif|leia image format|leiaschema|classic leia|leialoft|leiainc/|LEIA_EXE|LEIA_VER|LEIA_TAG|SecLeia|G_Leia|LeiaUnrealSDK|LeiaPlayerWin'
+          ALLOW='cnsdk|leia_cnsdk|libdxrp050_leia_cnsdk|leiasdk|leiasr|displayxr-leia|leia-plugin|leiaplugin|leia_plugin|leia_tag|leia-sr|leia sr|leia hardware|leia display|leia dp|leia android dp|leia sdk|leia plug|leia panel|leia weave|leia face|leia viewer|leia-viewer|leia convention|leia lif|leia heif|leia image format|leiaschema|classic leia|leialoft|leiainc/|com.leia.|com\.leia\.\*|LEIA_EXE|LEIA_VER|LEIA_TAG|SecLeia|G_Leia|LeiaUnrealSDK|LeiaPlayerWin'
           hits=$(grep -rniI \
                    --exclude-dir=.git --exclude-dir=.claude \
                    --exclude-dir=openxr --exclude-dir=displayxr-common \

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -35,6 +35,21 @@
         <intent>
             <action android:name="org.freedesktop.monado.ipc.CONNECT" />
         </intent>
+        <!--
+            ARCHITECTURE A (in-process, ADR-036 D2 / ADR-025): the vendor display
+            processor runs in THIS process; its CNSDK core loader calls
+            PackageManager.getPackageInfo() on the on-device vendor services to
+            bind display config + face tracking. Package visibility is enforced
+            per CALLING UID, so declaring them in the runtime APK is not enough —
+            without these two lines the loader gets a NameNotFoundException it
+            never clears and the next JNI call trips CheckJNI, aborting the app
+            during head-tracking bring-up (in-process only; the OOP path binds
+            them in the runtime process). This is the last vendor-specific thing
+            in a client APK; it goes away once the vendor services advertise a
+            neutral intent action (ADR-036 D5 / vendor ask L7).
+        -->
+        <package android:name="com.leialoft.display.config" />
+        <package android:name="com.leia.headtrackingservice" />
     </queries>
 
     <uses-feature


### PR DESCRIPTION
The last of the five demos to get this fix. `avatar`, `earthview`, `mediaplayer` and `modelviewer` all landed it in August; `gaussiansplat` was missed — and it reads as *clean* (zero unreleased commits), so nothing surfaced the gap until an org-wide survey compared all five manifests side by side.

```
gaussiansplat: *** MISSING ***      avatar: HAS      modelviewer: HAS
mediaplayer:   HAS                  earthview: HAS
```

## Why this demo is in scope

The in-process vendor display processor (ADR-036 D2 / ADR-025) calls `PackageManager.getPackageInfo()` on the on-device vendor services during head-tracking bring-up. Android 11+ enforces package visibility **per calling UID**, so declaring them in the runtime APK is not enough — without `<package>` visibility the CNSDK loader hits a `NameNotFoundException` it never clears, and the next JNI call trips CheckJNI, aborting the app shortly after the plug-in loads.

This repo's own manifest already declares **both** runtime flavors (`out_of_process (production, ADR-025) or in_process (dev)`) and already documents CNSDK's face tracker being *"loaded by the runtime broker into this app's process"* — precisely the configuration that needs per-UID visibility. `DisplayXRGaussianSplat-*.apk` ships on every release, so the shipped artifact is affected.

Block copied **verbatim from `displayxr-demo-modelviewer`**, comment included, so the five manifests stay identical rather than drifting into per-repo prose.

## Also pre-empts the vendor-name guard

`com.leia.headtrackingservice` is not covered by this repo's Tier-A ALLOW list, and `lint.yml` is `pull_request`-only — so adding the manifest lines alone would have made this very PR fail on a hit it introduced. Same one-line allowlist the other four now carry (tokens taken from `displayxr-demo-avatar`). Verified with the guard's exact grep locally: passes.

## NOT tested

**No device run.** I have no NP02J access from here. The manifest parses as valid XML and the guard passes locally, but the actual in-process launch on hardware is unverified — the other four demos each had a device-verified run in their commit. Worth one pass before the release that ships this APK.