### PR TITLE
feat(undock): launch contract — CLI (new) + --transparent/--rect/--src/--vh + displayxr-view: protocol handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ Flags are `--key=value`, never `--key value`. `--` ends flag parsing.
 The same fields arrive as a query string on the `displayxr-view:` scheme:
 
 ```
-displayxr-view://open?src=<pct>&type=model|splat&rect=X,Y,W,H&vh=0.2&dpr=2.5&title=<pct>&v=1
+displayxr-view://open?src=<pct>&type=model|splat&rect=X,Y,W,H&vh=0.2&dpr=2.5&title=<pct>&transparent=1&v=1
 ```
 
 `open` is the verb; `v=1` lets this viewer reject a future grammar loudly rather
 than half-honour it. Every value is percent-encoded by the sender
-(`encodeURIComponent`); only `%XX` is decoded — `+` is **not** a space.
+(`encodeURIComponent`); only `%XX` is decoded — `+` is **not** a space. A
+protocol launch is **transparent by default** (displayxr-common >= v2.9.1);
+`transparent=0` opts out for a framed window. `--transparent` on the command
+line stays opt-in.
 
 The viewer registers `HKCU\Software\Classes\displayxr-view` for itself at
 launch, not from the installer (the installer runs elevated, so its `HKCU`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,88 @@ A test scene, `butterfly.spz`, is bundled and auto-loads at startup.
 | Ctrl+T | Toggle transparent background (desktop see-through; Windows only, requires runtime ≥ v1.3.0) |
 | Esc | Quit |
 
+## Command line and the `displayxr-view:` protocol (Windows)
+
+A web page — or a native app such as a CAD tool "undocking" a part — can spawn
+this viewer as a floating, transparent, click-through-shaped window over the
+desktop, already showing a given scene at a given screen rect. There is no
+Ctrl+T step and no style change after the window exists: `--transparent` makes
+the window borderless and topmost **from creation**, which is what a shaped
+`WS_EX_NOREDIRECTIONBITMAP` window requires.
+
+```bat
+gaussian_splatting_handle_vk_win.exe C:\scenes\butterfly.spz
+gaussian_splatting_handle_vk_win.exe --transparent --rect=300,300,800,800 --vh=0.2 C:\scenes\butterfly.spz
+gaussian_splatting_handle_vk_win.exe --transparent --src=https://host/scene.spz
+```
+
+| Flag | Meaning |
+|---|---|
+| *(positional)* | Scene path, `.ply` or `.spz`. Replaces the bundled `butterfly.spz` auto-load. |
+| `--transparent` | Borderless + topmost + click-through-shaped from the first frame. Ctrl+T still toggles it later. |
+| `--rect=X,Y,W,H` | Window rect in **physical** virtual-screen pixels. Clamped into the 3D panel's monitor when the runtime confirms which monitor that is; never snapped. |
+| `--src=<url\|path>` | Scene to load. An `http(s)` URL is downloaded into the cache below; a local path loads directly. |
+| `--vh=<metres>` | Virtual display height the scene was authored at. Overrides the auto-fit guess and does not follow viewport changes. |
+| `--title=<text>` | **Appended** to the window title; never replaces it. |
+| `--type=model\|splat` | Routing hint. `model` is forwarded to the DisplayXR 3D Model Viewer. |
+| `--dpr=<float>` | The launching page's `devicePixelRatio`. Logged only. |
+| `--max-bytes=<n>` | Download cap. Default 256 MiB. |
+| `--no-cache` | Re-download even on a cache hit (dev aid). |
+| `--allow-local` | Native callers only: permit a `file:`/local `src` inside a protocol URL. A web page cannot set this — it is an argv flag, not a URL field. |
+
+Flags are `--key=value`, never `--key value`. `--` ends flag parsing.
+
+### Protocol URLs
+
+The same fields arrive as a query string on the `displayxr-view:` scheme:
+
+```
+displayxr-view://open?src=<pct>&type=model|splat&rect=X,Y,W,H&vh=0.2&dpr=2.5&title=<pct>&v=1
+```
+
+`open` is the verb; `v=1` lets this viewer reject a future grammar loudly rather
+than half-honour it. Every value is percent-encoded by the sender
+(`encodeURIComponent`); only `%XX` is decoded — `+` is **not** a space.
+
+The viewer registers `HKCU\Software\Classes\displayxr-view` for itself at
+launch, not from the installer (the installer runs elevated, so its `HKCU`
+writes would land in the elevating admin's hive). Every DisplayXR viewer
+registers the same scheme so the browser only asks the user once; whichever one
+the OS starts forwards a URL whose `type=` belongs to a sibling, looked up via
+`HKLM\Software\DisplayXR\Demos\<Viewer>\InstallPath`. A second launch does not
+open a second window — it hands its URL to the running instance over
+`WM_COPYDATA`, which re-applies the rect, the vH and the scene.
+
+### The policy, in two sentences
+
+The browser's one-time "Open this app?" dialog is the only consent gate on the
+protocol path and it is sticky per origin, so from then on **any** page on that
+origin can drive this parser — which means the viewer has to be safe against a
+hostile URL on its own merits. Therefore a protocol launch accepts `src` only
+over `https:` (any host) or `http:` on loopback, refuses `file:`, UNC and bare
+local paths outright, re-applies that same check to the URL a redirect chain
+actually lands on, and bounds every length and rect; `--allow-local` lifts the
+local-path restriction for native callers only, because a web page cannot pass
+an argv flag.
+
+A refused launch logs the reason, shows a message box and exits with code **2**
+(**3** when the URL belongs to a sibling viewer that is not installed). Set
+`DXR_LAUNCH_QUIET=1` in the process environment to suppress those launch-time
+message boxes and rely on the log line plus the exit code — the modal is right
+for a human-initiated launch but makes automated checks hang. Note that a
+percent-encoded URL must **not** be passed through `cmd /c "set VAR=1 && app ..."`:
+`cmd` expands `%XX%` inside it and hands the app a different string.
+
+### Download cache
+
+URL scenes land in `%LOCALAPPDATA%\DisplayXR\GaussianSplat\cache`, named by the
+SHA-1 of the requested URL (never by anything in the URL's path, so a hostile
+`src=.../../../x` has no traversal surface). A cache hit skips the network
+entirely, which is what makes the second undock of the same scene instant.
+
+Only `.ply` and `.spz` are loadable. **`.sog` is not supported** — a `.sog` URL
+is refused at the extension check, not half-loaded.
+
 ## Agent tools (MCP)
 
 When the runtime's MCP capability is enabled (`DISPLAYXR_MCP=1` or the

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.9.3
+    GIT_TAG v2.9.5
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.9.0
+    GIT_TAG v2.9.1
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.9.2
+    GIT_TAG v2.9.3
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.9.1
+    GIT_TAG v2.9.2
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.8.1
+    GIT_TAG v2.9.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/installer/DisplayXRGaussianSplatInstaller.nsi
+++ b/installer/DisplayXRGaussianSplatInstaller.nsi
@@ -329,6 +329,34 @@ Section "Uninstall"
     ; Don't RMDir $SMPROGRAMS\DisplayXR — the runtime's own shortcuts may
     ; still live there.
 
+    ; The displayxr-view: protocol association (the "undock" launch contract).
+    ; It is written by the VIEWER at launch, not here — this installer runs
+    ; elevated, so an HKCU write would land in the elevating admin's hive rather
+    ; than the logged-in user's. So there is nothing to install; there is only
+    ; something to clean up, and ONLY if this viewer still owns it.
+    ;
+    ; Every DisplayXR viewer registers the same scheme, last writer wins. If the
+    ; model viewer (or any sibling) owns it now, deleting the key would break a
+    ; product the user did NOT uninstall. Hence the guard: delete only while the
+    ; registered command still points inside $INSTDIR.
+    ; The viewer writes exactly one command form (view_protocol.h CommandFor:
+    ; `"<exe>" "%1"`), so an equality test IS the "still points into $INSTDIR"
+    ; check, and it cannot misfire on a sibling whose path merely contains a
+    ; similar substring. NSIS `==` is case-insensitive, so path casing is fine.
+    ;
+    ; Best-effort by nature: an uninstaller elevated by a DIFFERENT user reads
+    ; that admin's HKCU, not the logged-in user's. Leaving the key behind is
+    ; harmless — EnsureViewProtocolRegistered rewrites any association whose
+    ; command names an executable that no longer exists.
+    ReadRegStr $0 HKCU "Software\Classes\displayxr-view\shell\open\command" ""
+    StrCpy $1 '"$INSTDIR\gaussian_splatting_handle_vk_win.exe" "%1"'
+    ${If} $0 == $1
+        DetailPrint "Removing displayxr-view protocol association (owned by this viewer)"
+        DeleteRegKey HKCU "Software\Classes\displayxr-view"
+    ${ElseIf} $0 != ""
+        DetailPrint "Leaving displayxr-view protocol association alone (owned by another viewer)"
+    ${EndIf}
+
     DeleteRegKey HKLM "Software\DisplayXR\Demos\GaussianSplat"
     DeleteRegKey /ifempty HKLM "Software\DisplayXR\Demos"
     DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DisplayXRGaussianSplat"

--- a/openxr_includes/openxr/XR_DXR_display_info.h
+++ b/openxr_includes/openxr/XR_DXR_display_info.h
@@ -6,7 +6,8 @@
 // Khronos OpenXR registry: extension numbers and XrStructureType values sit
 // in a provisional experimental block (1004999xxx) pending official
 // assignment. Extension names are expected to be stable; numeric values are
-// not. SPEC_VERSION restarted at 1 on the XR_EXT_* -> XR_DXR_* rename.
+// not. SPEC_VERSION continues the pre-rename XR_EXT_* numbering (the
+// interface history did not restart with the name).
 // See GOVERNANCE.md.
 //
 /*!
@@ -31,7 +32,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_display_info 1
-#define XR_DXR_display_info_SPEC_VERSION 1
+#define XR_DXR_display_info_SPEC_VERSION 18
 #define XR_DXR_DISPLAY_INFO_EXTENSION_NAME "XR_DXR_display_info"
 
 // Reuse the type value from the deleted XR_EXT_dynamic_render_resolution
@@ -91,6 +92,112 @@ typedef struct XrDisplayDesktopPositionDXR {
     int32_t                     left;       //!< Panel left edge in virtual-desktop pixels
     int32_t                     top;        //!< Panel top edge in virtual-desktop pixels
 } XrDisplayDesktopPositionDXR;
+
+// ---- v18: Full panel desktop rect + stable device name (#1301) ----
+
+#define XR_TYPE_DISPLAY_DESKTOP_INFO_DXR ((XrStructureType)1004999211)
+
+//! Size of XrDisplayDesktopInfoDXR::deviceName, in bytes, including the NUL.
+#define XR_MAX_DISPLAY_DEVICE_NAME_SIZE_DXR 128
+
+/*!
+ * @brief Desktop geometry and stable identity of the monitor the 3D panel is
+ * on, returned by xrGetSystemProperties (v18 addition).
+ *
+ * Supersedes XrDisplayDesktopPositionDXR, which carries only the origin. That
+ * struct keeps working unchanged — this is a SEPARATE chained struct rather
+ * than extra fields on it, because the runtime writes chained output structs
+ * with its own compiled layout and appending to a published struct would write
+ * past an app allocation compiled against v16.
+ *
+ * ## What it is for
+ *
+ * Nothing else in the wire protocol says WHERE the panel is, so a client that
+ * creates its own window has to guess, and typically lands on the OS primary
+ * monitor (see displayxr-unity#266). Matching displayPixelWidth/Height against
+ * the OS monitor list is ambiguous the moment two monitors share a resolution.
+ * Chain this struct instead, then place the window inside @ref desktopRect.
+ *
+ * ## Coordinate contract — read this before using desktopRect
+ *
+ * @ref desktopRect is in THE COORDINATE SPACE THE OS PLACES WINDOWS IN, which
+ * is what a client needs and which differs per platform:
+ *
+ * - Windows: physical virtual-screen pixels (what a per-monitor-DPI-aware-v2
+ *   process sees). The runtime pins a per-monitor-v2 DPI context while
+ *   resolving, so the value is physical regardless of the host process's own
+ *   DPI awareness.
+ * - macOS: POINTS in the global display space, NOT backing pixels — a Retina
+ *   panel's backing store is 2x this. Read displayPixelWidth/Height for pixels.
+ * - Linux/X11: device pixels in root-window coordinates.
+ *
+ * All three are TOP-DOWN with the origin at the primary/main display's
+ * top-left, and monitors left of or above it have NEGATIVE offsets. On macOS
+ * that is deliberately the CoreGraphics convention, not Cocoa's — an app
+ * placing an NSWindow must flip into NSScreen's bottom-up space itself, and one
+ * that forgets will mirror its position vertically on any multi-display setup.
+ *
+ * A consumer MUST act in that same space. A DPI-UNAWARE process that passes
+ * these coordinates to SetWindowPos (or any managed wrapper over it) is handed
+ * virtualised coordinates by the OS and will place the window wrong by the
+ * ratio of the two monitors' scale factors — correct on a single-monitor box,
+ * wrong on exactly the mixed-DPI multi-monitor rigs this struct exists to
+ * serve. Either declare per-monitor-v2 awareness for the process, or wrap the
+ * placement call in SetThreadDpiAwarenessContext(PER_MONITOR_AWARE_V2).
+ *
+ * ## desktopRect is not displayPixelWidth/Height
+ *
+ * XrDisplayInfoDXR::displayPixelWidth/Height are the panel's NATIVE
+ * resolution. @ref desktopRect.extent is the monitor's CURRENT desktop mode.
+ * They differ whenever the user runs a non-native mode. Use @ref desktopRect
+ * for placement and displayPixel* for render sizing.
+ *
+ * @extends XrSystemProperties
+ */
+typedef struct XrDisplayDesktopInfoDXR {
+    XrStructureType             type;       //!< Must be XR_TYPE_DISPLAY_DESKTOP_INFO_DXR
+    void* XR_MAY_ALIAS          next;       //!< Pointer to next structure in chain
+    /*!
+     * The panel monitor's full desktop rect in physical virtual-desktop
+     * pixels. `offset` is the signed top-left; `extent` is the current desktop
+     * mode's size. An all-zero rect means the runtime could not resolve it —
+     * treat the geometry as unknown and fall back to your previous placement.
+     */
+    XrRect2Di                   desktopRect;
+    /*!
+     * Stable OS device name of the panel's monitor, NUL-terminated UTF-8, for
+     * re-resolving the monitor after a hotplug or arrangement change (feed it
+     * to EnumDisplayDevices, or match it against DXGI_OUTPUT_DESC::DeviceName).
+     *
+     * Windows: the GDI name, e.g. `\\.\DISPLAY1`.
+     * macOS: the display UUID — deliberately not the CGDirectDisplayID, which
+     * is reassigned across reboots and replug and so cannot survive the very
+     * event this field exists for. Linux/X11: the RandR output name, e.g.
+     * `HDMI-1`. Empty string when the runtime could not resolve one.
+     */
+    char                        deviceName[XR_MAX_DISPLAY_DEVICE_NAME_SIZE_DXR];
+    /*!
+     * XR_TRUE when the panel's monitor is the desktop's primary monitor, in
+     * which case a client that only wants "open on the panel" can skip moving
+     * its window entirely. Common in the field: making the 3D panel the
+     * Windows primary is the standing workaround for the absence of this
+     * struct, so machines that already worked around it report XR_TRUE.
+     */
+    XrBool32                    isPrimary;
+    /*!
+     * XR_TRUE when the resolved monitor's current mode matches the panel's
+     * reported native resolution — i.e. the runtime genuinely located the 3D
+     * panel.
+     *
+     * XR_FALSE means the display processor expressed no position and the
+     * runtime fell back to the primary monitor. That happens with
+     * `sim_display` (hardware-free development) and on the platforms whose
+     * panel-origin plumbing is still open (#715). The rect is still a valid,
+     * placeable monitor rect — it is just not evidence that a 3D panel is
+     * there, so a client may prefer to leave its window where it is.
+     */
+    XrBool32                    isPanelConfirmed;
+} XrDisplayDesktopInfoDXR;
 
 /*!
  * @brief Hardware display state for xrRequestDisplayModeDXR (v15 repurpose).
@@ -430,6 +537,56 @@ typedef struct XrEventDataEyeTrackingStateChangedDXR {
     XrBool32                    isTracking; //!< New state
     XrEyeTrackingModeDXR        activeMode; //!< Session's MANAGED/MANUAL preference at edge time
 } XrEventDataEyeTrackingStateChangedDXR;
+
+// ---- v17: Display-mode request denial (panel lease, ADR-035 D2 / #961) ----
+
+#define XR_TYPE_EVENT_DATA_DISPLAY_MODE_REQUEST_DENIED_DXR ((XrStructureType)1004999014)
+
+//! Sentinel for XrEventDataDisplayModeRequestDeniedDXR::requestedModeIndex when
+//! the denied request carried no content mode (a pure xrRequestDisplayModeDXR).
+#define XR_DISPLAY_MODE_INDEX_NONE_DXR 0xFFFFFFFFu
+
+/*!
+ * @brief Why a display-mode request was denied.
+ *
+ * The runtime holds a single PANEL LEASE: while a workspace controller is
+ * active it owns the display mode; otherwise the built-in policy grants it to
+ * the focused session. A request from any other session is not applied and is
+ * NOT queued for later — this event is the only answer it gets. A request that
+ * the display hardware itself refuses (DISPLAY_PROCESSOR_REJECTED) leaves the
+ * runtime's reported mode unchanged.
+ */
+typedef enum XrDisplayModeDenialReasonDXR {
+    XR_DISPLAY_MODE_DENIAL_REASON_NONE_DXR = 0,
+    XR_DISPLAY_MODE_DENIAL_REASON_WORKSPACE_OWNS_MODE_DXR = 1,        //!< a workspace controller owns the panel
+    XR_DISPLAY_MODE_DENIAL_REASON_NOT_FOCUSED_DXR = 2,                //!< no controller; only the focused session may request
+    XR_DISPLAY_MODE_DENIAL_REASON_NO_DISPLAY_PROCESSOR_DXR = 3,       //!< nothing to apply the request to
+    XR_DISPLAY_MODE_DENIAL_REASON_DISPLAY_PROCESSOR_REJECTED_DXR = 4, //!< the display hardware refused the state
+    XR_DISPLAY_MODE_DENIAL_REASON_RELAY_OWNS_MODE_DXR = 5,            //!< a relay owns this session's mode (mechanism reserved; no relay ships today)
+    XR_DISPLAY_MODE_DENIAL_REASON_MAX_ENUM_DXR = 0x7FFFFFFF
+} XrDisplayModeDenialReasonDXR;
+
+/*!
+ * @brief Event delivered to the requesting session when its
+ * xrRequestDisplayRenderingModeDXR / xrRequestDisplayModeDXR call was denied.
+ *
+ * Both entry points return XR_SUCCESS at call time (the request is forwarded
+ * to the runtime's mode owner); this event, or a
+ * XrEventDataRenderingModeChangedDXR / XrEventDataHardwareDisplayStateChangedDXR,
+ * is the outcome. requestedModeIndex is XR_DISPLAY_MODE_INDEX_NONE_DXR when the
+ * request carried no content mode; requestedHardware3D is -1 when it carried no
+ * hardware state, else 0 (2D) / 1 (3D).
+ *
+ * @extends XrEventDataBaseHeader
+ */
+typedef struct XrEventDataDisplayModeRequestDeniedDXR {
+    XrStructureType               type;       //!< Must be XR_TYPE_EVENT_DATA_DISPLAY_MODE_REQUEST_DENIED_DXR
+    const void* XR_MAY_ALIAS      next;
+    XrSession                     session;
+    uint32_t                      requestedModeIndex;
+    int32_t                       requestedHardware3D;
+    XrDisplayModeDenialReasonDXR  reason;
+} XrEventDataDisplayModeRequestDeniedDXR;
 
 #ifdef __cplusplus
 }

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -2637,6 +2637,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // inherits the browser's environment (XRT_FORCE_MODE=ipc), which would make this
     // process an IPC client that is not the panel owner: 2D whenever the browser holds
     // the panel, no drag phase-snap. Must run before xrCreateInstance loads the runtime.
+    // Inherited IPC routing cannot be overridden in place (the runtime DLL's dynamic CRT
+    // snapshots the environment at process start), so re-launch once with a scrubbed
+    // block and let the child run. The in-place override below stays as the fallback.
+    if (dxr::ReexecWithCleanRuntimeEnvIfNeeded(g_launch)) {
+        LOG_WARN("launch: inherited IPC routing -> re-launched with a clean environment; this instance exits");
+        ShutdownLogging();
+        return 0;
+    }
     if (dxr::ForceInProcessRuntimeForUndock(g_launch))
         LOG_WARN("launch: inherited IPC routing overridden -> XRT_FORCE_MODE=native (undock is standalone)");
     if (!g_launch.ok()) {

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -39,8 +39,15 @@
 #include "vk_overlay_kit.h"   // dxr::CachedLayerUploader (#837 — no per-frame HUD upload+wait)
 #include "vk_clickthrough_region.h" // dxr::ClickThroughRegion (#833 — transparent-mode punch-through)
 #include "win_window_drag.h"        // dxr::RmbWindowDrag (move the borderless overlay)
+// The "undock" launch contract (displayxr-common): one grammar + one security
+// policy shared by every DisplayXR viewer a web page or a CAD app can spawn.
+#include "launch_args.h"    // dxr::ParseLaunchArgsFromCommandLine -> dxr::LaunchArgs
+#include "url_fetch.h"      // dxr::FetchUrlToCache — --src=<url> into the per-user cache
+#include "view_protocol.h"  // displayxr-view: registration, sibling forward, single instance
+#include "toast.h"          // dxr::ToastState — the only UI a shaped, chrome-free window has
 
 #include <atomic>
+#include <cstdarg>
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -141,6 +148,89 @@ static const UINT kBorderlessMsg = WM_APP + 0x33;
 static std::atomic<bool> g_borderless{false};
 static dxr::ClickThroughRegion g_punch; // render-thread owned
 static dxr::RmbWindowDrag g_windowDrag; // window-thread owned (WndProc)
+
+// ── Undock launch contract state ─────────────────────────────────────────────
+// Parsed once at the top of WinMain and then read-only. A second launch does
+// NOT mutate it: WM_COPYDATA parses its own LaunchArgs and applies it live, so
+// there is no shared mutable launch state to lock. Everything the render thread
+// needs out of the launch is mirrored into an atomic below.
+static dxr::LaunchArgs g_launch;
+// Held for the process lifetime when this is the instance that owns the
+// protocol scheme; releasing it would let a second launch open a rival window.
+static HANDLE g_singleInstanceMutex = nullptr;
+// A --src (local or URL) replaces the bundled butterfly.spz. For a URL the
+// scene arrives seconds later on the fetch thread, so the auto-load must be
+// suppressed rather than raced.
+static std::atomic<bool> g_suppressBundledAutoLoad{false};
+// --vh pins the virtual display height the asset was authored at. It is the
+// launcher's statement about the ASSET, so it outranks the auto-fit rule (which
+// only guesses from bounds) — but not the user's own zoom, which is a separate
+// multiplier.
+static std::atomic<bool> g_vhPinned{false};
+static std::atomic<float> g_vhPinnedValue{0.0f};
+// One download at a time; a second URL arriving over WM_COPYDATA while one is
+// in flight is refused with a toast rather than queued.
+static std::atomic<bool> g_fetchInFlight{false};
+
+// The only UI a --transparent window has: chrome is hidden by design in
+// transparent mode (#833), so a download that reported nothing would be a
+// window that sits empty for 20 seconds with no explanation.
+static dxr::ToastState g_toast;
+// ASCII in / wide out — every message this app produces is ASCII, so %hs
+// widening avoids a locale dependency (same helper as the avatar demo).
+static void ToastF(const char* fmt, ...) {
+    char buf[192];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    wchar_t w[224];
+    swprintf(w, 224, L"%hs", buf);
+    g_toast.Show(w);
+}
+
+/*!
+ * DXR_LAUNCH_QUIET=1 suppresses every launch-time MessageBoxW (a refused URL,
+ * a missing sibling viewer) and leaves the log line + the process exit code as
+ * the whole report.
+ *
+ * A refusal is MODAL: the process sits there until a human clicks OK. That is
+ * the right behaviour for a browser-initiated launch — nothing appeared, and
+ * the user deserves to know why — but it makes the negative cases untestable
+ * without a person, and an automated run that trips one leaves a dialog sitting
+ * on the panel. GetEnvironmentVariableW, not getenv: the CRT's environment
+ * snapshot is not the one a `set VAR=1 && app.exe` parent handed us.
+ *
+ * Exit codes are the machine-readable half and do not change: 2 = the launch
+ * was refused, 3 = the URL belongs to a sibling viewer that is not installed.
+ */
+static bool LaunchQuiet() {
+    wchar_t buf[16] = {};
+    const DWORD n = GetEnvironmentVariableW(L"DXR_LAUNCH_QUIET", buf, 16);
+    return n > 0 && n < 16 && buf[0] != L'\0' && buf[0] != L'0';
+}
+
+static void LaunchMessageBox(const std::wstring& text, UINT icon) {
+    if (LaunchQuiet()) {
+        LOG_WARN("DXR_LAUNCH_QUIET=1 - dialog suppressed: %ls", text.c_str());
+        return;
+    }
+    MessageBoxW(nullptr, text.c_str(), L"DisplayXR Gaussian Splat Viewer", MB_OK | icon);
+}
+
+// Toast window-space layer resources (render-thread owned after creation).
+// Sized to the chip, NOT the main HUD: RenderToastStandalone fills its whole
+// texture with one pill.
+static const uint32_t TOAST_TEX_W = 768;
+static const uint32_t TOAST_TEX_H = 96;
+static const uint32_t TOAST_FONT_BASE = TOAST_TEX_H * 11;  // ~45px glyphs in a 96px pill
+static const float    TOAST_SIZE_FRACTION = 0.60f;         // of the shorter window side
+static const float    TOAST_Y_FRACTION = 0.84f;
+static SwapchainInfo  g_toastSwapchain;
+static bool           g_hasToastSwapchain = false;
+static HudRenderer    g_toastHud = {};
+static bool           g_toastReady = false;
+static std::vector<XrSwapchainImageVulkanKHR> g_toastSwapImages;
 static std::string g_loadedFileName;
 static std::mutex g_sceneMutex;
 
@@ -233,6 +323,17 @@ static void ApplyAutoFitForLoadedScene_locked() {
         // Degenerate scene (all splats in a thin slice) — fall back to a
         // sensible vHeight rather than failing the fit. Mirrors macOS:1399.
         if (!(vh > 1e-3f)) vh = kFallbackVirtualDisplayHeightM;
+        // --vh wins over the guess. The launcher knows the metres the asset was
+        // authored at; auto-fit only infers them from the bounding box, so
+        // letting the fit overwrite an explicit --vh would silently discard the
+        // one number the caller actually knew.
+        if (g_vhPinned.load(std::memory_order_relaxed)) {
+            const float pinned = g_vhPinnedValue.load(std::memory_order_relaxed);
+            if (pinned > 1e-3f) {
+                LOG_INFO("Auto-fit vHeight %.3f overridden by --vh=%.3f", vh, pinned);
+                vh = pinned;
+            }
+        }
         g_fitVHeight = vh;
         // Cache the CONTENT half of the fit (extents are scene properties) and
         // the viewport this base was derived for, so RefitForViewport can
@@ -309,6 +410,12 @@ static void ApplyAutoFitForLoadedScene_locked() {
 // request to undo deliberate user state — recentring belongs on Space.
 static void RefitForViewport(float dtSeconds) {
     if (!g_fitValid.load(std::memory_order_relaxed)) {
+        return;
+    }
+    // A pinned --vh is an absolute statement in metres, so it does not follow
+    // the viewport. Returning before the transition update also leaves the
+    // load-time value in place rather than animating away from it.
+    if (g_vhPinned.load(std::memory_order_relaxed)) {
         return;
     }
     const float extW = g_fitExtentW.load(std::memory_order_relaxed);
@@ -749,8 +856,38 @@ static bool IsClickOnModeButton(int mouseX, int mouseY, int windowW, int windowH
 // common/atlas_capture* — see dxr_capture::MakeCaptureAtlasPrefix /
 // TriggerCaptureFlash / PostFlashRequest.
 
+// Load a scene on the CALLING thread. Only valid before the render thread
+// starts (the startup path); every later load must go through QueueSceneLoad,
+// because GsRenderer::loadScene submits on the graphics queue that the render
+// thread otherwise owns exclusively.
+static bool LoadSceneAtStartup(const std::string& path, const char* why) {
+    if (!PathFileExistsA(path.c_str())) {
+        LOG_WARN("%s: no file at %s", why, path.c_str());
+        return false;
+    }
+    if (!ValidateSceneFile(path)) return false;
+    LOG_INFO("%s: %s", why, path.c_str());
+    std::lock_guard<std::mutex> lock(g_sceneMutex);
+    if (g_gsRenderer.loadScene(path.c_str())) {
+        g_loadedFileName = GetPlyFilename(path);
+        LOG_INFO("Loaded %s (%s)", g_loadedFileName.c_str(), GetPlyFileSize(path).c_str());
+        ApplyAutoFitForLoadedScene_locked();
+        return true;
+    }
+    LOG_WARN("%s: load failed for %s", why, path.c_str());
+    return false;
+}
+
 // Attempt to auto-load butterfly.spz from next to the exe.
 static void TryAutoLoadBundledScene() {
+    // A launch that named its own asset (positional path, --src, or a protocol
+    // URL) must not flash the bundled butterfly first — and for a URL the real
+    // scene only arrives once the fetch thread lands, so the slot has to stay
+    // empty rather than be raced.
+    if (g_suppressBundledAutoLoad.load(std::memory_order_relaxed)) {
+        LOG_INFO("Bundled auto-load skipped: the launch named its own asset");
+        return;
+    }
     char exePath[MAX_PATH] = {0};
     if (!GetModuleFileNameA(nullptr, exePath, MAX_PATH)) return;
     // Strip basename
@@ -763,16 +900,7 @@ static void TryAutoLoadBundledScene() {
         LOG_INFO("No bundled scene at %s (skipping auto-load)", path.c_str());
         return;
     }
-    if (!ValidateSceneFile(path)) return;
-    LOG_INFO("Auto-loading bundled scene: %s", path.c_str());
-    std::lock_guard<std::mutex> lock(g_sceneMutex);
-    if (g_gsRenderer.loadScene(path.c_str())) {
-        g_loadedFileName = GetPlyFilename(path);
-        LOG_INFO("Loaded %s (%s)", g_loadedFileName.c_str(), GetPlyFileSize(path).c_str());
-        ApplyAutoFitForLoadedScene_locked();
-    } else {
-        LOG_WARN("Auto-load failed for %s", path.c_str());
-    }
+    LoadSceneAtStartup(path, "Auto-loading bundled scene");
 }
 
 // Hand a picked path off to the render thread for scene load. Validates the
@@ -791,6 +919,152 @@ static bool QueueSceneLoad(HWND hwnd, const std::string& path) {
     g_loadRequested.store(true, std::memory_order_release);
     LOG_INFO("Queued 3DGS scene load: %s", path.c_str());
     return true;
+}
+
+// ── --src=<url>: fetch on a worker thread, load on the render thread ─────────
+
+// Percent-encode everything outside the unreserved set, so the re-check below
+// parses the FINAL url through exactly the same grammar the requested one went
+// through (rather than a hand-rolled second opinion that could drift from it).
+static std::string PercentEncodeAll(const std::string& s) {
+    static const char* kHex = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(s.size() * 3);
+    for (unsigned char c : s) {
+        const bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                                (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+                                c == '.' || c == '~';
+        if (unreserved) {
+            out.push_back((char)c);
+        } else {
+            out.push_back('%');
+            out.push_back(kHex[c >> 4]);
+            out.push_back(kHex[c & 0xF]);
+        }
+    }
+    return out;
+}
+
+// Policy re-check for the URL a redirect chain actually landed on. A hostile
+// page cannot get a `file:` or off-loopback `http:` src past launch_args.h, but
+// nothing stops an https host it IS allowed to name from 302-ing somewhere
+// else — so the final URL is re-parsed AS IF it had arrived over the protocol,
+// which is the strictest of the two policies and needs no second implementation.
+static bool LaunchPolicyAllowsFinalUrl(const std::string& finalUrl) {
+    const std::string probe =
+        "displayxr-view://open?src=" + PercentEncodeAll(finalUrl) + "&v=1";
+    const dxr::LaunchArgs a = dxr::ParseLaunchArgs({probe});
+    const bool allowed = a.ok() && a.srcKind == dxr::LaunchSrcKind::Url;
+    if (!allowed) {
+        LOG_WARN("Redirect target refused by launch policy: %s", finalUrl.c_str());
+    }
+    return allowed;
+}
+
+// Kick a detached download. Synchronous inside the thread (FetchUrlToCache
+// blocks); progress lands on the toast, the finished file goes through the same
+// cross-thread queue Ctrl+O uses. NEVER loads from this thread.
+static void StartUrlFetch(HWND hwnd, const std::string& url, uint64_t maxBytes, bool noCache) {
+    bool expected = false;
+    if (!g_fetchInFlight.compare_exchange_strong(expected, true)) {
+        ToastF("Busy - a download is already running");
+        LOG_WARN("Download refused, one already in flight: %s", url.c_str());
+        return;
+    }
+    LOG_INFO("Fetching --src URL: %s (maxBytes=%llu noCache=%d)",
+             url.c_str(), (unsigned long long)maxBytes, noCache ? 1 : 0);
+    ToastF("Downloading...");
+    std::thread([hwnd, url, maxBytes, noCache]() {
+        dxr::UrlFetchOptions opts;
+        opts.cacheDir = dxr::DefaultCacheDir(L"GaussianSplat");
+        opts.allowedExtensions = {".ply", ".spz"};  // .sog is not a loadable format here
+        opts.maxBytes = maxBytes;
+        opts.noCache = noCache;
+        opts.urlAllowed = &LaunchPolicyAllowsFinalUrl;
+        opts.progress = [](uint64_t done, uint64_t total) {
+            // Throttled: the toast replaces its own message, and re-rasterizing
+            // a chip per network chunk would be pure waste.
+            static uint64_t s_lastTick = 0;
+            const uint64_t now = GetTickCount64();
+            if (now - s_lastTick < 300) return;
+            s_lastTick = now;
+            if (total > 0) {
+                ToastF("Downloading  %llu%%  (%.1f / %.1f MB)",
+                       (unsigned long long)(done * 100ull / total),
+                       (double)done / (1024.0 * 1024.0),
+                       (double)total / (1024.0 * 1024.0));
+            } else {
+                ToastF("Downloading  %.1f MB", (double)done / (1024.0 * 1024.0));
+            }
+        };
+        const dxr::UrlFetchResult r = dxr::FetchUrlToCache(url, opts);
+        g_fetchInFlight.store(false);
+        if (!r.ok) {
+            LOG_ERROR("Download failed for %s: %s", url.c_str(), r.error.c_str());
+            ToastF("Download failed - %s", r.error.c_str());
+            return;
+        }
+        const std::string path = dxr::NarrowPathForFopen(dxr::Utf8FromWide(r.path));
+        LOG_INFO("Downloaded %llu bytes%s -> %s",
+                 (unsigned long long)r.bytes, r.fromCache ? " (cache hit)" : "", path.c_str());
+        if (!ValidateSceneFile(path)) {
+            // Unreachable while allowedExtensions is {.ply,.spz}; toast rather
+            // than MessageBox because this is not the UI thread.
+            ToastF("Unsupported scene file");
+            LOG_ERROR("Fetched file rejected by ValidateSceneFile: %s", path.c_str());
+            return;
+        }
+        ToastF(r.fromCache ? "Loading (cached)" : "Loading");
+        QueueSceneLoad(hwnd, path);
+    }).detach();
+}
+
+// Nudge a requested --rect back INSIDE the panel monitor, and only that: a
+// launcher that deliberately straddles two monitors keeps its geometry, we just
+// refuse to place the window entirely off the panel. Never snaps to the panel
+// origin, and does nothing at all when the runtime did not confirm the panel
+// (sim_display, or a platform whose panel-origin plumbing is still open) or
+// reported an all-zero rect — an unconfirmed rect is a valid monitor, but not
+// evidence that the 3D panel is there.
+static void ClampRectIntoPanel(int32_t& x, int32_t& y, int32_t w, int32_t h) {
+    if (!g_displayPanelConfirmed) return;
+    const XrRect2Di& p = g_displayDesktopRect;
+    if (p.extent.width <= 0 || p.extent.height <= 0) return;
+    const int32_t right = p.offset.x + p.extent.width;
+    const int32_t bottom = p.offset.y + p.extent.height;
+    if (x + w > right)  x = right - w;
+    if (y + h > bottom) y = bottom - h;
+    if (x < p.offset.x) x = p.offset.x;
+    if (y < p.offset.y) y = p.offset.y;
+}
+
+// Apply a SECOND launch's arguments to this running instance (the WM_COPYDATA
+// hand-off from view_protocol.h's single-instance path). Deliberately narrower
+// than the startup path: geometry moves with SetWindowPos ONLY. A style change
+// on a shaped window is the one thing transparency Rule 2 forbids, and the
+// second launch has no way to know whether this window is currently shaped.
+static void ApplyLaunchArgsLive(HWND hwnd, const dxr::LaunchArgs& a) {
+    if (a.hasRect) {
+        int32_t x = a.rectX, y = a.rectY;
+        ClampRectIntoPanel(x, y, a.rectW, a.rectH);
+        SetWindowPos(hwnd, nullptr, x, y, a.rectW, a.rectH, SWP_NOZORDER | SWP_NOACTIVATE);
+        LOG_INFO("WM_COPYDATA rect: requested (%d,%d %dx%d) -> final (%d,%d %dx%d)",
+                 a.rectX, a.rectY, a.rectW, a.rectH, x, y, a.rectW, a.rectH);
+    }
+    if (a.hasVh) {
+        g_vhPinned.store(true, std::memory_order_relaxed);
+        g_vhPinnedValue.store(a.vh, std::memory_order_relaxed);
+        std::lock_guard<std::mutex> lock(g_inputMutex);
+        g_inputState.viewParams.virtualDisplayHeight = a.vh;
+        LOG_INFO("WM_COPYDATA vh: %.3f m", a.vh);
+    }
+    if (a.srcKind == dxr::LaunchSrcKind::Url) {
+        StartUrlFetch(hwnd, a.src, a.maxBytes, a.noCache);
+    } else if (a.srcKind == dxr::LaunchSrcKind::LocalPath) {
+        QueueSceneLoad(hwnd, dxr::NarrowPathForFopen(a.src));
+    } else if (!a.positionalPath.empty()) {
+        QueueSceneLoad(hwnd, dxr::NarrowPathForFopen(a.positionalPath));
+    }
 }
 
 // Open a file dialog and load a .ply or .spz scene (called from main thread).
@@ -880,6 +1154,31 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     }
 
     switch (msg) {
+    case WM_COPYDATA: {
+        // A second launch of this viewer handed us its URL instead of opening a
+        // rival window (view_protocol.h AcquireSingleInstanceOrForward). The
+        // payload is attacker-influenced text, so it goes through the SAME
+        // parser + policy as argv — never straight to a loader.
+        const COPYDATASTRUCT* cds = reinterpret_cast<const COPYDATASTRUCT*>(lParam);
+        if (!cds || cds->dwData != dxr::kViewProtocolCopyDataId || !cds->lpData ||
+            cds->cbData == 0) {
+            break;
+        }
+        // Length-bounded: trust cbData, not a NUL the sender may have omitted.
+        const char* raw = static_cast<const char*>(cds->lpData);
+        size_t n = strnlen(raw, cds->cbData);
+        const std::string url(raw, n);
+        LOG_INFO("WM_COPYDATA launch URL received (%zu bytes)", n);
+        const dxr::LaunchArgs a = dxr::ParseLaunchArgs({url});
+        for (const std::string& w : a.warnings) LOG_WARN("launch: %s", w.c_str());
+        if (!a.ok()) {
+            for (const std::string& e : a.errors) LOG_ERROR("launch: %s", e.c_str());
+            ToastF("Refused: %s", a.errors.empty() ? "bad launch URL" : a.errors[0].c_str());
+            return TRUE;
+        }
+        ApplyLaunchArgsLive(hwnd, a);
+        return TRUE;
+    }
     case WM_NCHITTEST:
         // Shaped borderless mode: the OS only delivers hits inside the
         // region; claim them for normal app input.
@@ -1033,8 +1332,22 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
-static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height, int32_t screenLeft, int32_t screenTop) {
-    LOG_INFO("Creating application window (%dx%d) at (%d, %d)", width, height, screenLeft, screenTop);
+/*!
+ * Create the app window.
+ *
+ * `borderless` is the --transparent launch: the window is born WS_POPUP +
+ * WS_EX_TOPMOST and stays that way. This is transparency Rule 2 — a shaped
+ * WS_EX_NOREDIRECTIONBITMAP window can never paint an OS frame, so the style
+ * must be right from creation rather than swapped afterwards (the Ctrl+T
+ * kBorderlessMsg path exists for the interactive toggle, and posting it at
+ * startup would produce exactly the flip this contract promises not to do).
+ * `titleSuffix` is APPENDED to WINDOW_TITLE — a launcher can label its window,
+ * never impersonate a different app.
+ */
+static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height, int32_t screenLeft, int32_t screenTop,
+                            bool borderless, const std::wstring& titleSuffix) {
+    LOG_INFO("Creating application window (%dx%d) at (%d, %d) style=%s", width, height,
+             screenLeft, screenTop, borderless ? "WS_POPUP (transparent launch)" : "WS_OVERLAPPEDWINDOW");
 
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
@@ -1057,15 +1370,26 @@ static HWND CreateAppWindow(HINSTANCE hInstance, int width, int height, int32_t 
         }
     }
 
+    // Borderless has no non-client area, so AdjustWindowRect would inflate the
+    // window past the rect the launcher asked for. Skip it: for WS_POPUP the
+    // window rect IS the client rect.
     RECT rect = { 0, 0, width, height };
-    AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
+    if (!borderless) AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
+
+    std::wstring title = WINDOW_TITLE;
+    if (!titleSuffix.empty()) title += L" - " + titleSuffix;
 
     // INV-1.3: open on the 3D panel (runtime#715 — handle apps otherwise open
     // on the primary monitor on multi-monitor boxes). (screenLeft, screenTop)
     // is the panel top-left in virtual-desktop pixels from
     // XrDisplayDesktopPositionDXR; (0,0) = primary/unknown, a safe default.
-    HWND hwnd = CreateWindowEx(WS_EX_NOREDIRECTIONBITMAP, WINDOW_CLASS, WINDOW_TITLE,
-        WS_OVERLAPPEDWINDOW,
+    // WS_EX_TOPMOST on the transparent launch matches the avatar: a click
+    // punched through to a window behind activates it, but the scene stays on
+    // top instead of disappearing under the app the user just clicked.
+    const DWORD exStyle = WS_EX_NOREDIRECTIONBITMAP | (borderless ? WS_EX_TOPMOST : 0u);
+    const DWORD style = borderless ? (WS_POPUP | WS_VISIBLE) : WS_OVERLAPPEDWINDOW;
+    HWND hwnd = CreateWindowEx(exStyle, WINDOW_CLASS, title.c_str(),
+        style,
         screenLeft, screenTop,
         rect.right - rect.left, rect.bottom - rect.top,
         nullptr, nullptr, hInstance, nullptr);
@@ -1897,12 +2221,31 @@ static void RenderThreadFunc(
                                     s_punchInit = g_punch.init(vkDevice, physDevice, queueFamilyIndex);
                                 }
                                 if (s_punchInit) {
+                                    // The toast is the ONE piece of chrome that must
+                                    // survive shaping. Everything else is hidden in
+                                    // transparent mode, so a --src download on an
+                                    // empty window would otherwise be carved away
+                                    // entirely — a blank silhouette reporting nothing.
+                                    RECT chrome[1];
+                                    uint32_t chromeCount = 0;
+                                    if (g_toast.Active() && windowW > 0 && windowH > 0) {
+                                        const dxr::ToastLayerRect tr = dxr::ComputeToastLayerRect(
+                                            windowW, windowH,
+                                            (float)TOAST_TEX_W / (float)TOAST_TEX_H,
+                                            TOAST_SIZE_FRACTION, TOAST_Y_FRACTION);
+                                        chrome[0].left   = (LONG)(tr.x * (float)windowW);
+                                        chrome[0].top    = (LONG)(tr.y * (float)windowH);
+                                        chrome[0].right  = (LONG)((tr.x + tr.width) * (float)windowW);
+                                        chrome[0].bottom = (LONG)((tr.y + tr.height) * (float)windowH);
+                                        chromeCount = 1;
+                                    }
                                     // Union the LAST view's tile too — a view-0-only
                                     // region clips the other views' parallax edges
                                     // once content moves off ZDP (butterfly bug).
                                     const uint32_t lastV = (uint32_t)(eyeCount - 1);
                                     g_punch.update(graphicsQueue, (*swapchainVkImages)[imageIndex],
-                                                   renderW, renderH, hwnd, windowW, windowH, nullptr, 0,
+                                                   renderW, renderH, hwnd, windowW, windowH,
+                                                   chromeCount ? chrome : nullptr, chromeCount,
                                                    (lastV % cols) * renderW, (lastV / cols) * renderH,
                                                    eyeCount > 1);
                                 }
@@ -2119,11 +2462,81 @@ static void RenderThreadFunc(
                     }
                 }
 
+                // ── Toast layer ─────────────────────────────────────────────
+                // Built and submitted only on the frames dxr::ToastState says a
+                // message is live; once it expires the layer is simply absent
+                // (a true toggle, not a transparent layer). Its own swapchain,
+                // so it survives the transparent-mode chrome blackout above.
+                XrCompositionLayerWindowSpaceDXR toastLayer = {};
+                bool toastLayerReady = false;
+                if (rendered && g_toastReady && g_hasToastSwapchain) {
+                    std::wstring toastText;
+                    float toastAlpha = 1.0f;
+                    if (g_toast.Snapshot(toastText, toastAlpha)) {
+                        static dxr::CachedLayerUploader s_toastUp;
+                        static bool s_toastUpInit = false;
+                        static bool s_toastUploadedOnce = false;
+                        if (!s_toastUpInit) {
+                            s_toastUpInit = s_toastUp.init(vkDevice, physDevice, queueFamilyIndex,
+                                                           TOAST_TEX_W, TOAST_TEX_H);
+                        }
+                        // Alpha is quantised into the hash so the fade-out
+                        // re-rasterizes, but a steady message does not.
+                        const uint32_t alphaQ = (uint32_t)(toastAlpha * 32.0f);
+                        uint64_t th = dxr::HashBytes(toastText.data(),
+                                                     toastText.size() * sizeof(wchar_t));
+                        th = dxr::HashBytes(&alphaQ, sizeof(alphaQ), th);
+                        if (s_toastUpInit && s_toastUp.needsUpload(th)) {
+                            uint32_t pitch = 0;
+                            const void* px = RenderToastStandalone(g_toastHud, &pitch,
+                                                                   toastText, toastAlpha);
+                            uint32_t idx = 0;
+                            if (px && AcquireWindowSpaceImage(g_toastSwapchain, idx)) {
+                                if (s_toastUp.upload(graphicsQueue, g_toastSwapImages[idx].image,
+                                                     px, pitch, TOAST_TEX_W * 4, TOAST_TEX_H, th)) {
+                                    s_toastUploadedOnce = true;
+                                }
+                                ReleaseWindowSpaceImage(g_toastSwapchain);
+                            }
+                            if (px) UnmapHud(g_toastHud);
+                        }
+                        if (s_toastUploadedOnce) {
+                            const dxr::ToastLayerRect tr = dxr::ComputeToastLayerRect(
+                                windowW, windowH, (float)TOAST_TEX_W / (float)TOAST_TEX_H,
+                                TOAST_SIZE_FRACTION, TOAST_Y_FRACTION);
+                            toastLayer.type = (XrStructureType)XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_DXR;
+                            toastLayer.next = nullptr;
+                            toastLayer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+                            toastLayer.subImage.swapchain = g_toastSwapchain.swapchain;
+                            toastLayer.subImage.imageRect.offset = {0, 0};
+                            toastLayer.subImage.imageRect.extent = {(int32_t)TOAST_TEX_W,
+                                                                    (int32_t)TOAST_TEX_H};
+                            toastLayer.subImage.imageArrayIndex = 0;
+                            toastLayer.x = tr.x;
+                            toastLayer.y = tr.y;
+                            toastLayer.width = tr.width;
+                            toastLayer.height = tr.height;
+                            toastLayer.disparity = 0.0f;
+                            toastLayerReady = true;
+                            // One-shot (never per-frame): proves the layer
+                            // actually reached xrEndFrame, which is otherwise
+                            // only checkable by eye on the panel.
+                            static bool s_toastLoggedOnce = false;
+                            if (!s_toastLoggedOnce) {
+                                s_toastLoggedOnce = true;
+                                LOG_INFO("Toast layer submitted: rect=(%.3f,%.3f %.3fx%.3f) "
+                                         "of a %ux%u window",
+                                         tr.x, tr.y, tr.width, tr.height, windowW, windowH);
+                            }
+                        }
+                    }
+                }
+
                 // Submit frame
                 uint32_t submitViewCount = (xr->renderingModeCount > 0 && xr->currentModeIndex < xr->renderingModeCount) ? xr->renderingModeViewCounts[xr->currentModeIndex] : 2;
                 if (submitViewCount == 0) submitViewCount = 1;
                 if (submitViewCount > 8) submitViewCount = 8;  // matches projectionViews[8] sizing
-                if (rendered && hudSubmitted) {
+                if (rendered && (hudSubmitted || toastLayerReady)) {
                     // Layer footprint sized per-frame to match the HUD
                     // swapchain's aspect (computed above as layerFracW ×
                     // layerFracH), so the runtime's swapchain→layer rect
@@ -2137,9 +2550,16 @@ static void RenderThreadFunc(
                     // this demo passes the bit explicitly (its vendored copy
                     // used to hardcode it) — required for the Ctrl+T
                     // transparent-background path; a no-op when opaque.
-                    EndFrameWithWindowSpaceHud(*xr, frameState.predictedDisplayTime, projectionViews,
+                    //
+                    // The toast rides as an extra window-space layer with its
+                    // own swapchain, so it composites on top of the HUD and
+                    // shows even on the frames where `submitHud` is false
+                    // (transparent mode hides all other chrome).
+                    EndFrameWithWindowSpaceLayers(*xr, frameState.predictedDisplayTime, projectionViews,
                         0.0f, 0.0f, layerFracW, layerFracH, 0.0f, submitViewCount,
+                        toastLayerReady ? &toastLayer : nullptr, toastLayerReady ? 1u : 0u,
                         0, 0, -1, -1,
+                        /*submitHud=*/hudSubmitted,
                         XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT);
                 } else if (rendered) {
                     EndFrame(*xr, frameState.predictedDisplayTime, projectionViews, submitViewCount,
@@ -2197,6 +2617,90 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     LOG_INFO("=== SR 3DGS OpenXR Ext Vulkan Application ===");
 
+    // ── The undock launch contract ──────────────────────────────────────────
+    // GetCommandLineW, not WinMain's ANSI lpCmdLine, so a non-ASCII path
+    // survives. One parse, one policy — see displayxr-common/common/launch_args.h.
+    g_launch = dxr::ParseLaunchArgsFromCommandLine();
+    LOG_INFO("Launch: transparent=%d rect=%d(%d,%d %dx%d) src=%s(%s) positional='%s' "
+             "vh=%d(%.3f) dpr=%d(%.2f) type='%s' title='%s' protocol=%d maxBytes=%llu noCache=%d",
+             g_launch.transparent ? 1 : 0, g_launch.hasRect ? 1 : 0,
+             g_launch.rectX, g_launch.rectY, g_launch.rectW, g_launch.rectH,
+             g_launch.src.c_str(),
+             g_launch.srcKind == dxr::LaunchSrcKind::Url ? "url"
+                 : g_launch.srcKind == dxr::LaunchSrcKind::LocalPath ? "path" : "none",
+             g_launch.positionalPath.c_str(),
+             g_launch.hasVh ? 1 : 0, g_launch.vh, g_launch.hasDpr ? 1 : 0, g_launch.dpr,
+             g_launch.type.c_str(), g_launch.title.c_str(), g_launch.fromProtocol ? 1 : 0,
+             (unsigned long long)g_launch.maxBytes, g_launch.noCache ? 1 : 0);
+    for (const std::string& w : g_launch.warnings) LOG_WARN("launch: %s", w.c_str());
+    if (!g_launch.ok()) {
+        for (const std::string& e : g_launch.errors) LOG_ERROR("launch: %s", e.c_str());
+        // A protocol launch has no console to read the error from, and the
+        // browser already asked the user to open this app — say why nothing
+        // appeared. A CLI launch gets the log and a non-zero exit code.
+        if (g_launch.fromProtocol) {
+            LaunchMessageBox(dxr::WideFromUtf8(g_launch.errors[0]), MB_ICONERROR);
+        }
+        ShutdownLogging();
+        return 2;
+    }
+
+    // Register HKCU\Software\Classes\displayxr-view -> this exe. Done by the
+    // VIEWER, not the installer: the NSIS installers run elevated, so their HKCU
+    // writes land in the elevating admin's hive. Idempotent; a LIVE sibling that
+    // already owns the scheme is left alone (type forwarding covers that).
+    {
+        const bool reg = dxr::EnsureViewProtocolRegistered(
+            dxr::ThisExePath(), L"DisplayXR Gaussian Splat Viewer");
+        LOG_INFO("displayxr-view protocol association: %s", reg ? "usable" : "FAILED");
+    }
+
+    if (g_launch.fromProtocol) {
+        // (a) Wrong viewer for this asset. One scheme serves every viewer so the
+        // browser only asks once; whoever the OS launched forwards by type.
+        if (!g_launch.type.empty() && g_launch.type != "splat") {
+            const std::wstring sibling =
+                dxr::FindSiblingViewer(L"ModelViewer", L"model_viewer_handle_vk_win.exe");
+            if (sibling.empty()) {
+                LOG_ERROR("type='%s' is not ours and the model viewer is not installed",
+                          g_launch.type.c_str());
+                LaunchMessageBox(
+                    L"This link opens a 3D model, which needs the DisplayXR 3D Model Viewer.\n\n"
+                    L"Please install the DisplayXR 3D Model Viewer and try again.",
+                    MB_ICONINFORMATION);
+                ShutdownLogging();
+                return 3;
+            }
+            const bool launched = dxr::LaunchViewerWithUrl(
+                sibling, dxr::WideFromUtf8(g_launch.protocolUrl));
+            LOG_INFO("Forwarded type='%s' to %ls: %s", g_launch.type.c_str(), sibling.c_str(),
+                     launched ? "ok" : "FAILED");
+            ShutdownLogging();
+            return launched ? 0 : 3;
+        }
+        // (b) Already running? Hand the URL to that instance and exit, so a page
+        // that undocks twice retargets one window instead of stacking viewers.
+        g_singleInstanceMutex = dxr::AcquireSingleInstanceOrForward(
+            L"Local\\DisplayXR.GaussianSplat.Undock", WINDOW_CLASS, g_launch.protocolUrl);
+        if (g_singleInstanceMutex == nullptr) {
+            LOG_INFO("Forwarded the URL to the running instance; exiting");
+            ShutdownLogging();
+            return 0;
+        }
+    }
+
+    // Mirror the launch into the render-thread-visible flags before anything
+    // that reads them (the bundled auto-load runs during init, below).
+    if (g_launch.hasVh) {
+        g_vhPinned.store(true, std::memory_order_relaxed);
+        g_vhPinnedValue.store(g_launch.vh, std::memory_order_relaxed);
+    }
+    if (g_launch.srcKind != dxr::LaunchSrcKind::None || !g_launch.positionalPath.empty()) {
+        g_suppressBundledAutoLoad.store(true, std::memory_order_relaxed);
+    }
+    g_transparentBg.store(g_launch.transparent);
+    g_borderless.store(g_launch.transparent);
+
     // Drift guard: assert the view/unproject/orientation conventions are
     // self-consistent (round-trip + +NDC->+world). A non-zero result means the
     // render-vs-pick frame math has drifted — fail loud rather than ship a
@@ -2239,7 +2743,26 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // Create the app window on the 3D panel
     int32_t panelLeft = 0, panelTop = 0;
     GetDisplayDesktopPosition(panelLeft, panelTop);
-    HWND hwnd = CreateAppWindow(hInstance, g_windowWidth, g_windowHeight, panelLeft, panelTop);
+    // --rect=X,Y,W,H replaces the default placement. Physical virtual-screen
+    // pixels (this exe declares PerMonitorV2, so no DPI virtualisation).
+    if (g_launch.hasRect) {
+        int32_t rx = g_launch.rectX, ry = g_launch.rectY;
+        ClampRectIntoPanel(rx, ry, g_launch.rectW, g_launch.rectH);
+        LOG_INFO("Launch rect: requested (%d,%d %dx%d) -> final (%d,%d %dx%d) "
+                 "panel=(%d,%d %dx%d) confirmed=%d dpr=%.2f",
+                 g_launch.rectX, g_launch.rectY, g_launch.rectW, g_launch.rectH,
+                 rx, ry, g_launch.rectW, g_launch.rectH,
+                 g_displayDesktopRect.offset.x, g_displayDesktopRect.offset.y,
+                 g_displayDesktopRect.extent.width, g_displayDesktopRect.extent.height,
+                 g_displayPanelConfirmed ? 1 : 0, g_launch.hasDpr ? g_launch.dpr : 0.0f);
+        panelLeft = rx;
+        panelTop = ry;
+        g_windowWidth = (UINT)g_launch.rectW;
+        g_windowHeight = (UINT)g_launch.rectH;
+    }
+    HWND hwnd = CreateAppWindow(hInstance, (int)g_windowWidth, (int)g_windowHeight,
+                                panelLeft, panelTop, g_launch.transparent,
+                                dxr::WideFromUtf8(g_launch.title));
     if (!hwnd) {
         LOG_ERROR("Failed to create window");
         CleanupOpenXR(xr);
@@ -2360,6 +2883,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                                queueFamilyIndex, renderW, renderH)) {
             LOG_WARN("3DGS renderer init failed - scene rendering will not be available");
         } else {
+            // Startup scene selection. A local asset named on the command line
+            // loads here, synchronously, exactly where the bundled sample would
+            // have — the render thread does not exist yet, so this is the one
+            // moment loadScene may run off it. A URL cannot: it is kicked after
+            // the render thread is up, so the toast can report it.
+            if (g_launch.srcKind == dxr::LaunchSrcKind::LocalPath) {
+                LoadSceneAtStartup(dxr::NarrowPathForFopen(g_launch.src), "Loading --src");
+            } else if (!g_launch.positionalPath.empty()) {
+                LoadSceneAtStartup(dxr::NarrowPathForFopen(g_launch.positionalPath),
+                                   "Loading command-line scene");
+            }
             TryAutoLoadBundledScene();
         }
     }
@@ -2453,7 +2987,29 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         }
     }
 
-    ShowWindow(hwnd, nCmdShow);
+    // ── Toast window-space layer ────────────────────────────────────────────
+    // Its own small swapchain rather than a corner of the HUD, because the HUD
+    // (and every other piece of chrome) is HIDDEN in transparent mode by design
+    // — which is precisely when a download most needs to say something. Failure
+    // is non-fatal: the log still carries the progress.
+    {
+        if (InitializeHudRenderer(g_toastHud, TOAST_TEX_W, TOAST_TEX_H, TOAST_FONT_BASE) &&
+            CreateWindowSpaceSwapchain(xr, g_toastSwapchain, TOAST_TEX_W, TOAST_TEX_H)) {
+            uint32_t c = g_toastSwapchain.imageCount;
+            g_toastSwapImages.resize(c, {XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR});
+            xrEnumerateSwapchainImages(g_toastSwapchain.swapchain, c, &c,
+                (XrSwapchainImageBaseHeader*)g_toastSwapImages.data());
+            g_hasToastSwapchain = true;
+            g_toastReady = true;
+            LOG_INFO("Toast swapchain: %ux%u, %u images", TOAST_TEX_W, TOAST_TEX_H, c);
+        } else {
+            LOG_WARN("Toast layer unavailable - progress will only reach the log");
+        }
+    }
+
+    // A --transparent launch must not steal focus: it is a floating overlay a
+    // page spawned, not a window the user asked to switch to.
+    ShowWindow(hwnd, g_launch.transparent ? SW_SHOWNOACTIVATE : nCmdShow);
     UpdateWindow(hwnd);
 
     LOG_INFO("");
@@ -2463,7 +3019,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LOG_INFO("          L=Load  Tab=HUD  F11=Fullscreen  ESC=Quit");
     LOG_INFO("");
 
-    g_inputState.viewParams.virtualDisplayHeight = kFallbackVirtualDisplayHeightM;
+    // --vh seeds the fallback: with a URL src there is no scene yet, so this is
+    // the value the first frames actually render at.
+    g_inputState.viewParams.virtualDisplayHeight =
+        g_vhPinned.load(std::memory_order_relaxed) ? g_vhPinnedValue.load(std::memory_order_relaxed)
+                                                   : kFallbackVirtualDisplayHeightM;
     g_inputState.renderingModeCount = xr.renderingModeCount;
     // Align runtime active rendering mode with app's default (mode 1 = first 3D mode).
     // The main loop's dispatch picks this up on the first frame and calls
@@ -2485,6 +3045,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         hudOk ? &hudSwapImages : nullptr,
         (VkCommandPool)VK_NULL_HANDLE, (std::vector<XrSwapchainImageVulkanKHR>*)nullptr,
         (uint32_t)0, (uint32_t)0);
+
+    // --src=<url>: start the download now that the render thread (and with it
+    // the toast) is alive, so progress is visible from the first byte.
+    if (g_launch.srcKind == dxr::LaunchSrcKind::Url) {
+        StartUrlFetch(hwnd, g_launch.src, g_launch.maxBytes, g_launch.noCache);
+    }
 
     MSG msg = {};
     while (GetMessage(&msg, nullptr, 0, 0) > 0) {
@@ -2510,6 +3076,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     if (hudStagingMemory != VK_NULL_HANDLE) vkFreeMemory(vkDevice, hudStagingMemory, nullptr);
     if (hudOk) CleanupHudRenderer(hudRenderer);
 
+    // Toast layer — destroy the swapchain before CleanupOpenXR tears the
+    // session down under it.
+    if (g_toastReady) CleanupHudRenderer(g_toastHud);
+    if (g_toastSwapchain.swapchain != XR_NULL_HANDLE) {
+        xrDestroySwapchain(g_toastSwapchain.swapchain);
+        g_toastSwapchain.swapchain = XR_NULL_HANDLE;
+        g_hasToastSwapchain = false;
+    }
+
     g_xr = nullptr;
     CleanupOpenXR(xr);
     vkDestroyDevice(vkDevice, nullptr);
@@ -2517,6 +3092,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     DestroyWindow(hwnd);
     UnregisterClass(WINDOW_CLASS, hInstance);
+
+    // Released last: while this handle is open we are THE instance, and a
+    // second launch forwards to us instead of opening a rival window.
+    if (g_singleInstanceMutex) {
+        CloseHandle(g_singleInstanceMutex);
+        g_singleInstanceMutex = nullptr;
+    }
 
     LOG_INFO("Application shutdown complete");
     ShutdownLogging();

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -2633,6 +2633,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
              g_launch.type.c_str(), g_launch.title.c_str(), g_launch.fromProtocol ? 1 : 0,
              (unsigned long long)g_launch.maxBytes, g_launch.noCache ? 1 : 0);
     for (const std::string& w : g_launch.warnings) LOG_WARN("launch: %s", w.c_str());
+    // An undocked viewer must run its OWN in-process compositor. A protocol handler
+    // inherits the browser's environment (XRT_FORCE_MODE=ipc), which would make this
+    // process an IPC client that is not the panel owner: 2D whenever the browser holds
+    // the panel, no drag phase-snap. Must run before xrCreateInstance loads the runtime.
+    if (dxr::ForceInProcessRuntimeForUndock(g_launch))
+        LOG_WARN("launch: inherited IPC routing overridden -> XRT_FORCE_MODE=native (undock is standalone)");
     if (!g_launch.ok()) {
         for (const std::string& e : g_launch.errors) LOG_ERROR("launch: %s", e.c_str());
         // A protocol launch has no console to read the error from, and the

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -34,6 +34,15 @@ void GetDisplayDesktopPosition(int32_t& left, int32_t& top)
     top = s_displayDesktopTop;
 }
 
+// #1301 / display_info v18: the panel monitor's FULL desktop rect + the
+// runtime's own "this really is the panel" confidence flag. A SEPARATE chained
+// struct from XrDisplayDesktopPositionDXR (the runtime writes chained output
+// with its own layout, so the v16 struct could not simply grow). Zero-init means
+// an older runtime that ignores the unknown chain entry leaves it all-zero,
+// which is exactly the "geometry unknown" sentinel the header specifies.
+XrRect2Di g_displayDesktopRect = {};
+bool      g_displayPanelConfirmed = false;
+
 #define XR_CHECK(call) \
     do { \
         XrResult result = (call); \
@@ -163,6 +172,11 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         // consumed by CreateAppWindow so the window opens on the 3D panel.
         XrDisplayDesktopPositionDXR desktopPos = {};
         desktopPos.type = XR_TYPE_DISPLAY_DESKTOP_POSITION_DXR;
+        // display_info v18 (#1301): the full panel rect, for --rect clamping.
+        // Additive and separately chained — an older runtime just leaves it zero.
+        XrDisplayDesktopInfoDXR desktopInfo = {};
+        desktopInfo.type = XR_TYPE_DISPLAY_DESKTOP_INFO_DXR;
+        desktopPos.next = &desktopInfo;
         eyeCaps.next = &desktopPos;
         displayInfo.next = &eyeCaps;
         sysProps.next = &displayInfo;
@@ -181,7 +195,13 @@ bool InitializeOpenXR(XrSessionManager& xr) {
             xr.defaultEyeTrackingMode = (uint32_t)eyeCaps.defaultMode;
             s_displayDesktopLeft = desktopPos.left;
             s_displayDesktopTop = desktopPos.top;
+            g_displayDesktopRect = desktopInfo.desktopRect;
+            g_displayPanelConfirmed = (desktopInfo.isPanelConfirmed == XR_TRUE);
             LOG_INFO("Display desktop position: (%d, %d)", s_displayDesktopLeft, s_displayDesktopTop);
+            LOG_INFO("Display desktop rect: (%d, %d) %dx%d  panelConfirmed=%s  device='%s'",
+                g_displayDesktopRect.offset.x, g_displayDesktopRect.offset.y,
+                g_displayDesktopRect.extent.width, g_displayDesktopRect.extent.height,
+                g_displayPanelConfirmed ? "yes" : "no", desktopInfo.deviceName);
             LOG_INFO("Display info: scale=%.3fx%.3f, size=%.3fx%.3fm, pixels=%ux%u, nominal=(%.0f,%.0f,%.0f)mm",
                 xr.recommendedViewScaleX, xr.recommendedViewScaleY,
                 xr.displayWidthM, xr.displayHeightM,

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -25,6 +25,17 @@ bool XrViewRigExtAvailable();
 // for the same reason as XrViewRigExtAvailable().
 void GetDisplayDesktopPosition(int32_t& left, int32_t& top);
 
+// #1301 / display_info v18: the FULL desktop rect of the monitor the 3D panel
+// is on, in the same coordinate space the OS places windows in (Windows:
+// physical virtual-screen pixels, which is why this exe declares PerMonitorV2 —
+// a DPI-virtualised process reads a scaled rect and mis-places the window).
+// An all-zero rect means "runtime could not resolve it": treat the geometry as
+// unknown and do NOT clamp against it. g_displayPanelConfirmed is the runtime's
+// own confidence flag — a --rect is clamped INTO the panel only when both the
+// flag is set and the rect is non-zero, and it is never snapped.
+extern XrRect2Di g_displayDesktopRect;
+extern bool      g_displayPanelConfirmed;
+
 // Get Vulkan graphics requirements and set up Vulkan instance/device per OpenXR spec
 bool GetVulkanGraphicsRequirements(XrSessionManager& xr);
 


### PR DESCRIPTION
## What

A web page — or a native app such as a CAD tool "undocking" a part — can now spawn this viewer as a transparent, borderless, topmost, click-through-shaped window over the desktop, already showing a given scene at a given screen rect. No Ctrl+T, and no style change after the window exists.

- **A command line, where there was none.** `WinMain` did `(void)lpCmdLine;`. It now parses `GetCommandLineW` through `dxr::ParseLaunchArgsFromCommandLine()`: a positional scene path, `--transparent`, `--rect=X,Y,W,H`, `--src=<url|path>`, `--vh=<metres>`, `--title=`, `--type=`, `--dpr=`, `--max-bytes=`, `--no-cache`, `--allow-local`.
- **`displayxr-view:` protocol handler.** The viewer registers `HKCU\Software\Classes\displayxr-view` for itself at launch (the installer runs elevated, so its HKCU writes land in the elevating admin's hive). A `type=` that is not ours is forwarded to the sibling viewer by `CreateProcessW`; a second launch of our own type hands its URL to the running instance over `WM_COPYDATA` instead of stacking a rival window.
- **Transparent at launch.** The window is born `WS_POPUP | WS_VISIBLE | WS_EX_TOPMOST`, skips `AdjustWindowRect`, and never posts `kBorderlessMsg` at startup — transparency Rule 2, because a shaped `WS_EX_NOREDIRECTIONBITMAP` window can never paint an OS frame. Ctrl+T is unchanged.
- **`XrDisplayDesktopInfoDXR` (display_info v18, #1301).** Chained next to the existing origin query so `--rect` can be clamped *into* the panel's monitor — only when the runtime confirms it found the panel, and never snapped.
- **A toast.** This demo had none, and transparent mode hides all chrome by design (#833) — so a `--src` download on an empty shaped window would sit silent for twenty seconds. Its own small window-space swapchain, submitted through `EndFrameWithWindowSpaceLayers` only on frames a message is live, with its band unioned into the click-through region as the one piece of chrome that survives shaping.

## Why it looks the way it does

- **The grammar and the policy are not re-implemented here.** They come from `displayxr-common` (`launch_args.h`, `url_fetch.h`, `view_protocol.h`, pinned at `v2.9.0`), so every DisplayXR viewer refuses the same hostile URL the same way. The browser's one-time "Open this app?" consent is sticky per origin, so from then on any page on that origin can drive this parser — hence: protocol `src` must be `https:` or loopback `http:`, `file:`/UNC/bare paths are refused, and `--allow-local` (an argv flag a page cannot set) is the native-caller escape hatch.
- **The redirect target is re-checked by re-parsing it as a protocol URL**, rather than by a second hand-written opinion that could drift from the first.
- **`--src=<url>` never loads from the fetch thread.** `GsRenderer::loadScene` submits on the graphics queue the render thread owns exclusively, so the download hands its path to the same cross-thread queue `Ctrl+O` uses.
- **`DXR_LAUNCH_QUIET=1`** (read with `GetEnvironmentVariableW`) suppresses the launch-refusal message boxes. The modal is correct for a browser-initiated launch, but it makes every negative case untestable without a human and leaves a dialog on the panel. Exit codes are the machine-readable half and do not change: **2** = refused, **3** = the URL belongs to a sibling viewer that is not installed.

## Verification

Built with `scripts\build-with-deps.bat` (clean, no new warnings). Runtime `v2.16.5-3-ge6b12cd19`, Leia SR plug-in `2.6.13`, 250% display scaling. All measuring scripts call `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` first — a DPI-unaware probe reads `800x800` as `320x320` on this box and would have reported a false failure.

**1. Transparent + rect + vh + positional path — PASS**

```
exe --transparent --rect=300,300,800,800 --vh=0.2 "<...>\butterfly.spz"
```
```
class='SR3DGSOpenXRExtVKClass' rect=(300,300)-(1100,1100) size=800x800
  STYLE=0x94000000 POPUP=True CAPTION=False VISIBLE=True
  EXSTYLE=0x00200018 TOPMOST=True NRB=True
```
App log:
```
Launch: transparent=1 rect=1(300,300 800x800) src=(none) positional='...\butterfly.spz' vh=1(0.200) ... protocol=0
displayxr-view protocol association: usable
Display desktop rect: (0, 0) 3840x2160  panelConfirmed=yes  device='\\.\DISPLAY1'
Launch rect: requested (300,300 800x800) -> final (300,300 800x800) panel=(0,0 3840x2160) confirmed=1
Creating application window (800x800) at (300, 300) style=WS_POPUP (transparent launch)
Loading command-line scene: ...\butterfly.spz
Auto-fit vHeight 2.285 overridden by --vh=0.200
Bundled auto-load skipped: the launch named its own asset
```
No `Transparent background: ... (Ctrl+T)` line anywhere — the startup style swap does not happen.

**2a. Protocol URL download — PASS** (`python -m http.server 8731` in the exe dir; loopback http is admitted by policy)

```
exe "displayxr-view://open?src=http%3A%2F%2Flocalhost%3A8731%2Fbutterfly.spz&type=splat&rect=400,200,900,700&vh=0.25&v=1"
```
```
Toast swapchain: 768x96, 3 images
Fetching --src URL: http://localhost:8731/butterfly.spz (maxBytes=268435456 noCache=0)
Downloaded 4049714 bytes -> ...\DisplayXR\GaussianSplat\cache\292eda8892d66f2a8471479fe84d1a2b086d8d3a.spz
Queued 3DGS scene load: ...\292eda...spz
Scene loaded: 292eda...spz (3.9 MB)
Auto-fit vHeight 1.979 overridden by --vh=0.250
```
Window measured `(400,200) 932x788` — decorated, so the outer rect is the 900x700 client plus non-client, which is correct for a launch without `--transparent`.

**2b. Cache hit + `WM_COPYDATA` forward while the first instance runs — PASS**

Instance A (rect 400,200 900x700), then instance B with a *different* rect and vH:
```
B: Forwarded the URL to the running instance; exiting     (exit code 0)
A: WM_COPYDATA launch URL received (116 bytes)
A: WM_COPYDATA rect: requested (1200,300 700x700) -> final (1200,300 700x700)
A: WM_COPYDATA vh: 0.350 m
A: Downloaded 0 bytes (cache hit) -> ...\292eda...spz
A: Scene loaded: 292eda...spz (3.9 MB)
```
A's window measured at `(1200,300) 700x700` afterwards.

**3. Hostile `src` refused, no window — PASS** (all with `DXR_LAUNCH_QUIET=1`, exit code asserted)

```
CHECK3  file: refused           : PASS  exit=2 (expected 2)
CHECK3b off-loopback http       : PASS  exit=2 (expected 2)
CHECK3c future grammar v=2      : PASS  exit=2 (expected 2)
```
```
launch: src: file: URLs are not accepted from a protocol launch
DXR_LAUNCH_QUIET=1 - dialog suppressed: src: file: URLs are not accepted from a protocol launch
```
Without the env var the same launch shows the modal and exits 2 with no viewer window — confirmed separately before the flag existed.

**4. `type=model` forwarding — PASS**

```
CHECK4  type=model forwarded    : PASS  exit=0 (expected 0)
Forwarded type='model' to C:\Program Files\DisplayXR\Demos\ModelViewer\model_viewer_handle_vk_win.exe: ok
```
The forwarded `model_viewer_handle_vk_win.exe` really started (observed in the process list, then killed). The "not installed" branch (exit 3 + install message) was **not** exercised — the model viewer is installed on this box and I did not edit the machine's registry to fake its absence.

**5. Scheme ownership — as designed, not fought over**

```
"C:\...\displayxr-demo-modelviewer-wt-undock\build\windows\model_viewer_handle_vk_win.exe" "%1"
```
The parallel model-viewer session currently owns it. Our `EnsureViewProtocolRegistered` correctly left a live owner alone and logged `usable`.

**6. OS route — PASS, end to end across two viewers**

`Start-Process "displayxr-view://open?...&type=splat&v=1"` → OS → the model viewer (current scheme owner) → forwarded by `type=splat` via the `HKLM\...\Demos\GaussianSplat\InstallPath` breadcrumb → launched `C:\Program Files\DisplayXR\Demos\GaussianSplat\gaussian_splatting_handle_vk_win.exe`. Exactly the designed hand-off; note it lands on the *installed* build, not this branch's.

**7. Transparent + URL together — PASS**

```
exe --transparent --rect=300,300,800,800 --src=http://localhost:8731/butterfly.spz --no-cache
```
Window `(300,300) 800x800`, `WS_POPUP`/TOPMOST/NRB, and:
```
Toast layer submitted: rect=(0.200,0.840 0.600x0.075) of a 800x800 window
Downloaded 4049714 bytes -> ...\292eda...spz          (--no-cache forced a real fetch)
Scene loaded: 292eda...spz (3.9 MB)
```

No viewer or HTTP server was left running; `displayxr-service` was not touched.

## What a human has to eyeball on the panel

Two things this session cannot see, both under `exe --transparent --rect=300,300,800,800 "<butterfly.spz>"`:

1. **True 3D** — the splats must show real parallax on the panel, not a flat 2D image. A log line saying the mode is 3D is the runtime's *belief*, not the lens; only an eye can confirm the lens is actually on.
2. **Click-through outside the silhouette** — clicking the transparent area around the butterfly must reach whatever window is behind, while the butterfly itself stays on top and keeps taking input. The toast band is deliberately kept inside the region, so during a `--src` download the chip should be visible and clickable while the rest of the window is not.

## Notes

- `common/CMakeLists.txt` pins `displayxr-common` at `v2.9.0`.
- The `openxr_includes/openxr/XR_DXR_display_info.h` refresh (1 → 18) is purely additive; the version define had simply never been bumped after the `XR_EXT_*` → `XR_DXR_*` rename.
- `windows/sr_3dgs_openxr_ext_vk.manifest` already declared `PerMonitorV2`, so no manifest change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZS571NBBnZ2n9d8CXtJwz
