### PR TITLE
feat(mcp): set_transparent_background tool — drive Ctrl+T transparency from an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Capabilities registry key), the viewer registers its controls as agent
 tools on the runtime-hosted per-process MCP server via
 `XR_DXR_mcp_tools` (macOS build; appId `gaussiansplat`):
 `load_splat`, `get_status`, `set_camera`, `orbit`, `reset_camera`,
-`set_auto_orbit`. Agents reach them through the `displayxr-mcp` adapter
+`set_auto_orbit`, plus `set_transparent_background` on Windows (the agent
+equivalent of Ctrl+T). Agents reach them through the `displayxr-mcp` adapter
 (`--target pid:<PID>`, or namespaced as `gaussiansplat__<tool>` via
 `--target workspace`) and can verify camera moves with the runtime's
 `capture_frame` tool. With the gate off (the default) the tools are

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -654,6 +654,23 @@ std::string HandleAgentToolCall(XrSessionManager& xr, const std::string& toolNam
             }
             result = enabled ? "{\"auto_orbit\":true}" : "{\"auto_orbit\":false}";
         }
+    } else if (strcmp(toolName_c, "set_transparent_background") == 0) {
+        // Same code path as Ctrl+T: raise the shared input handler's request
+        // flag and let the render loop stay the single place that flips
+        // g_transparentBg, logs, and posts kBorderlessMsg. Omitting 'enabled'
+        // toggles; passing it makes the call idempotent — the flag is raised
+        // only when the target differs from the live state.
+        const bool current = g_transparentBg.load();
+        bool want = !current;                 // no 'enabled' -> toggle, like Ctrl+T
+        JsonGetBool(a, "enabled", &want);     // absent/non-boolean keeps the toggle target
+        const bool changing = (want != current);
+        if (changing) {
+            std::lock_guard<std::mutex> lock(g_inputMutex);
+            g_inputState.transparentBgToggleRequested = true;
+        }
+        snprintf(buf, sizeof(buf), "{\"transparent_background\":%s,\"changed\":%s}",
+                 want ? "true" : "false", changing ? "true" : "false");
+        result = buf;
     } else {
         ok = false;
         result = std::string("{\"error\":\"unhandled tool '") + toolName + "'\"}";

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -626,6 +626,18 @@ void RegisterAgentTools(XrSessionManager& xr) {
         "{\"type\":\"object\",\"properties\":{\"enabled\":{\"type\":\"boolean\"}},"
         "\"required\":[\"enabled\"]}");
 
+    // Windows-only (the transparent-background path is the DComp punch-through
+    // one behind Ctrl+T); the macOS tool list is unchanged.
+    reg("set_transparent_background",
+        "Turn the transparent background on or off - the agent equivalent of Ctrl+T: "
+        "with it on, the splats are composited over the desktop instead of the "
+        "viewer's opaque background, and the window goes borderless. Omit 'enabled' "
+        "to toggle the current state. The flip is applied by the render thread on the "
+        "next frame, so the returned value is the REQUESTED state - read the settled "
+        "one back with get_status.",
+        "{\"type\":\"object\",\"properties\":{\"enabled\":{\"type\":\"boolean\","
+        "\"description\":\"Target state; omit to toggle.\"}}}");
+
     // Install the app's tool-call handler on the shared PollEvents hook
     // (displayxr-common v2.1.0 / #18). PollEvents fetches args + submits the
     // result; HandleAgentToolCall only maps (toolName, argsJson) -> resultJson.


### PR DESCRIPTION
Stacked on #97 (`fix/ctrl-t-keeps-workspace-window-hidden`) — this PR targets that branch so the diff shows only the new tool. **Retarget to `main` once #97 merges.**

## What

Adds a seventh `XR_DXR_mcp_tools` tool, `set_transparent_background`, so an agent can drive the same transparent-background mode Ctrl+T does. One optional boolean argument `enabled`; omit it to toggle. `get_status` already reported `transparent_background` read-only — this makes it writable.

## How

The handler does not touch `g_transparentBg`. It raises the same request flag the shared displayxr-common input handler raises for Ctrl+T — `InputState::transparentBgToggleRequested` — so the render loop remains the single place that flips the state, logs, and posts `kBorderlessMsg`. Agent and keyboard therefore cannot diverge, and the workspace-safe style swap from #97 applies unchanged.

With an explicit `enabled` the flag is raised only when the target differs from the live state, so repeated calls are no-ops instead of alternating flips.

Because the flip lands on the render thread's next frame, the tool returns the **requested** state (and a `changed` flag), and the tool description says so; the settled value stays readable via `get_status`.

Registration follows the existing `reg(...)` pattern in `windows/xr_session.cpp`, next to `set_auto_orbit` (the other `enabled`-boolean tool).

## Scope

Windows only — the macOS build has its own tool registration in `macos/main.mm` and is left unchanged in this pass. Adding the macOS arm (the demo does have `g_transparentBg` there) is a reasonable follow-up.

## Sibling

`displayxr-demo-modelviewer` gets the same tool in its own PR (stacked on its #110).

## Verification

`scripts\build-with-deps.bat` — clean build, no new warnings.

Not exercised against a live MCP adapter in this pass; the dispatch/registration follows the existing `set_auto_orbit` pattern verbatim.

## Docs

README's *Agent tools (MCP)* list now names the new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkLZgV9NnwKuu21oc5jvj7
