### PR TITLE
docs(android): the in-process/out-of-process comment has been wrong since #1031

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -27,8 +27,14 @@
         <provider
             android:authorities="org.khronos.openxr.runtime_broker"
             tools:replace="android:authorities" />
-        <!-- Both runtime flavors so the same APK runs against either:
-             out_of_process (production, ADR-025) or in_process (dev). -->
+        <!-- Both runtime packages, so the same APK runs against either.
+             NOTE: the old reading of these two names — out_of_process as
+             "production" and in_process as "dev" — is WRONG since
+             displayxr-runtime#1031 merged the flavors into ONE hybrid runtime
+             APK: IN-PROCESS IS THE DEFAULT, and IPC is opted into per app via
+             manifest meta-data (or `setprop debug.dxr.force_ipc 1` for a
+             one-off). Getting this backwards mis-triaged a real user-facing
+             judder as dev-only for a day (displayxr-runtime#1196). -->
         <package android:name="org.freedesktop.monado.openxr_runtime.in_process" />
         <package android:name="org.freedesktop.monado.openxr_runtime.out_of_process" />
         <!-- IPC bind to the out-of-process runtime service. -->


### PR DESCRIPTION
The manifest called `out_of_process` **"production"** and `in_process` **"dev"**. That stopped being true when DisplayXR/displayxr-runtime#1031 merged the two flavors into **one hybrid runtime APK**: in-process is the **default**, and IPC is opted into per app via manifest meta-data (or `setprop debug.dxr.force_ipc 1` for a one-off).

## Why this is not cosmetic

This comment is the most visible statement of the mode default anywhere in the tree, and reading it as fact caused a real, user-facing Android judder (DisplayXR/displayxr-runtime#1196) to be triaged as **dev-path-only** for most of a day — the wrong severity went into the issue body and the fix PR, and both had to be corrected after the fact by the maintainer pointing out that in-process is the default.

Companion PRs: DisplayXR/displayxr-demo-mediaplayer#53, DisplayXR/displayxr-demo-earthview#44, and one to follow on `displayxr-demo-modelviewer` once its release lands. `displayxr-demo-avatar` carries no such comment.

No functional change — both `<package>` entries are byte-identical; only the comment above them changed. Manifest re-parsed as valid XML.