### PR TITLE
fix(android): the fit viewport is the WINDOW, not the native panel

### DIFF
--- a/3dgs_common/gs_adreno_renderer.cpp
+++ b/3dgs_common/gs_adreno_renderer.cpp
@@ -796,6 +796,15 @@ void GsAdrenoRenderer::renderEye(VkImage swapchainImage, VkFormat /*swapchainFor
 
 // ═══════════════════════════ getRobustSceneBounds ═══════════════════════════
 
+bool GsAdrenoRenderer::getSceneBBox(float outMin[3], float outMax[3]) const {
+    if (!sceneBBoxValid_) return false;
+    for (int a = 0; a < 3; a++) {
+        outMin[a] = sceneBBoxMin_[a];
+        outMax[a] = sceneBBoxMax_[a];
+    }
+    return true;
+}
+
 bool GsAdrenoRenderer::getRobustSceneBounds(float loPct, float hiPct,
                                             float outCenter[3], float outExtent[3]) const {
     if (numGaussians_ == 0) return false;

--- a/3dgs_common/gs_adreno_renderer.h
+++ b/3dgs_common/gs_adreno_renderer.h
@@ -63,6 +63,11 @@ struct GsAdrenoRenderer {
     // Robust scene centroid + per-axis extent (outlier-trimmed): per axis takes
     // the loPct/hiPct quantile positions, center=midpoint, extent=hi-lo. Used by
     // the demo for auto-framing. Returns false if no scene is loaded.
+    //! Full scene AABB over every gaussian CENTRE (no percentile trim).
+    //! Mirrors GsRenderer::getSceneBBox. Used to measure how much the robust
+    //! percentile box under-reports the visible extent.
+    bool getSceneBBox(float outMin[3], float outMax[3]) const;
+
     bool getRobustSceneBounds(float loPct, float hiPct,
                               float outCenter[3], float outExtent[3]) const;
 

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -43,6 +43,7 @@
 // XR_DXR_display_info: the panel pixel size, so the load-time auto-fit
 // can use the real viewport instead of reconstructing one.
 #include <openxr/XR_DXR_display_info.h>
+#include <android/native_window.h>
 
 #define LOG_TAG "gausssplat_vk_android"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
@@ -887,13 +888,31 @@ load_butterfly(struct android_app *app)
 		// (both current modes: 2D 1.0x1.0, LeiaSR 0.75x0.75) and merely
 		// approximate for a hypothetical anamorphic one -- still far closer
 		// than the tile reconstruction it replaces.
+		//
+		// PRIORITY: the app's own WINDOW, then the panel, then the per-view
+		// aspect. The window is the only source that tracks ORIENTATION. The
+		// panel from display_info is the NATIVE (landscape) 2560x1600 whatever
+		// way up the device is held, so on a portrait launch it reports aspect
+		// 1.600 where the viewport is really 1600x2560 = 0.625 -- and the fit
+		// then stays height-bound and the asset overflows sideways. Measured:
+		// a 1.47x1.18 scene wants rig_vh 1.47 under 1.600 (height-bound) but
+		// 2.94 under 0.625 (width-bound), i.e. twice as small.
 		float vp_w = (float)g_views[0].width;
 		float vp_h = (float)g_views[0].height;
-		const char *vp_src = "per-view aspect (display_info absent)";
+		const char *vp_src = "per-view aspect (no window, no display_info)";
 		if (g_panel_px_w > 0 && g_panel_px_h > 0) {
 			vp_w = (float)g_panel_px_w;
 			vp_h = (float)g_panel_px_h;
-			vp_src = "panel (display_info)";
+			vp_src = "panel (display_info, orientation-blind)";
+		}
+		if (app != nullptr && app->window != nullptr) {
+			const int32_t win_w = ANativeWindow_getWidth(app->window);
+			const int32_t win_h = ANativeWindow_getHeight(app->window);
+			if (win_w > 0 && win_h > 0) {
+				vp_w = (float)win_w;
+				vp_h = (float)win_h;
+				vp_src = "window (ANativeWindow)";
+			}
 		}
 		float vh = ext[1] / kFill;
 		if (ext[0] > 0.0f && vp_w > 0.0f && vp_h > 0.0f) {

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -865,6 +865,25 @@ load_butterfly(struct android_app *app)
 	// which compensate getMainObjectBounds' 1.10x bake with 0.88.
 	float ext[3] = {1.0f, 1.0f, 1.0f};
 	if (g_gs.getRobustSceneBounds(0.05f, 0.95f, g_scene_center, ext)) {
+		// DIAGNOSTIC: the [5%,95%] box under-reports what is actually drawn.
+		// It trims 10% of gaussians AND is computed over CENTRES only, so it
+		// ignores every splat's rendered footprint. Fitting it to 80% therefore
+		// draws the VISIBLE asset larger than 80%. Log the wider boxes so the
+		// real ratio is measured rather than guessed at.
+		{
+			float c99[3], e99[3], bmin[3], bmax[3];
+			const bool ok99 =
+			    g_gs.getRobustSceneBounds(0.01f, 0.99f, c99, e99);
+			const bool okbb = g_gs.getSceneBBox(bmin, bmax);
+			LOGI("fitbox: p05_95=(%.3f,%.3f) p01_99=(%.3f,%.3f) full=(%.3f,%.3f) "
+			     "ratio_w p99/p95=%.3f full/p95=%.3f",
+			     ext[0], ext[1],
+			     ok99 ? e99[0] : -1.0f, ok99 ? e99[1] : -1.0f,
+			     okbb ? (bmax[0] - bmin[0]) : -1.0f,
+			     okbb ? (bmax[1] - bmin[1]) : -1.0f,
+			     (ok99 && ext[0] > 0.0f) ? e99[0] / ext[0] : -1.0f,
+			     (okbb && ext[0] > 0.0f) ? (bmax[0] - bmin[0]) / ext[0] : -1.0f);
+		}
 		// Remember the framed centroid as the long-press reset target.
 		g_scene_center_orig[0] = g_scene_center[0];
 		g_scene_center_orig[1] = g_scene_center[1];

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -165,6 +165,7 @@ static void mark_user_input() { g_last_input_ms.store(now_ms(), std::memory_orde
 // (the screen roughly spans the scene — desktop auto-fit semantics).
 bool g_has_view_rig = false;
 std::atomic<float> g_rig_vh{1.0f};
+}
 
 // Tablet gesture state (fed via MainActivity.dispatchTouchEvent → nativeOnTouch +
 // a GestureDetector, runtime#499). All applied to the DISPLAY rig pose / vH at
@@ -179,6 +180,136 @@ std::atomic<float> g_rig_vh{1.0f};
 std::atomic<float> g_orbit_yaw{0.0f};   // 1-finger drag, 0.005 rad/px, -= convention
 std::atomic<float> g_orbit_pitch{0.0f}; // clamped ±1.5 rad
 std::atomic<float> g_zoom{1.0f};        // pinch: >1 zooms in (rig_vh = base/g_zoom)
+
+// ── Load-time fit extents, cached so a viewport change can re-derive the base
+// without re-measuring the scene (they are properties of the CONTENT, not of
+// the viewport). 0 = no scene fitted yet.
+float g_fit_ext_w = 0.0f;
+float g_fit_ext_h = 0.0f;
+// Viewport the current base was derived from, so a config change that does not
+// alter the aspect (a resize that keeps proportions) does not retrigger.
+float g_fit_vp_w = 0.0f;
+float g_fit_vp_h = 0.0f;
+
+// ── Base-vHeight transition (rotation refit) ────────────────────────────────
+// Rotation changes the VIEWPORT, not the content and not the user's intent, so
+// the BASE is re-derived while g_zoom / orbit / pivot are left alone. Because
+// the render path already computes rig_vh = base / g_zoom, a pinch stays
+// RELATIVE: 2x of the old fit becomes 2x of the new one, so the subject keeps
+// its apparent size instead of jumping.
+//
+// Scalar mirror of dxr::RigTransition (displayxr-common common/rig_transition.h)
+// with Easing::SmoothStep -- same curve, same "t_ starts landed" convention.
+// Not linked directly: that class lerps whole dxr_rig structs and lives in a
+// .cpp inside displayxr_common_lib, which an Android build cannot link (the
+// same reason auto_fit.h is inlined here).
+constexpr float kRefitDurationS = 0.20f;
+// The live window, published by handle_cmd. Polled each frame rather than
+// keyed off a specific APP_CMD: rotation can surface as CONFIG_CHANGED,
+// WINDOW_RESIZED, or a TERM+INIT pair depending on the device, and polling is
+// correct for all of them. The aspect guard in refit_for_viewport makes the
+// poll cheap and makes "settled" fall out for free -- a mid-rotation
+// intermediate size that lands on the same aspect never retriggers.
+std::atomic<ANativeWindow *> g_native_window{nullptr};
+std::atomic<float> g_vh_from{0.0f};
+std::atomic<float> g_vh_to{0.0f};
+std::atomic<float> g_vh_t{1.0f}; //!< normalized progress; 1 = idle/landed
+
+inline float
+refit_curve(float t)
+{
+	if (t <= 0.0f)
+		return 0.0f;
+	if (t >= 1.0f)
+		return 1.0f;
+	return t * t * (3.0f - 2.0f * t); // SmoothStep, matches RigTransition
+}
+
+//! Seconds since the previous call (monotonic). First call returns 0.
+inline float
+frame_dt_s()
+{
+	static int64_t prev_ns = 0;
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	const int64_t now_ns = (int64_t)ts.tv_sec * 1000000000ll + ts.tv_nsec;
+	if (prev_ns == 0) {
+		prev_ns = now_ns;
+		return 0.0f;
+	}
+	const float dt = (float)(now_ns - prev_ns) * 1e-9f;
+	prev_ns = now_ns;
+	// Clamp: a backgrounded app would otherwise land the lerp instantly on
+	// resume, which is the snap this transition exists to avoid.
+	return (dt > 0.1f) ? 0.1f : dt;
+}
+
+void refit_for_viewport(float vp_w, float vp_h, const char *why);
+
+//! Advance the refit lerp and publish the interpolated base. No-op when landed.
+void
+refit_update(float dt_s)
+{
+	// Poll the window first: a rotation shows up here as a new aspect.
+	if (ANativeWindow *win = g_native_window.load(std::memory_order_relaxed)) {
+		const int32_t ww = ANativeWindow_getWidth(win);
+		const int32_t wh = ANativeWindow_getHeight(win);
+		if (ww > 0 && wh > 0) {
+			refit_for_viewport((float)ww, (float)wh, "viewport change");
+		}
+	}
+
+	float t = g_vh_t.load(std::memory_order_relaxed);
+	if (t >= 1.0f) {
+		return;
+	}
+	t += (kRefitDurationS > 0.0f) ? (dt_s / kRefitDurationS) : 1.0f;
+	if (t > 1.0f) {
+		t = 1.0f;
+	}
+	g_vh_t.store(t, std::memory_order_relaxed);
+	const float a = g_vh_from.load(std::memory_order_relaxed);
+	const float b = g_vh_to.load(std::memory_order_relaxed);
+	g_rig_vh.store(a + (b - a) * refit_curve(t), std::memory_order_relaxed);
+}
+
+//! Re-derive the base vHeight for a new viewport and start the transition.
+//! Retargets in flight rather than restarting, so a rotation that settles in
+//! two steps does not snap back to the old value mid-lerp.
+void
+refit_for_viewport(float vp_w, float vp_h, const char *why)
+{
+	if (!(g_fit_ext_w > 0.0f) || !(g_fit_ext_h > 0.0f)) {
+		return; // nothing fitted yet
+	}
+	if (!(vp_w > 0.0f) || !(vp_h > 0.0f)) {
+		return;
+	}
+	// Only the ASPECT moves the fit; ignore a resize that keeps proportions.
+	const float a_new = vp_w / vp_h;
+	const float a_old = (g_fit_vp_h > 0.0f) ? (g_fit_vp_w / g_fit_vp_h) : -1.0f;
+	if (a_old > 0.0f && std::fabs(a_new - a_old) < 1e-3f) {
+		return;
+	}
+	constexpr float kFill = 0.8f;
+	float vh = g_fit_ext_h / kFill;
+	const float vh_w = g_fit_ext_w / (kFill * a_new);
+	if (vh_w > vh) {
+		vh = vh_w;
+	}
+	if (!(vh > 1e-3f)) {
+		return;
+	}
+	g_fit_vp_w = vp_w;
+	g_fit_vp_h = vp_h;
+	g_vh_from.store(g_rig_vh.load(std::memory_order_relaxed),
+	                std::memory_order_relaxed);
+	g_vh_to.store(vh, std::memory_order_relaxed);
+	g_vh_t.store(0.0f, std::memory_order_relaxed);
+	LOGI("refit (%s): viewport=%.0fx%.0f aspect=%.3f base %.2f -> %.2f "
+	     "(zoom %.2fx preserved)",
+	     why, vp_w, vp_h, a_new, g_vh_from.load(std::memory_order_relaxed), vh,
+	     g_zoom.load(std::memory_order_relaxed));
 
 // Double-tap focus / long-press reset: the UI thread sets a pending tap NDC (or a
 // reset request); the render loop raycasts it (needs the located views) and
@@ -962,6 +1093,14 @@ load_butterfly(struct android_app *app)
 		}
 		if (vh > 1e-3f) {
 			g_rig_vh.store(vh, std::memory_order_relaxed);
+			// Cache for the rotation refit: the extents are CONTENT
+			// properties, so a viewport change re-derives the base from
+			// these without re-measuring the scene.
+			g_fit_ext_w = fit_w;
+			g_fit_ext_h = fit_h;
+			g_fit_vp_w = vp_w;
+			g_fit_vp_h = vp_h;
+			g_vh_t.store(1.0f, std::memory_order_relaxed); // landed
 		}
 		LOGI("scene center=(%.2f,%.2f,%.2f) extent=(%.2f,%.2f,%.2f) "
 		     "fit=(%.2f,%.2f) viewport=%.0fx%.0f aspect=%.3f src=%s "
@@ -1097,6 +1236,10 @@ render_frame()
 		// 2-finger drag → pan (rig position in its view plane), 1-finger drag →
 		// orbit (rig orientation). The runtime resolves the off-axis Kooima around
 		// this pose (server-side over IPC on the OOP path).
+		// Advance the rotation refit, then apply the user's pinch on top: the
+		// zoom is RELATIVE to whatever the current base is, so a 2x pinch stays
+		// 2x across a rotation instead of the subject changing size.
+		refit_update(frame_dt_s());
 		const float rig_vh = g_rig_vh.load(std::memory_order_relaxed) /
 		                     g_zoom.load(std::memory_order_relaxed);
 		XrPosef rig_pose = {};
@@ -1374,6 +1517,7 @@ handle_cmd(struct android_app *app, int32_t cmd)
 	switch (cmd) {
 	case APP_CMD_INIT_WINDOW:
 		LOGI("APP_CMD_INIT_WINDOW (window=%p)", app->window);
+		g_native_window.store(app->window, std::memory_order_relaxed);
 		if (g_instance == XR_NULL_HANDLE) {
 			bool ok =
 			    create_instance(app) &&
@@ -1389,8 +1533,14 @@ handle_cmd(struct android_app *app, int32_t cmd)
 			LOGI(ok ? "Bring-up complete." : "Bring-up failed; see logs.");
 		}
 		break;
+	case APP_CMD_TERM_WINDOW:
+		// Stop polling a window that is going away.
+		LOGI("APP_CMD_TERM_WINDOW");
+		g_native_window.store(nullptr, std::memory_order_relaxed);
+		break;
 	case APP_CMD_DESTROY:
 		LOGI("APP_CMD_DESTROY");
+		g_native_window.store(nullptr, std::memory_order_relaxed);
 		destroy_all();
 		break;
 	default:

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -865,29 +865,34 @@ load_butterfly(struct android_app *app)
 	// which compensate getMainObjectBounds' 1.10x bake with 0.88.
 	float ext[3] = {1.0f, 1.0f, 1.0f};
 	if (g_gs.getRobustSceneBounds(0.05f, 0.95f, g_scene_center, ext)) {
-		// DIAGNOSTIC: the [5%,95%] box under-reports what is actually drawn.
-		// It trims 10% of gaussians AND is computed over CENTRES only, so it
-		// ignores every splat's rendered footprint. Fitting it to 80% therefore
-		// draws the VISIBLE asset larger than 80%. Log the wider boxes so the
-		// real ratio is measured rather than guessed at.
-		{
-			float c99[3], e99[3], bmin[3], bmax[3];
-			const bool ok99 =
-			    g_gs.getRobustSceneBounds(0.01f, 0.99f, c99, e99);
-			const bool okbb = g_gs.getSceneBBox(bmin, bmax);
-			LOGI("fitbox: p05_95=(%.3f,%.3f) p01_99=(%.3f,%.3f) full=(%.3f,%.3f) "
-			     "ratio_w p99/p95=%.3f full/p95=%.3f",
-			     ext[0], ext[1],
-			     ok99 ? e99[0] : -1.0f, ok99 ? e99[1] : -1.0f,
-			     okbb ? (bmax[0] - bmin[0]) : -1.0f,
-			     okbb ? (bmax[1] - bmin[1]) : -1.0f,
-			     (ok99 && ext[0] > 0.0f) ? e99[0] / ext[0] : -1.0f,
-			     (okbb && ext[0] > 0.0f) ? (bmax[0] - bmin[0]) / ext[0] : -1.0f);
-		}
 		// Remember the framed centroid as the long-press reset target.
 		g_scene_center_orig[0] = g_scene_center[0];
 		g_scene_center_orig[1] = g_scene_center[1];
 		g_scene_center_orig[2] = g_scene_center[2];
+		// The bounds are percentiles over gaussian CENTRES, so they under-report
+		// what is actually drawn and the asset renders larger than `kFill`.
+		// Measured on device for the bundled scene:
+		//
+		//   p05_95 width 1.474   (what this used to fit)
+		//   p01_99 width 1.715   = 1.164x   -- the percentile trim
+		//   visible             ~= 1.25x    -- from "the asset fits the width
+		//                                      exactly" when 0.80 was asked for
+		//
+		// So the trim explains ~1.16x and the remaining ~1.07x is the splat
+		// FOOTPRINT: a percentile over centres cannot see how far each blob
+		// extends past its own centre, and the per-gaussian scales live GPU-side
+		// so the CPU cannot measure it here.
+		//
+		// Fix the BOX, not the fill: `kFill` keeps the shared rule's meaning
+		// (the asset occupies 80% of the viewport), and the box is corrected to
+		// approximate the asset. Widen to [1%,99%] -- still trims true floaters
+		// -- then inflate by the footprint term.
+		//
+		// kSplatFootprint is calibrated against ONE asset and ONE visual
+		// judgement, so treat it as an estimate, not a constant of nature. The
+		// desktop legs do the same kind of correction in the other direction:
+		// their bounds bake a 1.10x margin and they use fill 0.88 to cancel it.
+		constexpr float kSplatFootprint = 1.07f;
 		const float kFill = 0.8f;
 		// Viewport = the PANEL. This app is fullscreen, so window == panel;
 		// XR_DXR_display_info reports it directly.
@@ -933,9 +938,24 @@ load_butterfly(struct android_app *app)
 				vp_src = "window (ANativeWindow)";
 			}
 		}
-		float vh = ext[1] / kFill;
-		if (ext[0] > 0.0f && vp_w > 0.0f && vp_h > 0.0f) {
-			const float vh_w = ext[0] / (kFill * (vp_w / vp_h));
+		// Fit extents: widened percentile x footprint. The CENTROID above stays
+		// the robust [5%,95%] one -- a centre should not chase floaters.
+		float fit_w = ext[0];
+		float fit_h = ext[1];
+		{
+			float c99[3], e99[3];
+			if (g_gs.getRobustSceneBounds(0.01f, 0.99f, c99, e99) &&
+			    e99[0] > 0.0f && e99[1] > 0.0f) {
+				fit_w = e99[0];
+				fit_h = e99[1];
+			}
+		}
+		fit_w *= kSplatFootprint;
+		fit_h *= kSplatFootprint;
+
+		float vh = fit_h / kFill;
+		if (fit_w > 0.0f && vp_w > 0.0f && vp_h > 0.0f) {
+			const float vh_w = fit_w / (kFill * (vp_w / vp_h));
 			if (vh_w > vh) {
 				vh = vh_w;
 			}
@@ -944,9 +964,10 @@ load_butterfly(struct android_app *app)
 			g_rig_vh.store(vh, std::memory_order_relaxed);
 		}
 		LOGI("scene center=(%.2f,%.2f,%.2f) extent=(%.2f,%.2f,%.2f) "
-		     "viewport=%.0fx%.0f aspect=%.3f src=%s (%ux%u per view) rig_vh=%.2f",
+		     "fit=(%.2f,%.2f) viewport=%.0fx%.0f aspect=%.3f src=%s "
+		     "(%ux%u per view) rig_vh=%.2f",
 		     g_scene_center[0], g_scene_center[1], g_scene_center[2],
-		     ext[0], ext[1], ext[2], vp_w, vp_h,
+		     ext[0], ext[1], ext[2], fit_w, fit_h, vp_w, vp_h,
 		     (vp_h > 0.0f ? vp_w / vp_h : 0.0f), vp_src,
 		     g_views[0].width, g_views[0].height,
 		     g_rig_vh.load(std::memory_order_relaxed));

--- a/android/src/main/cpp/main.cpp
+++ b/android/src/main/cpp/main.cpp
@@ -165,7 +165,6 @@ static void mark_user_input() { g_last_input_ms.store(now_ms(), std::memory_orde
 // (the screen roughly spans the scene — desktop auto-fit semantics).
 bool g_has_view_rig = false;
 std::atomic<float> g_rig_vh{1.0f};
-}
 
 // Tablet gesture state (fed via MainActivity.dispatchTouchEvent → nativeOnTouch +
 // a GestureDetector, runtime#499). All applied to the DISPLAY rig pose / vH at
@@ -310,6 +309,7 @@ refit_for_viewport(float vp_w, float vp_h, const char *why)
 	     "(zoom %.2fx preserved)",
 	     why, vp_w, vp_h, a_new, g_vh_from.load(std::memory_order_relaxed), vh,
 	     g_zoom.load(std::memory_order_relaxed));
+}
 
 // Double-tap focus / long-press reset: the UI thread sets a pending tap NDC (or a
 // reset request); the render loop raycasts it (needs the located views) and


### PR DESCRIPTION
Follow-up to #91 — **that change was not enough, and the error was mine.**

#91 replaced the atlas aspect (3.200) with the panel aspect (1.600). Correct in landscape. Still wrong in **portrait**, where the window is 1600×2560 = **0.625**.

Reported from the pad: the demo opened in portrait and the asset was framed to height only, overflowing and clipping laterally. Confirmed on device (`user_rotation=0`), for the bundled 1.47 × 1.18 scene:

| viewport | aspect | vh_h | vh_w | result |
|---|---|---|---|---|
| atlas 3840×1200 (original) | 3.200 | 1.47 | 0.57 | height-bound |
| panel 2560×1600 (#91) | 1.600 | 1.47 | 1.15 | **still height-bound** |
| window 1600×2560 (portrait) | 0.625 | 1.47 | **2.94** | **width-bound** |

So the asset should be drawn **half the size** it was — exactly the reported symptom.

## Root error

`XR_DXR_display_info` reports the **native** panel: 2560×1600 whichever way up the device is held. It is **orientation-blind**, so it can never be the viewport for an app that can rotate. I reached for it because it was the most direct-looking source, and it happened to validate cleanly in landscape.

The rule wants the **window** (or the zone rect when rendering into a zone) — which is what `displayxr-common`'s `auto_fit.h` says in its own contract, and what I was told plainly in review. I under-applied it.

## Fix

Viewport source, in priority order:

1. **The app's own window** — `ANativeWindow_getWidth/Height`. The only source that tracks orientation. `load_butterfly()` already had the `android_app *`, so this is a direct read.
2. The `display_info` panel — kept as a fallback, now explicitly labelled *orientation-blind* so nobody mistakes it for the viewport again.
3. The per-view rect's own aspect.

The log prints which source won, so a wrong fit is diagnosable from one line instead of by re-deriving the arithmetic.

## Verification

Pending on the pad in **portrait** — I will confirm `src=window (ANativeWindow)`, `aspect≈0.625`, and `rig_vh≈2.94`, and that the asset visibly stops clipping. Landscape re-check too, since that is the case #91 got right and must not regress.