### PR TITLE
fix(transparency): Ctrl+T must not un-hide the window under the workspace

### DIFF
--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -669,29 +669,39 @@ static RECT g_savedWindowRect = {};
 static DWORD g_savedWindowStyle = 0;
 
 static void ToggleFullscreen(HWND hwnd) {
+    // Same rule as kBorderlessMsg below: a style swap must never change whether
+    // this window is on screen. Under the DisplayXR workspace the runtime hides
+    // the HWND at xrCreateSession, so preserve the WS_VISIBLE / WS_MINIMIZE bits
+    // and only touch the z-order while the window is actually on screen.
+    const LONG cur = GetWindowLong(hwnd, GWL_STYLE);
+    const LONG keep = cur & (WS_VISIBLE | WS_MINIMIZE);
+    const bool onScreen = (cur & WS_VISIBLE) != 0 && (cur & WS_MINIMIZE) == 0;
+    HWND zOrder = onScreen ? HWND_TOP : nullptr;
+    UINT swpFlags = SWP_FRAMECHANGED | (onScreen ? 0u : SWP_NOZORDER);
     if (g_fullscreen) {
-        SetWindowLong(hwnd, GWL_STYLE, g_savedWindowStyle);
-        SetWindowPos(hwnd, HWND_TOP,
+        SetWindowLong(hwnd, GWL_STYLE,
+            (LONG)((g_savedWindowStyle & ~(DWORD)(WS_VISIBLE | WS_MINIMIZE)) | (DWORD)keep));
+        SetWindowPos(hwnd, zOrder,
             g_savedWindowRect.left, g_savedWindowRect.top,
             g_savedWindowRect.right - g_savedWindowRect.left,
             g_savedWindowRect.bottom - g_savedWindowRect.top,
-            SWP_FRAMECHANGED);
+            swpFlags);
         g_fullscreen = false;
         LOG_INFO("Exited fullscreen mode");
     } else {
-        g_savedWindowStyle = GetWindowLong(hwnd, GWL_STYLE);
+        g_savedWindowStyle = (DWORD)cur;
         GetWindowRect(hwnd, &g_savedWindowRect);
 
         HMONITOR hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
         MONITORINFO mi = { sizeof(mi) };
         GetMonitorInfo(hMonitor, &mi);
 
-        SetWindowLong(hwnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
-        SetWindowPos(hwnd, HWND_TOP,
+        SetWindowLong(hwnd, GWL_STYLE, (LONG)(WS_POPUP | (DWORD)keep));
+        SetWindowPos(hwnd, zOrder,
             mi.rcMonitor.left, mi.rcMonitor.top,
             mi.rcMonitor.right - mi.rcMonitor.left,
             mi.rcMonitor.bottom - mi.rcMonitor.top,
-            SWP_FRAMECHANGED);
+            swpFlags);
         g_fullscreen = true;
         LOG_INFO("Entered fullscreen mode");
     }
@@ -868,16 +878,27 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         GetClientRect(hwnd, &client);
         POINT tl = {0, 0};
         ClientToScreen(hwnd, &tl);
-        const DWORD style = (borderless ? WS_POPUP : WS_OVERLAPPEDWINDOW) | WS_VISIBLE;
+        // Ctrl+T must never change whether this window is on screen. Under the
+        // DisplayXR workspace the runtime hides this HWND at xrCreateSession
+        // (its pixels reach the panel through the composed atlas); writing
+        // WS_VISIBLE here un-hid it and HWND_TOPMOST then put it on top of the
+        // shell. Keep the WS_VISIBLE / WS_MINIMIZE bits exactly as they are,
+        // and only touch the z-order while the window is actually on screen.
+        const LONG cur = GetWindowLong(hwnd, GWL_STYLE);
+        const LONG keep = cur & (WS_VISIBLE | WS_MINIMIZE);
+        const bool onScreen = (cur & WS_VISIBLE) != 0 && (cur & WS_MINIMIZE) == 0;
+        const DWORD style = (borderless ? WS_POPUP : WS_OVERLAPPEDWINDOW) | (DWORD)keep;
         SetWindowLong(hwnd, GWL_STYLE, (LONG)style);
         RECT want = {tl.x, tl.y, tl.x + client.right, tl.y + client.bottom};
         AdjustWindowRect(&want, style, FALSE);
         // Transparent mode floats above other apps (the avatar behavior):
         // clicks punched through to a window behind activate it, but the
         // scene stays on top. Ctrl+T off returns to the normal z-band.
-        SetWindowPos(hwnd, borderless ? HWND_TOPMOST : HWND_NOTOPMOST, want.left, want.top,
+        HWND zOrder = onScreen ? (borderless ? HWND_TOPMOST : HWND_NOTOPMOST) : nullptr;
+        UINT swpFlags = SWP_FRAMECHANGED | SWP_NOACTIVATE | (onScreen ? 0u : SWP_NOZORDER);
+        SetWindowPos(hwnd, zOrder, want.left, want.top,
                      want.right - want.left, want.bottom - want.top,
-                     SWP_FRAMECHANGED | SWP_NOACTIVATE);
+                     swpFlags);
         g_borderless.store(borderless);
         return 0;
     }


### PR DESCRIPTION
## The bug

Ctrl+T toggles the transparent background. Its real job is only to flip the
renderer's output alpha (`g_transparentBg`); the borderless style swap posted as
`kBorderlessMsg` is a standalone-mode cosmetic (a shaped NRB window can't paint
an OS frame).

That handler wrote `WS_VISIBLE` into `GWL_STYLE` unconditionally — and so also
cleared `WS_MINIMIZE` — and then raised the window with `HWND_TOPMOST`.

Under the DisplayXR workspace/shell (`DISPLAYXR_WORKSPACE_SESSION=1`) the
runtime hides the app's HWND at `xrCreateSession` (`ShowWindow SW_HIDE`),
because the app's pixels reach the panel through the composed atlas rather than
its own window. So pressing Ctrl+T under the shell un-hid the app's native
window and put it on top of the shell.

## The fix

Preserve the window's current visibility state instead of forcing it:

- keep the `WS_VISIBLE` / `WS_MINIMIZE` bits exactly as they are when writing
  the new `WS_POPUP` / `WS_OVERLAPPEDWINDOW` style;
- only touch the z-order while the window is actually on screen — otherwise
  pass a null insert-after HWND plus `SWP_NOZORDER`.

The existing client-rect preservation math (`GetClientRect` + `ClientToScreen` +
`AdjustWindowRect`) is unchanged.

For a normal, visible, non-minimised standalone window this is byte-for-byte the
old behaviour: same style word, same `HWND_TOPMOST` / `HWND_NOTOPMOST`, same
`SWP_FRAMECHANGED | SWP_NOACTIVATE`.

`ToggleFullscreen` (F11) is the only other place that wrote `WS_VISIBLE` into
`GWL_STYLE` for the main window at runtime (`WS_POPUP | WS_VISIBLE` on entry,
and a restore of a saved style word on exit), so it gets the same rule.

## Verification

Built locally on Windows with `scripts\build-with-deps.bat` — clean build, the
exe relinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkLZgV9NnwKuu21oc5jvj7
