### PR TITLE
fix(fit): frame against the runtime canvas, not our own window

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.8.0
+    GIT_TAG v2.8.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.7.0
+    GIT_TAG v2.8.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/macos/main.mm
+++ b/macos/main.mm
@@ -60,7 +60,8 @@
 #include "gs_renderer_select.h"   // GsActiveRenderer = graphics on Apple Silicon (default)
 #include "gs_scene_loader.h"
 #include "atlas_capture.h"
-#include "auto_fit.h"             // dxr::AutoFitVHeight (shared width-aware load-time framing)
+#include "auto_fit.h"             // dxr::AutoFitVHeight / FitTransition (shared width-aware framing)
+#include "auto_fit_canvas.h"      // dxr::AutoFitCanvas — the runtime-resolved viewport
 
 // ============================================================================
 // Logging
@@ -156,6 +157,15 @@ static float g_fitCenter[3] = {0.0f, 0.0f, 0.0f};
 static float g_fitVHeight   = kDefaultVirtualDisplayHeightM;
 static float g_fitYaw       = 0.0f;
 static bool  g_fitValid     = false;
+
+// Refit state (displayxr-common common/auto_fit_canvas.h). vHeight is a
+// function of (content, viewport): the CONTENT half is cached here so a
+// viewport change re-derives the base without re-measuring the splats.
+static float g_fitExtentW = 0.0f;
+static float g_fitExtentH = 0.0f;
+static float g_fitAspect  = 0.0f;          //!< viewport the current base was derived for
+static dxr::AutoFitCanvas g_autoFitCanvas; //!< runtime-resolved canvas, published post-locate
+static dxr::FitTransition g_fitTransition;
 
 // ============================================================================
 // Globals
@@ -1926,22 +1936,67 @@ static bool FileExists(const std::string& p) {
     return stat(p.c_str(), &st) == 0 && S_ISREG(st.st_mode);
 }
 
-// Viewport the auto-fit width rule frames against: the live content-view
-// bounds when the window exists (g_windowW/H are the drawable size sampled
-// once at startup and never refreshed on resize), else those startup dims.
-// Only the aspect ratio matters to dxr::AutoFitVHeight, so the backing scale
-// factor is irrelevant — it cancels.
-static void GetAutoFitViewport(float& outW, float& outH) {
+// Viewport the auto-fit width rule frames against. Only the aspect ratio
+// matters to dxr::AutoFitVHeight, so the backing scale factor is irrelevant
+// (it cancels) and metres mix freely with points.
+//
+// Prefer the canvas the runtime RESOLVED for the locate (XR_DXR_view_rig's raw
+// channel), falling back to the live content-view bounds (g_windowW/H are the
+// drawable size sampled once at startup and never refreshed on resize). The
+// two agree for an in-process app owning its window, which is every macOS case
+// today — there is no spatial shell here. The canvas still earns its place: it
+// is the one source that stays correct if that ever changes, and it is what
+// RefitForViewport gates on so a window resize re-derives the base instead of
+// leaving the load-time framing stale.
+//
+// Returns true when the dims came from the runtime canvas (metres) rather than
+// the view bounds (points) — the two are not comparable numbers, only their
+// aspects are, so anything logging them must say which it got.
+static bool GetAutoFitViewport(float& outW, float& outH) {
+    float fallbackW = (float)g_windowW;
+    float fallbackH = (float)g_windowH;
     if (g_window) {
         NSSize cs = [[g_window contentView] bounds].size;
         if (cs.width > 0.0 && cs.height > 0.0) {
-            outW = (float)cs.width;
-            outH = (float)cs.height;
-            return;
+            fallbackW = (float)cs.width;
+            fallbackH = (float)cs.height;
         }
     }
-    outW = (float)g_windowW;
-    outH = (float)g_windowH;
+    return g_autoFitCanvas.Viewport(fallbackW, fallbackH, outW, outH);
+}
+
+// Re-derive the base vHeight when the viewport's ASPECT changes, and animate
+// the move. Only the BASE moves: the render path computes rigVH =
+// virtualDisplayHeight / scaleFactor, so the user's zoom stays relative and
+// orbit/pivot are untouched. A viewport change is not a request to undo
+// deliberate user state — recentring belongs on Space.
+static void RefitForViewport(float dtSeconds) {
+    if (!g_fitValid || !(g_fitExtentH > 0.0f)) {
+        return;
+    }
+    float vpW = 0.0f, vpH = 0.0f;
+    const bool fromCanvas = GetAutoFitViewport(vpW, vpH);
+    const float aspect = (vpH > 0.0f) ? (vpW / vpH) : 0.0f;
+    if (dxr::AutoFitAspectChanged(g_fitAspect, aspect)) {
+        const float vh = dxr::AutoFitVHeight(g_fitExtentW, g_fitExtentH, vpW, vpH, kAutoFitFill);
+        if (vh > 1e-3f) {
+            // Retarget rather than restart: a resize that settles in two steps
+            // must not snap back to where it started.
+            g_fitTransition.start(g_fitTransition.value(), vh);
+            const float prev = g_fitVHeight;
+            g_fitAspect = aspect;
+            g_fitVHeight = vh;  // Space-reset target follows the live viewport
+            LOG_INFO("Auto-fit refit: viewport=%.3fx%.3f (%s) aspect=%.3f bound=%s "
+                     "base %.3f -> %.3f (zoom preserved)",
+                     vpW, vpH, fromCanvas ? "runtime canvas, m" : "view bounds, pt", aspect,
+                     (aspect > 0.0f && g_fitExtentW / aspect > g_fitExtentH) ? "width" : "height",
+                     prev, vh);
+        }
+    }
+    float animated = 0.0f;
+    if (g_fitTransition.update(dtSeconds, &animated)) {
+        g_input.viewParams.virtualDisplayHeight = animated;
+    }
 }
 
 // Compute robust scene bounds (5th–95th percentile per axis) and set the
@@ -1963,10 +2018,18 @@ static void ApplyAutoFitForLoadedScene() {
         // the viewport in BOTH axes, so a wide scene no longer overflows
         // horizontally. See kAutoFitFill for why fill is 0.88, not 0.80.
         float viewportW = 0.0f, viewportH = 0.0f;
-        GetAutoFitViewport(viewportW, viewportH);
+        const bool fromCanvas = GetAutoFitViewport(viewportW, viewportH);
         float vh = dxr::AutoFitVHeight(extent[0], extent[1], viewportW, viewportH, kAutoFitFill);
         if (!(vh > 1e-3f)) vh = kDefaultVirtualDisplayHeightM; // degenerate scene
         g_fitVHeight = vh;
+        // Cache the CONTENT half of the fit and the viewport this base was
+        // derived for, so RefitForViewport can re-derive on an aspect change
+        // without re-measuring the splats. A load lands the base immediately —
+        // the framing IS the load's result, so there is nothing to animate.
+        g_fitExtentW = extent[0];
+        g_fitExtentH = extent[1];
+        g_fitAspect = (viewportH > 0.0f) ? (viewportW / viewportH) : 0.0f;
+        g_fitTransition.start(vh, vh, 0.0f);
 
         // EXPERIMENT: yaw scan disabled to test if RUB load convention now
         // gives a natural yaw=0 facing (matching SuperSplat's default).
@@ -1978,10 +2041,11 @@ static void ApplyAutoFitForLoadedScene() {
         const float aspect = (viewportH > 0.0f) ? (viewportW / viewportH) : 0.0f;
         const bool widthBound = (aspect > 0.0f) && (extent[0] / aspect > extent[1]);
         LOG_INFO("Auto-fit: center=(%.3f, %.3f, %.3f) extent=(%.3f, %.3f, %.3f) "
-                 "viewport=%.0fx%.0f aspect=%.3f bound=%s fill=%.2f vHeight=%.3f yaw=%.0fdeg",
+                 "viewport=%.3fx%.3f (%s) aspect=%.3f bound=%s fill=%.2f vHeight=%.3f yaw=%.0fdeg",
                  center[0], center[1], center[2],
                  extent[0], extent[1], extent[2],
-                 viewportW, viewportH, aspect, widthBound ? "width" : "height",
+                 viewportW, viewportH, fromCanvas ? "runtime canvas, m" : "view bounds, pt",
+                 aspect, widthBound ? "width" : "height",
                  kAutoFitFill, vh, g_fitYaw * 57.2957795f);
     } else {
         g_fitValid = false;
@@ -2224,7 +2288,19 @@ int main(int argc, char** argv) {
             UpdateTopBarButtonTitles(xr);
         }
 
+        // UpdateCameraMovement consumes resetViewRequested, so sample it first.
+        const bool resetThisFrame = g_input.resetViewRequested;
         UpdateCameraMovement(g_input, deltaTime, xr.displayHeightM);
+
+        if (resetThisFrame) {
+            // Land any in-flight refit on the reset target, so the animation
+            // cannot drag the base back off what Space just restored.
+            g_fitTransition.start(g_fitVHeight, g_fitVHeight, 0.0f);
+        } else {
+            // Re-derive the base against the viewport the runtime resolved
+            // (published from the previous frame's locate) and advance the move.
+            RefitForViewport(deltaTime);
+        }
 
         // Handle rendering mode change (V=cycle, 0-3=direct, Mode button, or the
         // startup default-mode request) through the dxr::ModeSwitch sequencer:
@@ -2356,6 +2432,18 @@ int main(int argc, char** argv) {
                         // HUD eye readout. Under the rig, views[] carries render-ready
                         // WORLD eyes, so the display-space eyes come from the raw channel
                         // (XrViewDisplayRawDXR); without the rig, fall back to views[].
+                        // The same raw channel carries the canvas the runtime
+                        // RESOLVED for this locate — the viewport the auto-fit
+                        // must frame against. RefitForViewport picks it up next
+                        // tick and re-derives the base if the aspect moved.
+                        if (useRig) {
+                            g_autoFitCanvas.PublishFromRaw(
+                                viewRigRaw.canvasSizeMeters.width,
+                                viewRigRaw.canvasSizeMeters.height,
+                                viewRigRaw.canvasRectPx.extent.width,
+                                viewRigRaw.canvasRectPx.extent.height);
+                        }
+
                         if (useRig && viewRigRaw.eyeCountOutput > 0) {
                             for (uint32_t v = 0; v < viewRigRaw.eyeCountOutput && v < 8; v++) {
                                 xr.eyePositions[v][0] = viewRigRaw.rawEyes[v].x;

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -34,7 +34,8 @@
 #include "hud_renderer.h"
 #include "text_overlay.h"
 #include "atlas_capture.h"
-#include "auto_fit.h"         // dxr::AutoFitVHeight (shared width-aware load-time framing)
+#include "auto_fit.h"         // dxr::AutoFitVHeight / FitTransition (shared width-aware framing)
+#include "auto_fit_canvas.h"  // dxr::AutoFitCanvas — the runtime-resolved viewport (shell tile)
 #include "vk_overlay_kit.h"   // dxr::CachedLayerUploader (#837 — no per-frame HUD upload+wait)
 #include "vk_clickthrough_region.h" // dxr::ClickThroughRegion (#833 — transparent-mode punch-through)
 #include "win_window_drag.h"        // dxr::RmbWindowDrag (move the borderless overlay)
@@ -162,24 +163,50 @@ static float g_fitVHeight   = kFallbackVirtualDisplayHeightM;
 static float g_fitYaw       = 0.0f;
 static std::atomic<bool> g_fitValid{false};
 
+// Refit state (displayxr-common common/auto_fit_canvas.h). vHeight is a
+// function of (content, viewport), so the CONTENT half is cached here and the
+// viewport half is re-read every frame — see RefitForViewport below for why
+// the load-time fit alone is not enough under the shell.
+static std::atomic<float> g_fitExtentW{0.0f};  //!< content — survives viewport changes
+static std::atomic<float> g_fitExtentH{0.0f};
+static std::atomic<float> g_fitAspect{0.0f};   //!< viewport the current base was derived for
+static dxr::AutoFitCanvas g_autoFitCanvas;     //!< runtime-resolved canvas, published post-locate
+static dxr::FitTransition g_fitTransition;     //!< render-thread only
+
 // Latest computed frames-per-second, published each frame by the render thread
 // (after UpdatePerformanceStats) so the XR_DXR_mcp_tools get_status handler can
 // report it without reaching into the render thread's local PerformanceStats.
 static std::atomic<float> g_currentFps{0.0f};
 
-// Viewport the auto-fit width rule frames against: the live window client
-// rect when the window exists, else the last WM_SIZE dims. Only the aspect
-// ratio matters to dxr::AutoFitVHeight, so pixels are fine.
-static void GetAutoFitViewport(float& outW, float& outH) {
+// Viewport the auto-fit width rule frames against. Only the aspect ratio
+// matters to dxr::AutoFitVHeight, so pixels and meters mix freely.
+//
+// The app's own client rect is NOT the viewport under the shell. A
+// shell-launched app is composed into a 3D window tile the shell owns; this
+// window is hidden (SW_HIDE) and is never what the user sees, and the runtime
+// only resizes it to the tile later — deferred and async, once the client is
+// placed. The bundled scene auto-loads during init, long before that, so this
+// used to fit the 1280x720 CREATION size on every run, shell or not (the
+// "viewport=1280x720 aspect=1.778" in every log). In a square tile the
+// butterfly then came out ~15% oversized and overflowed the sides.
+//
+// So: prefer the canvas the runtime RESOLVED (XR_DXR_view_rig's raw channel —
+// the shell tile under a workspace, this window's client rect standalone), and
+// keep the client rect only as the bootstrap for the fit that runs before the
+// first locate. RefitForViewport re-derives once the real canvas arrives.
+// Returns true when the dims came from the runtime canvas (metres) rather than
+// the client-rect bootstrap (pixels) — the two are not comparable numbers, only
+// their aspects are, so anything logging them must say which it got.
+static bool GetAutoFitViewport(float& outW, float& outH) {
+    float fallbackW = (float)g_windowWidth;
+    float fallbackH = (float)g_windowHeight;
     RECT client = {};
     if (g_appWindow && GetClientRect(g_appWindow, &client) &&
         client.right > client.left && client.bottom > client.top) {
-        outW = (float)(client.right - client.left);
-        outH = (float)(client.bottom - client.top);
-        return;
+        fallbackW = (float)(client.right - client.left);
+        fallbackH = (float)(client.bottom - client.top);
     }
-    outW = (float)g_windowWidth;
-    outH = (float)g_windowHeight;
+    return g_autoFitCanvas.Viewport(fallbackW, fallbackH, outW, outH);
 }
 
 // Compute robust scene bounds (5th–95th percentile per axis) and stage
@@ -201,12 +228,22 @@ static void ApplyAutoFitForLoadedScene_locked() {
         // the viewport in BOTH axes, so a wide scene no longer overflows
         // horizontally. See kAutoFitFill for why fill is 0.88, not 0.80.
         float viewportW = 0.0f, viewportH = 0.0f;
-        GetAutoFitViewport(viewportW, viewportH);
+        const bool fromCanvas = GetAutoFitViewport(viewportW, viewportH);
         float vh = dxr::AutoFitVHeight(extent[0], extent[1], viewportW, viewportH, kAutoFitFill);
         // Degenerate scene (all splats in a thin slice) — fall back to a
         // sensible vHeight rather than failing the fit. Mirrors macOS:1399.
         if (!(vh > 1e-3f)) vh = kFallbackVirtualDisplayHeightM;
         g_fitVHeight = vh;
+        // Cache the CONTENT half of the fit (extents are scene properties) and
+        // the viewport this base was derived for, so RefitForViewport can
+        // re-derive on an aspect change without re-measuring the splats.
+        g_fitExtentW.store(extent[0], std::memory_order_relaxed);
+        g_fitExtentH.store(extent[1], std::memory_order_relaxed);
+        g_fitAspect.store((viewportH > 0.0f) ? (viewportW / viewportH) : 0.0f,
+                          std::memory_order_relaxed);
+        // A load lands the base immediately — the framing IS the load's result,
+        // so there is nothing to animate away from.
+        g_fitTransition.start(vh, vh, 0.0f);
         // Anchor at yaw=0 and trust the loader's RUB convention (PLY loader
         // converts RDF+X-mirror → RUB at load time; SPZ is RUB-native and
         // SuperSplat-authored scenes already face −Z at yaw=0). Matches
@@ -216,10 +253,11 @@ static void ApplyAutoFitForLoadedScene_locked() {
         const float aspect = (viewportH > 0.0f) ? (viewportW / viewportH) : 0.0f;
         const bool widthBound = (aspect > 0.0f) && (extent[0] / aspect > extent[1]);
         LOG_INFO("Auto-fit: center=(%.3f, %.3f, %.3f) extent=(%.3f, %.3f, %.3f) "
-                 "viewport=%.0fx%.0f aspect=%.3f bound=%s fill=%.2f vHeight=%.3f yaw=%.0fdeg",
+                 "viewport=%.3fx%.3f (%s) aspect=%.3f bound=%s fill=%.2f vHeight=%.3f yaw=%.0fdeg",
                  center[0], center[1], center[2],
                  extent[0], extent[1], extent[2],
-                 viewportW, viewportH, aspect, widthBound ? "width" : "height",
+                 viewportW, viewportH, fromCanvas ? "runtime canvas, m" : "client rect, px",
+                 aspect, widthBound ? "width" : "height",
                  kAutoFitFill, vh, g_fitYaw * 57.2957795f);
     }
     g_fitValid.store(ok);
@@ -251,6 +289,58 @@ static void ApplyAutoFitForLoadedScene_locked() {
         g_inputState.lastInputTimeSec = (double)duration_cast<microseconds>(
             high_resolution_clock::now().time_since_epoch()).count() * 1e-6;
         g_inputState.animationActive = false;
+    }
+}
+
+// Re-derive the base vHeight when the viewport's ASPECT changes, and animate
+// the move. Render thread only.
+//
+// This is what makes the load-time fit correct under the shell. The scene
+// auto-loads during init, before the first xrLocateViews, so the only viewport
+// available then is this window's own client rect — which under a workspace is
+// the hidden creation-size window, not the tile the user sees. The first
+// located frame publishes the real canvas, the aspect gate sees it differ from
+// the bootstrap one, and the fit lands on the tile. The same path handles a
+// live 3D-window resize, which mis-framed identically before.
+//
+// Only the BASE moves: the render path computes rigVH = virtualDisplayHeight /
+// scaleFactor, so the user's zoom stays relative (2x of the old fit becomes 2x
+// of the new one) and orbit/pivot are untouched. A viewport change is not a
+// request to undo deliberate user state — recentring belongs on Space.
+static void RefitForViewport(float dtSeconds) {
+    if (!g_fitValid.load(std::memory_order_relaxed)) {
+        return;
+    }
+    const float extW = g_fitExtentW.load(std::memory_order_relaxed);
+    const float extH = g_fitExtentH.load(std::memory_order_relaxed);
+    if (!(extH > 0.0f)) {
+        return;
+    }
+
+    float vpW = 0.0f, vpH = 0.0f;
+    const bool fromCanvas = GetAutoFitViewport(vpW, vpH);
+    const float aspect = (vpH > 0.0f) ? (vpW / vpH) : 0.0f;
+    if (dxr::AutoFitAspectChanged(g_fitAspect.load(std::memory_order_relaxed), aspect)) {
+        const float vh = dxr::AutoFitVHeight(extW, extH, vpW, vpH, kAutoFitFill);
+        if (vh > 1e-3f) {
+            // Retarget rather than restart: a resize that settles in two steps
+            // must not snap back to where it started.
+            g_fitTransition.start(g_fitTransition.value(), vh);
+            const float prev = g_fitVHeight;
+            g_fitAspect.store(aspect, std::memory_order_relaxed);
+            g_fitVHeight = vh;  // Space-reset target follows the live viewport
+            LOG_INFO("Auto-fit refit: viewport=%.3fx%.3f (%s) aspect=%.3f bound=%s "
+                     "base %.3f -> %.3f (zoom preserved)",
+                     vpW, vpH, fromCanvas ? "runtime canvas, m" : "client rect, px", aspect,
+                     (aspect > 0.0f && extW / aspect > extH) ? "width" : "height",
+                     prev, vh);
+        }
+    }
+
+    float animated = 0.0f;
+    if (g_fitTransition.update(dtSeconds, &animated)) {
+        std::lock_guard<std::mutex> lock(g_inputMutex);
+        g_inputState.viewParams.virtualDisplayHeight = animated;
     }
 }
 
@@ -1208,6 +1298,16 @@ static void RenderThreadFunc(
         }
         UpdateCameraMovement(inputSnapshot, perfStats.deltaTime, xr->displayHeightM);
 
+        // Re-derive the base against the viewport the runtime actually resolved
+        // (published from the previous frame's locate) and advance the move.
+        // Runs before the reset block so a Space in the same frame wins.
+        RefitForViewport(perfStats.deltaTime);
+        {
+            std::lock_guard<std::mutex> lock(g_inputMutex);
+            inputSnapshot.viewParams.virtualDisplayHeight =
+                g_inputState.viewParams.virtualDisplayHeight;
+        }
+
         // On Space-reset: shared UpdateCameraMovement returns to (0,0,0) + default
         // vHeight. For the splat demo, restore the per-scene auto-fit pose instead.
         if (resetRequested && g_fitValid.load()) {
@@ -1216,6 +1316,9 @@ static void RenderThreadFunc(
             inputSnapshot.cameraPosZ = g_fitCenter[2];
             inputSnapshot.yaw = g_fitYaw;
             inputSnapshot.viewParams.virtualDisplayHeight = g_fitVHeight;
+            // Land any in-flight refit on the reset target so the animation
+            // cannot drag the base back off it over the next frames.
+            g_fitTransition.start(g_fitVHeight, g_fitVHeight, 0.0f);
         }
 
         {
@@ -1364,6 +1467,20 @@ static void RenderThreadFunc(
                                 xr->eyePositions[v][1] = viewRigRaw.rawEyes[v].y;
                                 xr->eyePositions[v][2] = viewRigRaw.rawEyes[v].z;
                             }
+                        }
+
+                        // The same raw channel carries the canvas the runtime
+                        // RESOLVED for this locate — the shell's 3D window tile
+                        // under a workspace, this window's client rect
+                        // standalone. That, not our own (hidden, creation-size)
+                        // window, is the viewport the auto-fit must frame
+                        // against; RefitForViewport picks it up next tick.
+                        if (useRig) {
+                            g_autoFitCanvas.PublishFromRaw(
+                                viewRigRaw.canvasSizeMeters.width,
+                                viewRigRaw.canvasSizeMeters.height,
+                                viewRigRaw.canvasRectPx.extent.width,
+                                viewRigRaw.canvasRectPx.extent.height);
                         }
 
                         bool monoMode = (xr->renderingModeCount > 0 && !xr->renderingModeDisplay3D[xr->currentModeIndex]);


### PR DESCRIPTION
## The bug

The auto-fit framed the wrong rectangle under the shell. Every log in the archive, standalone and shell alike, says the same thing:

```
Auto-fit: ... viewport=1280x720 aspect=1.778 bound=height fill=0.88 vHeight=1.979
```

`1280x720` is the **window creation size**, never the tile.

A shell-launched app is composed into a 3D window tile the shell owns. Its own HWND is hidden (`SW_HIDE`), is never what the user sees, and holds whatever size it was created at. The runtime resizes that hidden window to the tile only **later** — deferred and async, once the client is placed — and `TryAutoLoadBundledScene` runs during init, long before that.

In a square tile the 2.01 x 1.74 butterfly is width-bound and wants `vHeight = 2.285`, not the `1.979` the 16:9 creation size produced. It rendered ~15% oversized and overflowed the sides — the reported "opens as if the 3D window were wide".

## The fix

`XR_DXR_view_rig`'s raw channel already reports the canvas the runtime **resolved** for the locate: the shell tile under a workspace, the client rect standalone. Both legs already chained it and read only `rawEyes`.

Now they publish the canvas too (`dxr::AutoFitCanvas`), and `RefitForViewport` re-derives the base whenever the **aspect** moves. One mechanism covers both the load-before-first-locate bootstrap and a live 3D-window resize, because a never-fitted aspect counts as changed. `dxr::FitTransition` animates the move; a load lands it immediately, since the framing *is* the load's result.

Only the **base** moves. `rigVH = virtualDisplayHeight / scaleFactor`, so a 2x pinch stays 2x of the *new* fit and orbit/pivot are untouched — a viewport change is not a request to undo deliberate user state. Space still recentres, and lands any in-flight refit so the animation cannot drag the base back off it.

Both viewport log lines now name their source: the canvas is in metres, the bootstrap in pixels. The first draft printed `viewport=0x0` with a correct aspect, which is exactly the kind of thing that costs a debugging round later.

## Verification

On hardware — shell + Leia SR, square tile forced with `--pose 0,0,0,0.12,0.12`:

```
Auto-fit:       viewport=1280.000x720.000 (client rect, px)  aspect=1.778 bound=height vHeight=1.979
Auto-fit refit: viewport=1120.000x560.000 (client rect, px)  aspect=2.000 bound=height base 1.979 -> 1.979
Auto-fit refit: viewport=0.120x0.120 (runtime canvas, m)     aspect=1.000 bound=width  base 1.979 -> 2.285
```

Atlas capture shows the splat framed inside the square tile with margins on all sides.

- **Standalone unchanged**: canvas == client rect, no refit fires.
- **Resize works**: dragging the standalone window to 900x900 refits 1.979 -> 2.171, width-bound.

macOS carries the same change for symmetry. There is no shell there, so it buys the resize refit rather than a bug fix; compile-checked by CI, not on this box.

## Dependency

Repins `displayxr-common` to **v2.8.0** (`AutoFitCanvas` + `FitTransition`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLFgqXsgF5ofMgX9BJK7Zv
