### PR TITLE
fix(spz): read SPZ v3/v4 (Niantic loader → upstream main) and never crash on a bad file

### DIFF
--- a/3dgs_common/CMakeLists.txt
+++ b/3dgs_common/CMakeLists.txt
@@ -34,62 +34,76 @@ else()
     set(SPZ_ZLIB_TARGET ZLIB::ZLIB)
 endif()
 
+# zstd — required since SPZ header version 4: the NGSP container stores each
+# attribute as its own ZSTD stream (load-spz.cc: decompressNgspStreams). Built
+# from source the same way spz is (SOURCE_SUBDIR _skip + our own add_library),
+# so it inherits this directory's CMAKE_MSVC_RUNTIME_LIBRARY (static CRT) and
+# needs none of zstd's own build options. Only common/ + compress/ +
+# decompress/ are needed; ZSTD_DISABLE_ASM keeps the x86-64 .S out (MSVC
+# cannot assemble it, and the C fallback is correct everywhere).
+find_package(zstd QUIET)
+if(TARGET zstd::libzstd_static)
+    # A system zstd is used only when it offers a STATIC target: the app links
+    # the static CRT and ships no side-by-side DLLs.
+    set(SPZ_ZSTD_TARGET zstd::libzstd_static)
+else()
+    message(STATUS "Static system zstd not found — fetching via FetchContent")
+    FetchContent_Declare(zstd
+        URL      https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz
+        URL_HASH SHA256=8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
+        SOURCE_SUBDIR _skip
+    )
+    FetchContent_MakeAvailable(zstd)
+    file(GLOB _ZSTD_SRCS
+        "${zstd_SOURCE_DIR}/lib/common/*.c"
+        "${zstd_SOURCE_DIR}/lib/compress/*.c"
+        "${zstd_SOURCE_DIR}/lib/decompress/*.c"
+    )
+    add_library(zstd_lib STATIC ${_ZSTD_SRCS})
+    target_include_directories(zstd_lib PUBLIC "${zstd_SOURCE_DIR}/lib")
+    target_compile_definitions(zstd_lib PRIVATE ZSTD_DISABLE_ASM=1 XXH_NAMESPACE=ZSTD_)
+    if(MSVC)
+        set_target_properties(zstd_lib PROPERTIES
+            MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+        )
+    endif()
+    set(SPZ_ZSTD_TARGET zstd_lib)
+endif()
+
+# Pinned to upstream main, NOT a tag: v4 (`LATEST_SPZ_HEADER_VERSION = 4`,
+# smallest-three quaternions from v3, ZSTD NGSP container from v4) landed after
+# v3.0.0. Files written by @playcanvas/splat-transform 3.3.3 are v4, and the
+# v1.1.0 loader this repo used to pin accepted versions 1–2 only — it returned
+# an empty cloud whose `convertCoordinates()` then did `numCoeffs / numPoints`
+# with numPoints == 0, i.e. the INT_DIVIDE_BY_ZERO (0xC0000094) crash. Keep this
+# SHA identical to android/src/main/cpp/CMakeLists.txt.
 FetchContent_Declare(spz
     GIT_REPOSITORY https://github.com/nianticlabs/spz.git
-    GIT_TAG        v1.1.0
+    GIT_TAG        affd0ecea7fbb4c265ee119475af7ee5b2997482
     SOURCE_SUBDIR  _skip
 )
 FetchContent_MakeAvailable(spz)
 
-# MSVC-compat patches for spz (see in-tree CMakeLists.txt for rationale).
-# SPZ upstream uses std::sort in splat-types.h without including <algorithm>.
-# libc++ (macOS/Clang) drags it in transitively, but libstdc++ (GCC/Linux)
-# does not, so the Linux build fails with "'sort' is not a member of 'std'"
-# (the MSVC block below already injects it for that toolchain). Inject it on
-# ALL compilers here; idempotent via the FIND guard so re-configures + the
-# MSVC block below stay no-ops.
-set(_SPZ_HEADER "${spz_SOURCE_DIR}/src/cc/splat-types.h")
-file(READ "${_SPZ_HEADER}" _spz_hdr)
-string(FIND "${_spz_hdr}" "#include <algorithm>" _spz_has_algo)
-if(_spz_has_algo EQUAL -1)
-    string(REPLACE "#include <cmath>" "#include <cmath>\n#include <algorithm>" _spz_hdr "${_spz_hdr}")
-    file(WRITE "${_SPZ_HEADER}" "${_spz_hdr}")
-endif()
-
-if(MSVC)
-    set(_SPZ_HEADER "${spz_SOURCE_DIR}/src/cc/splat-types.h")
-    file(READ "${_SPZ_HEADER}" _spz_content)
-    string(REPLACE "constexpr " "inline " _spz_content "${_spz_content}")
-    string(FIND "${_spz_content}" "_USE_MATH_DEFINES" _has_math_def)
-    if(_has_math_def EQUAL -1)
-        string(REPLACE "#include <cmath>" "#define _USE_MATH_DEFINES\n#include <cmath>\n#include <algorithm>" _spz_content "${_spz_content}")
-    endif()
-    file(WRITE "${_SPZ_HEADER}" "${_spz_content}")
-
-    set(_SPZ_SOURCE "${spz_SOURCE_DIR}/src/cc/splat-types.cc")
-    file(READ "${_SPZ_SOURCE}" _spz_src)
-    string(FIND "${_spz_src}" "#include <limits>" _spz_has_limits)
-    if(_spz_has_limits EQUAL -1)
-        string(REPLACE "#include <cmath>" "#include <cmath>\n#include <limits>" _spz_src "${_spz_src}")
-    endif()
-    string(REPLACE "0.0f / 0.0f" "std::numeric_limits<float>::quiet_NaN()" _spz_src "${_spz_src}")
-    string(REPLACE "0.0f/0.0f" "std::numeric_limits<float>::quiet_NaN()" _spz_src "${_spz_src}")
-    string(REPLACE "1.0f / 0.0f" "std::numeric_limits<float>::infinity()" _spz_src "${_spz_src}")
-    string(REPLACE "1.0f/0.0f" "std::numeric_limits<float>::infinity()" _spz_src "${_spz_src}")
-    file(WRITE "${_SPZ_SOURCE}" "${_spz_src}")
-endif()
-
+# No source patching any more: upstream now includes <algorithm> and <limits>
+# itself and no longer compile-time-divides by zero, so the historical
+# splat-types.{h,cc} rewrites are gone. `constexpr `→`inline ` in particular
+# MUST NOT come back — upstream has `inline constexpr` tables and a
+# `constexpr int SH_MAX_DEGREE` used as an array bound, both of which that
+# blanket replace would break. M_PI in splat-types.h is still MSVC-sensitive,
+# but upstream's splat-c-types.h now #defines _USE_MATH_DEFINES itself right
+# before <math.h>, so nothing is needed from us.
 add_library(spz_lib STATIC
     ${spz_SOURCE_DIR}/src/cc/load-spz.cc
     ${spz_SOURCE_DIR}/src/cc/splat-c-types.cc
     ${spz_SOURCE_DIR}/src/cc/splat-types.cc
 )
 target_include_directories(spz_lib PUBLIC ${spz_SOURCE_DIR}/src/cc)
-target_link_libraries(spz_lib PRIVATE ${SPZ_ZLIB_TARGET})
+target_link_libraries(spz_lib PRIVATE ${SPZ_ZLIB_TARGET} ${SPZ_ZSTD_TARGET})
 set_target_properties(spz_lib PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
 if(MSVC)
-    target_compile_definitions(spz_lib PUBLIC _USE_MATH_DEFINES)
-    target_compile_options(spz_lib PUBLIC /FIalgorithm)
+    # No _USE_MATH_DEFINES / /FIalgorithm here any more: upstream's
+    # splat-c-types.h defines the former itself (ours only produced a C4005
+    # redefinition warning in every TU) and splat-types.h includes <algorithm>.
     set_target_properties(spz_lib PROPERTIES
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
     )
@@ -168,3 +182,8 @@ target_link_libraries(gs_renderer PUBLIC
     Vulkan::Vulkan
     spz_lib
 )
+
+# gs_spz_loader.cpp peels the gzip wrapper itself before handing the payload to
+# spz (see the comment there), so it needs zlib directly — spz_lib links it
+# PRIVATE and therefore does not propagate it.
+target_link_libraries(gs_renderer PRIVATE ${SPZ_ZLIB_TARGET})

--- a/3dgs_common/gs_adreno_renderer.cpp
+++ b/3dgs_common/gs_adreno_renderer.cpp
@@ -226,13 +226,26 @@ bool GsAdrenoRenderer::init(VkInstance instance, VkPhysicalDevice physicalDevice
 bool GsAdrenoRenderer::loadScene(const char* scenePath) {
     if (!initialized_) { GS_LOGE("GsAdreno: not initialized"); return false; }
     cleanupScene();
+    lastLoadError_.clear();
 
     std::vector<GsVertex> verts;
     std::string path(scenePath);
     std::string ext = path.substr(path.find_last_of('.'));
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-    bool ok = (ext == ".spz") ? ParseSpzFile(path, verts) : ParsePlyFile(path, verts);
-    if (!ok || verts.empty()) { GS_LOGE("GsAdreno: parse failed: %s", scenePath); return false; }
+    bool ok;
+    if (ext == ".spz") {
+        SpzFileInfo info;
+        ok = ParseSpzFile(path, verts, &info);
+        if (!ok) lastLoadError_ = info.error;
+    } else {
+        ok = ParsePlyFile(path, verts);
+        if (!ok) lastLoadError_ = "not a readable PLY scene (corrupt or unsupported)";
+    }
+    if (!ok || verts.empty()) {
+        if (lastLoadError_.empty()) lastLoadError_ = "scene file contains no gaussians";
+        GS_LOGE("GsAdreno: parse failed: %s - %s", scenePath, lastLoadError_.c_str());
+        return false;
+    }
 
     // Load-time decimation: keep ~keepFrac_ of the gaussians, hash-selected for
     // a spatially-uniform thinning independent of file order. Every stage

--- a/3dgs_common/gs_adreno_renderer.h
+++ b/3dgs_common/gs_adreno_renderer.h
@@ -58,6 +58,12 @@ struct GsAdrenoRenderer {
 
     bool hasScene() const { return sceneLoaded_; }
     const std::string& scenePath() const { return loadedScenePath_; }
+
+    //! One-line reason the last loadScene() returned false (empty after a
+    //! success). Never a crash substitute for logging: the caller is expected
+    //! to surface this to the user, since a chrome-free transparent window has
+    //! no other way to say why nothing appeared.
+    const std::string& lastLoadError() const { return lastLoadError_; }
     uint32_t gaussianCount() const { return numGaussians_; }
 
     // Robust scene centroid + per-axis extent (outlier-trimmed): per axis takes
@@ -127,6 +133,7 @@ private:
     bool initialized_ = false;
     bool sceneLoaded_ = false;
     std::string loadedScenePath_;
+    std::string lastLoadError_;
     uint32_t numGaussians_ = 0;
 
     // Internal render scale (1.0 = full res). Default 0.6 on Android — the

--- a/3dgs_common/gs_renderer.cpp
+++ b/3dgs_common/gs_renderer.cpp
@@ -686,6 +686,7 @@ bool GsRenderer::loadScene(const char* plyPath)
 
     // Clean up previous scene if any
     cleanupScene();
+    lastLoadError_.clear();
 
     // Auto-detect format by extension and parse scene file
     std::vector<GsVertex> vertices;
@@ -693,15 +694,22 @@ bool GsRenderer::loadScene(const char* plyPath)
     std::string ext = scenePath.substr(scenePath.find_last_of('.'));
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
+    // A parse failure is a RETURN, never an exception and never a crash: an
+    // unsupported or corrupt file must leave the window up with a message.
     bool parseOk;
     if (ext == ".spz") {
-        parseOk = ParseSpzFile(scenePath, vertices);
+        SpzFileInfo info;
+        parseOk = ParseSpzFile(scenePath, vertices, &info);
+        if (!parseOk) lastLoadError_ = info.error;
     } else {
         parseOk = ParsePlyFile(scenePath, vertices);
+        if (!parseOk) lastLoadError_ = "not a readable PLY scene (corrupt or unsupported)";
     }
 
     if (!parseOk || vertices.empty()) {
-        fprintf(stderr, "GsRenderer: failed to parse scene file: %s\n", plyPath);
+        if (lastLoadError_.empty()) lastLoadError_ = "scene file contains no gaussians";
+        fprintf(stderr, "GsRenderer: failed to parse scene file: %s - %s\n",
+                plyPath, lastLoadError_.c_str());
         return false;
     }
 

--- a/3dgs_common/gs_renderer.h
+++ b/3dgs_common/gs_renderer.h
@@ -51,6 +51,12 @@ struct GsRenderer {
     // Returns the loaded scene file path.
     const std::string& scenePath() const;
 
+    //! One-line reason the last loadScene() returned false (empty after a
+    //! success). Never a crash substitute for logging: the caller is expected
+    //! to surface this to the user, since a chrome-free transparent window has
+    //! no other way to say why nothing appeared.
+    const std::string& lastLoadError() const { return lastLoadError_; }
+
     // Returns the number of Gaussians in the loaded scene.
     uint32_t gaussianCount() const;
 
@@ -209,6 +215,7 @@ private:
     bool initialized_ = false;
     bool sceneLoaded_ = false;
     std::string loadedScenePath_;
+    std::string lastLoadError_;
     uint32_t numGaussians_ = 0;
 
     // ── Derived dimensions ───────────────────────────────────────────────

--- a/3dgs_common/gs_spz_loader.cpp
+++ b/3dgs_common/gs_spz_loader.cpp
@@ -6,6 +6,27 @@
  *
  * Uses the Niantic spz library to decompress .spz files into GaussianCloud,
  * then converts to our GPU vertex format (GsVertex, 240 bytes per splat).
+ *
+ * Container shapes this has to cope with (all four are ".spz"):
+ *
+ *   1. gzip( legacy 16-byte header + one raw stream )   — SPZ v1…v3, e.g. the
+ *      bundled butterfly.spz (v2). This is what `spz::loadSpzPacked` calls the
+ *      "legacy single-stream GZip format" and handles directly.
+ *   2. raw NGSP 32-byte header + N ZSTD streams          — SPZ v4 as upstream
+ *      writes it. `spz::loadSpzPacked` dispatches on the leading NGSP magic.
+ *   3. gzip( NGSP 32-byte header + N ZSTD streams )      — SPZ v4 as
+ *      @playcanvas/splat-transform 3.3.3 writes it (the storefront's
+ *      undocked gen/*.spz). Upstream does NOT re-dispatch after gunzip: it
+ *      sees the gzip magic, inflates, then parses the result with the LEGACY
+ *      16-byte header and fails on the size check. So we peel the gzip
+ *      ourselves and hand the inner NGSP buffer to spz.
+ *   4. anything else                                     — rejected, loudly.
+ *
+ * Note the asymmetry in 1 vs 3: for a legacy file we must pass the ORIGINAL
+ * gzip bytes (the inner legacy header also starts with NGSP magic, so handing
+ * spz the inflated buffer would send it down the NGSP path and it would reject
+ * the version as < 4). Hence the "gunzip, look, then choose which buffer to
+ * pass" shape below.
  */
 
 #include "gs_spz_loader.h"
@@ -13,42 +34,215 @@
 #include <load-spz.h>
 #include <splat-types.h>
 
+#include <zlib.h>
+
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <exception>
+#include <vector>
 
-static float spz_sigmoid(float x) {
+namespace {
+
+//! 'NGSP' — leads BOTH the legacy 16-byte header and the v4 NGSP one.
+constexpr uint32_t kNgspMagic = 0x5053474eu;
+//! Smallest container that can carry a readable version field.
+constexpr size_t kMinHeaderBytes = 16;
+//! Refuse absurd inputs before allocating; 2 GB is far past any real scene.
+//! uint64_t, not size_t: a 32-bit ABI (armeabi-v7a) would wrap the constant.
+constexpr uint64_t kMaxFileBytes = 2ull * 1024 * 1024 * 1024;
+//! Same ceiling for the inflated payload — a zip bomb must not OOM the viewer.
+constexpr uint64_t kMaxInflatedBytes = 2ull * 1024 * 1024 * 1024;
+
+float spz_sigmoid(float x) {
     return 1.0f / (1.0f + std::exp(-x));
 }
 
-bool ParseSpzFile(const std::string& path, std::vector<GsVertex>& vertices)
+//! SH floats per point beyond the DC term (which lives in cloud.colors).
+//! Mirrors the table in spz's GaussianCloud docs; degree 4 (72) exists upstream
+//! but our GsVertex only has room for degrees 1–3, so the copy below clamps.
+int ShFloatsPerPoint(int shDegree) {
+    switch (shDegree) {
+        case 1:  return 9;   //  3 coeffs * 3 channels
+        case 2:  return 24;  //  8 coeffs * 3 channels
+        case 3:  return 45;  // 15 coeffs * 3 channels
+        case 4:  return 72;  // 24 coeffs * 3 channels
+        default: return 0;
+    }
+}
+
+bool ReadWholeFile(const std::string& path, std::vector<uint8_t>& out) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return false; }
+    const long len = ftell(f);
+    if (len < 0 || (uint64_t)len > kMaxFileBytes) { fclose(f); return false; }
+    if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return false; }
+    out.resize((size_t)len);
+    const size_t got = out.empty() ? 0 : fread(out.data(), 1, out.size(), f);
+    fclose(f);
+    if (got != out.size()) { out.clear(); return false; }
+    return true;
+}
+
+//! Inflate a gzip member. windowBits 15|16 = "gzip wrapper only" (the same
+//! setting spz uses internally). Returns false on any inflate error, including
+//! a truncated stream — a partial payload is never handed on as if it were
+//! whole.
+bool GunzipBuffer(const uint8_t* data, size_t size, std::vector<uint8_t>& out) {
+    out.clear();
+    if (size == 0) return false;
+
+    z_stream zs = {};
+    zs.next_in = const_cast<Bytef*>(data);
+    zs.avail_in = (uInt)size;
+    if (inflateInit2(&zs, 15 + 16) != Z_OK) return false;
+
+    std::vector<uint8_t> chunk(64 * 1024);
+    bool ok = false;
+    for (;;) {
+        zs.next_out = chunk.data();
+        zs.avail_out = (uInt)chunk.size();
+        const int rc = inflate(&zs, Z_NO_FLUSH);
+        if (rc != Z_OK && rc != Z_STREAM_END) break;
+        const size_t produced = chunk.size() - zs.avail_out;
+        if ((uint64_t)out.size() + produced > kMaxInflatedBytes) break;
+        out.insert(out.end(), chunk.data(), chunk.data() + produced);
+        if (rc == Z_STREAM_END) { ok = true; break; }
+        if (produced == 0 && zs.avail_in == 0) break;  // truncated input
+    }
+    inflateEnd(&zs);
+    if (!ok) out.clear();
+    return ok;
+}
+
+//! Read magic + version + numPoints + shDegree out of an SPZ header. Works for
+//! both header shapes: magic@0, version@4, numPoints@8, shDegree@12.
+bool PeekSpzHeader(const uint8_t* data, size_t size,
+                   uint32_t* version, uint32_t* numPoints, uint32_t* shDegree) {
+    if (size < kMinHeaderBytes) return false;
+    uint32_t magic = 0;
+    std::memcpy(&magic, data, sizeof(magic));
+    if (magic != kNgspMagic) return false;
+    std::memcpy(version, data + 4, sizeof(uint32_t));
+    std::memcpy(numPoints, data + 8, sizeof(uint32_t));
+    *shDegree = data[12];
+    return true;
+}
+
+}  // namespace
+
+bool ParseSpzFile(const std::string& path, std::vector<GsVertex>& vertices, SpzFileInfo* info)
 {
     vertices.clear();
+    SpzFileInfo local;
+    SpzFileInfo& fi = info ? *info : local;
+    fi = SpzFileInfo{};
+
+    std::vector<uint8_t> file;
+    if (!ReadWholeFile(path, file) || file.size() < kMinHeaderBytes) {
+        fi.error = "cannot read file (missing, empty or truncated)";
+        fprintf(stderr, "ParseSpzFile: %s — %s\n", path.c_str(), fi.error.c_str());
+        return false;
+    }
+
+    // Pick the buffer to hand to spz (see the file header comment for the four
+    // container shapes). Default: the file exactly as it sits on disk.
+    const uint8_t* payload = file.data();
+    size_t payloadSize = file.size();
+    std::vector<uint8_t> inflated;
+
+    uint32_t version = 0, headerPoints = 0, headerShDegree = 0;
+    const bool isGzip = file[0] == 0x1f && file[1] == 0x8b;
+    if (isGzip) {
+        if (!GunzipBuffer(file.data(), file.size(), inflated)) {
+            fi.error = "gzip container is corrupt or truncated";
+            fprintf(stderr, "ParseSpzFile: %s — %s\n", path.c_str(), fi.error.c_str());
+            return false;
+        }
+        if (PeekSpzHeader(inflated.data(), inflated.size(), &version, &headerPoints,
+                          &headerShDegree) &&
+            version >= 4) {
+            // Shape 3: gzip-wrapped NGSP. Feed spz the INNER buffer so its
+            // magic dispatch takes the NGSP/ZSTD path.
+            payload = inflated.data();
+            payloadSize = inflated.size();
+        }
+        // Shape 1 (legacy v1–v3): leave payload pointing at the gzip bytes.
+    } else {
+        PeekSpzHeader(file.data(), file.size(), &version, &headerPoints, &headerShDegree);
+    }
+    fi.version = (int)version;
+    fi.numPoints = (int)headerPoints;
+    fi.shDegree = (int)headerShDegree;
 
     // EXPERIMENT: was RDF (Y-down, Z-forward = COLMAP/gsplat-trainer PLY convention).
     // Trying RUB (Y-up, Z-back = OpenGL / OpenXR / SPZ-native) to see if the
     // scene matches SuperSplat's orientation without needing a 180° yaw fix.
-    spz::UnpackOptions options;
-    options.to = spz::CoordinateSystem::RUB;
-    spz::GaussianCloud cloud = spz::loadSpz(path, options);
-
-    if (cloud.numPoints <= 0) {
-        fprintf(stderr, "ParseSpzFile: failed to load %s (0 points)\n", path.c_str());
+    spz::GaussianCloud cloud;
+    try {
+        spz::UnpackOptions options;
+        options.to = spz::CoordinateSystem::RUB;
+        cloud = spz::loadSpz(payload, payloadSize, options);
+    } catch (const std::exception& e) {
+        fi.error = std::string("spz loader threw: ") + e.what();
+        fprintf(stderr, "ParseSpzFile: %s — %s\n", path.c_str(), fi.error.c_str());
+        return false;
+    } catch (...) {
+        fi.error = "spz loader threw an unknown exception";
+        fprintf(stderr, "ParseSpzFile: %s — %s\n", path.c_str(), fi.error.c_str());
         return false;
     }
 
-    uint32_t numPoints = (uint32_t)cloud.numPoints;
-    printf("ParseSpzFile: loading %u gaussians from %s (shDegree=%d)\n",
-           numPoints, path.c_str(), cloud.shDegree);
+    if (cloud.numPoints <= 0) {
+        // Every rejection upstream can make — unsupported version, bad point
+        // count, ZSTD/gzip failure, size mismatch — arrives here as an empty
+        // cloud. Name the version so the log says WHICH file shape was refused.
+        if (fi.version == 0) {
+            fi.error = "not an SPZ container (bad magic or unreadable header)";
+        } else if (fi.version > 4) {
+            fi.error = "unsupported SPZ v" + std::to_string(fi.version) +
+                       " (this build reads v1-v4)";
+        } else {
+            fi.error = "SPZ v" + std::to_string(fi.version) +
+                       " file rejected by the loader (corrupt or truncated)";
+        }
+        fprintf(stderr, "ParseSpzFile: %s — %s\n", path.c_str(), fi.error.c_str());
+        return false;
+    }
 
-    // SH floats per point (beyond DC, which is stored in cloud.colors)
-    int shPerPoint = 0;
-    switch (cloud.shDegree) {
-        case 1: shPerPoint = 9; break;   // 3 coeffs * 3 channels
-        case 2: shPerPoint = 24; break;  // 8 coeffs * 3 channels
-        case 3: shPerPoint = 45; break;  // 15 coeffs * 3 channels
-        default: shPerPoint = 0; break;
+    const uint32_t numPoints = (uint32_t)cloud.numPoints;
+    fi.numPoints = (int)numPoints;
+    fi.shDegree = cloud.shDegree;
+
+    // The vertex loop below indexes six parallel arrays by numPoints. spz sizes
+    // them itself and checkSizes() enforces it, but this is the arithmetic that
+    // a malformed file used to reach — assert it here rather than trust it.
+    const size_t n = (size_t)numPoints;
+    if (cloud.positions.size() < n * 3 || cloud.scales.size() < n * 3 ||
+        cloud.rotations.size() < n * 4 || cloud.alphas.size() < n ||
+        cloud.colors.size() < n * 3) {
+        fi.error = "SPZ v" + std::to_string(fi.version) +
+                   " attribute arrays are short for " + std::to_string(numPoints) +
+                   " gaussians";
+        fprintf(stderr, "ParseSpzFile: %s — %s\n", path.c_str(), fi.error.c_str());
+        return false;
+    }
+
+    printf("ParseSpzFile: loading %u gaussians from %s (spzVersion=%d, shDegree=%d)\n",
+           numPoints, path.c_str(), fi.version, cloud.shDegree);
+
+    // SH floats per point (beyond DC, which is stored in cloud.colors). Degree 4
+    // is accepted but only its first 45 floats (bands 1–3) fit GsVertex; the
+    // layout is coefficient-outer/channel-inner in increasing band order, so the
+    // prefix is exactly bands 1–3 and the truncation is well defined.
+    int shPerPoint = ShFloatsPerPoint(cloud.shDegree);
+    if (shPerPoint > 0 && cloud.sh.size() < n * (size_t)shPerPoint) {
+        fprintf(stderr, "ParseSpzFile: %s — SH array short for degree %d, dropping SH\n",
+                path.c_str(), cloud.shDegree);
+        shPerPoint = 0;
     }
 
     vertices.resize(numPoints);
@@ -93,7 +287,7 @@ bool ParseSpzFile(const std::string& path, std::vector<GsVertex>& vertices)
         // Our GPU layout sh[3..47] is identical: [R_1, G_1, B_1, R_2, G_2, B_2, ...]
         if (shPerPoint > 0) {
             int floatsToCopy = std::min(shPerPoint, 45);
-            std::memcpy(&v.sh[3], &cloud.sh[i * shPerPoint],
+            std::memcpy(&v.sh[3], &cloud.sh[(size_t)i * (size_t)shPerPoint],
                         floatsToCopy * sizeof(float));
             // Zero-fill remaining coefficients if shDegree < 3
             for (int j = 3 + floatsToCopy; j < 48; j++) {

--- a/3dgs_common/gs_spz_loader.h
+++ b/3dgs_common/gs_spz_loader.h
@@ -11,9 +11,27 @@
 #include <vector>
 #include "gs_scene_loader.h"  // for GsVertex
 
+//! What the loader learned about the file, whether or not it loaded.
+//!
+//! `version` is read straight out of the SPZ container header (both the legacy
+//! gzip-wrapped 16-byte header and the v4 NGSP one put it at byte offset 4), so
+//! a rejected file can still be NAMED in the log — "unsupported SPZ v9" beats
+//! "load failed". 0 means the file is not an SPZ container at all (wrong magic,
+//! truncated below a header, or not decompressible).
+struct SpzFileInfo {
+    int         version   = 0;  //!< SPZ header version, 0 = unknown / not an SPZ container
+    int         numPoints = 0;  //!< gaussians the header claims (0 when unknown)
+    int         shDegree  = 0;  //!< spherical-harmonics degree the header claims
+    std::string error;          //!< one-line failure reason, empty on success
+};
+
 // Parse a Niantic SPZ file and return GPU-ready vertices.
 // Converts from SPZ's RUB coordinate system to PLY's RDF convention.
 // Applies: sigmoid(opacity), exp(scale), normalize(rotation), SH mapping.
-// Returns true on success. On failure, vertices is empty.
+// Returns true on success. On failure, vertices is empty and, when `info` is
+// non-null, info->error carries a one-line reason naming the SPZ version.
+// NEVER throws and never divides by a header-supplied count: a corrupt or
+// unsupported file is a return value, not a crash.
 bool ParseSpzFile(const std::string& path,
-                  std::vector<GsVertex>& vertices);
+                  std::vector<GsVertex>& vertices,
+                  SpzFileInfo* info = nullptr);

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -22,9 +22,31 @@ set(GS_COMMON "${REPO_ROOT}/3dgs_common")
 
 # ── Niantic SPZ format support (FetchContent; zlib comes from the NDK) ────
 include(FetchContent)
+
+# zstd — required since SPZ header version 4 (the NGSP container stores each
+# attribute as its own ZSTD stream). The NDK sysroot ships zlib but NOT zstd,
+# so it is built from source here, exactly as the desktop leg does in
+# 3dgs_common/CMakeLists.txt. Plain C, no platform assumptions —
+# ZSTD_DISABLE_ASM drops the x86-64 .S so every ABI (arm64-v8a included) uses
+# the C decoder.
+FetchContent_Declare(zstd
+    URL      https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz
+    URL_HASH SHA256=8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
+    SOURCE_SUBDIR _skip)
+FetchContent_MakeAvailable(zstd)
+file(GLOB _ZSTD_SRCS
+    "${zstd_SOURCE_DIR}/lib/common/*.c"
+    "${zstd_SOURCE_DIR}/lib/compress/*.c"
+    "${zstd_SOURCE_DIR}/lib/decompress/*.c")
+add_library(zstd_lib STATIC ${_ZSTD_SRCS})
+target_include_directories(zstd_lib PUBLIC "${zstd_SOURCE_DIR}/lib")
+target_compile_definitions(zstd_lib PRIVATE ZSTD_DISABLE_ASM=1 XXH_NAMESPACE=ZSTD_)
+
+# Pinned to upstream main, NOT a tag — v4 landed after v3.0.0. Keep this SHA
+# identical to 3dgs_common/CMakeLists.txt.
 FetchContent_Declare(spz
     GIT_REPOSITORY https://github.com/nianticlabs/spz.git
-    GIT_TAG        v1.1.0
+    GIT_TAG        affd0ecea7fbb4c265ee119475af7ee5b2997482
     SOURCE_SUBDIR  _skip)
 FetchContent_MakeAvailable(spz)
 
@@ -33,7 +55,7 @@ add_library(spz_lib STATIC
     ${spz_SOURCE_DIR}/src/cc/splat-c-types.cc
     ${spz_SOURCE_DIR}/src/cc/splat-types.cc)
 target_include_directories(spz_lib PUBLIC ${spz_SOURCE_DIR}/src/cc)
-target_link_libraries(spz_lib PRIVATE z)    # NDK sysroot zlib
+target_link_libraries(spz_lib PRIVATE z zstd_lib)    # NDK sysroot zlib + fetched zstd
 
 # ── 3DGS compute shaders → SPIR-V header arrays ───────────────────────────
 # Compiled from the SHARED 3dgs_common/shaders. var name = <name>_comp_data,
@@ -95,6 +117,7 @@ set_target_properties(gausssplat_vk_android PROPERTIES
 target_link_libraries(gausssplat_vk_android
     native_app_glue
     spz_lib
+    z                                           # gs_spz_loader peels gzip itself
     OpenXR::openxr_loader
     vulkan
     android

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -634,7 +634,9 @@ std::string HandleAgentToolCall(XrSessionManager& xr, const std::string& toolNam
             std::lock_guard<std::mutex> lock(g_sceneMutex);
             if (!g_gsRenderer.loadScene(path.c_str())) {
                 ok = false;
-                result = "{\"error\":\"failed to load '" + JsonEscape(path) + "' (corrupt or unsupported)\"}";
+                const std::string why = g_gsRenderer.lastLoadError();
+                result = "{\"error\":\"failed to load '" + JsonEscape(path) + "' (" +
+                         JsonEscape(why.empty() ? std::string("corrupt or unsupported") : why) + ")\"}";
             } else {
                 g_loadedFileName = GetPlyFilename(path);
                 ApplyAutoFitForLoadedScene_locked();
@@ -870,11 +872,16 @@ static bool LoadSceneAtStartup(const std::string& path, const char* why) {
     std::lock_guard<std::mutex> lock(g_sceneMutex);
     if (g_gsRenderer.loadScene(path.c_str())) {
         g_loadedFileName = GetPlyFilename(path);
-        LOG_INFO("Loaded %s (%s)", g_loadedFileName.c_str(), GetPlyFileSize(path).c_str());
+        LOG_INFO("Loaded %s (%s, %u gaussians)", g_loadedFileName.c_str(),
+                 GetPlyFileSize(path).c_str(), g_gsRenderer.gaussianCount());
         ApplyAutoFitForLoadedScene_locked();
         return true;
     }
-    LOG_WARN("%s: load failed for %s", why, path.c_str());
+    const std::string reason = g_gsRenderer.lastLoadError();
+    LOG_WARN("%s: load failed for %s - %s", why, path.c_str(),
+             reason.empty() ? "corrupt or unsupported" : reason.c_str());
+    ToastF("Can't open %s - %s", GetPlyFilename(path).c_str(),
+           reason.empty() ? "corrupt or unsupported" : reason.c_str());
     return false;
 }
 
@@ -1614,13 +1621,27 @@ static void RenderThreadFunc(
                 std::lock_guard<std::mutex> lock(g_sceneMutex);
                 if (g_gsRenderer.loadScene(path.c_str())) {
                     g_loadedFileName = GetPlyFilename(path);
-                    LOG_INFO("Scene loaded: %s (%s)", g_loadedFileName.c_str(),
-                        GetPlyFileSize(path).c_str());
+                    LOG_INFO("Scene loaded: %s (%s, %u gaussians)", g_loadedFileName.c_str(),
+                        GetPlyFileSize(path).c_str(), g_gsRenderer.gaussianCount());
                     ApplyAutoFitForLoadedScene_locked();
                 } else {
-                    LOG_ERROR("Failed to load scene: %s", path.c_str());
-                    MessageBoxA(hwnd, "Failed to load scene file.\nThe file may be corrupt or unsupported.",
-                        "Load Error", MB_OK | MB_ICONERROR);
+                    // The window STAYS UP. A bad file is a message, not an
+                    // exit and not a crash — in transparent mode the toast is
+                    // the only chrome there is, so it carries the reason
+                    // (which names the SPZ version for an .spz).
+                    const std::string why = g_gsRenderer.lastLoadError();
+                    LOG_ERROR("Failed to load scene: %s - %s", path.c_str(),
+                              why.empty() ? "corrupt or unsupported" : why.c_str());
+                    ToastF("Can't open %s - %s", GetPlyFilename(path).c_str(),
+                           why.empty() ? "corrupt or unsupported" : why.c_str());
+                    // A modal box would freeze the render thread (it IS this
+                    // thread) and is invisible-by-design in transparent mode.
+                    if (!g_transparentBg.load() && !LaunchQuiet()) {
+                        MessageBoxA(hwnd, ("Failed to load scene file.\n" +
+                                           (why.empty() ? std::string("The file may be corrupt or unsupported.")
+                                                        : why)).c_str(),
+                            "Load Error", MB_OK | MB_ICONERROR);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## The bug

The storefront undocks its splats as `.spz` written by `@playcanvas/splat-transform` 3.3.3 — **SPZ header version 4**. This repo pinned `nianticlabs/spz` **v1.1.0**, whose loader accepts versions **1–2 only**, so opening one crashed the viewer outright:

```
[INFO]  Loading 3DGS scene: ...\handbag_gen.spz
[ERROR] !!! UNHANDLED EXCEPTION: INT_DIVIDE_BY_ZERO (0xC0000094) at address 0x00007FF7D12F9B73 !!!
```

That is the maintainer's "black canvas for a while then disappears".

**Where the divide was.** `deserializePackedGaussians` rejects the unknown version and returns `{}`; `unpackGaussians` then calls `convertCoordinates()` **unconditionally** on that empty cloud, and v1.1.0's `GaussianCloud::convertCoordinates` opens with

```cpp
const size_t numCoeffs         = sh.size() / 3;          // 0
const size_t numCoeffsPerPoint = numCoeffs / numPoints;  // 0 / 0  → 0xC0000094
```

So it was inside spz, not in `ParseSpzFile` (which does guard `numPoints <= 0`) and not in `GsRenderer::loadScene`.

## What changed

**1. spz → upstream `main`, pinned by SHA `affd0ecea7fbb4c265ee119475af7ee5b2997482`** (2026-08-05), in **both** CMake files (desktop + Android). Not a tag: the v4 work (`LATEST_SPZ_HEADER_VERSION = 4`, `MIN_SMALLEST_THREE_QUATERNIONS_VERSION = 3`, `MIN_ZSTD_SPZ_HEADER_VERSION = 4`) landed after `v3.0.0`. Upstream also guards `numPoints == 0` now, so the divide is gone at the root as well as being unreachable.

**2. zstd is a new dependency** — v4 stores each attribute as its own ZSTD stream inside the NGSP container. Provided by FetchContent the same way spz is (`SOURCE_SUBDIR _skip` + our own `add_library` over `lib/{common,compress,decompress}/*.c`, zstd 1.5.6 release tarball, SHA256-pinned). That keeps it on this directory's static MSVC CRT and needs none of zstd's own build options. `ZSTD_DISABLE_ASM=1` drops the x86-64 `.S`, so MSVC and every Android ABI use the C decoder. **Android is not gated** — the NDK sysroot ships zlib but no zstd, so the same three source dirs are built there; it is plain C and arm64-v8a needs nothing special.

**3. The gzip-wrapped-NGSP dispatch (`gs_spz_loader.cpp`).** `spz::loadSpzPacked` switches on the **first four bytes**: NGSP magic → v4/ZSTD path, gzip magic → legacy pre-v4 path — and does **not** re-dispatch after inflating. The storefront's files are `gzip( NGSP v4 + ZSTD streams )`, so upstream alone still fails them (it parses the inflated NGSP header as the legacy 16-byte one and trips the size check). The loader now peels the gzip itself and hands spz the **inner** buffer when it is NGSP v4. The asymmetry is load-bearing and commented: a legacy v1–v3 file must still be passed as the **original gzip bytes**, because its inflated legacy header *also* starts with NGSP magic and would be sent down the v4 path and rejected as `version < 4`.

**4. The loader is total.** `ParseSpzFile` reads the file itself (bounded), never divides by a header-supplied count, catches anything spz throws, and verifies every attribute array is long enough for `numPoints` before the vertex loop indexes it. Failure is a return value carrying a one-line reason that **names the SPZ version**. `shDegree 4` is accepted too (72 SH floats, truncated to the 45 that fit `GsVertex` — the layout is band-ordered, so the prefix is exactly bands 1–3).

**5. A bad file is a toast, not a crash and not a modal box.** `GsRenderer` / `GsAdrenoRenderer` keep `lastLoadError()`; the Windows viewer surfaces it in the app log, on the toast chip (the only chrome a transparent window has, #833 — reusing the `--src` fetch-failure path), and in the MCP `load_splat` error payload. `MessageBoxA` now fires only for an opaque, non-`DXR_LAUNCH_QUIET` launch — on the render thread it would freeze rendering, and in transparent mode it is invisible by design. Successful loads log the gaussian count.

## Verification (Leia SR box, Windows, local build)

| Check | Result |
|---|---|
| `handbag_gen.spz` (v4, gzip-NGSP) | `Loaded handbag_gen.spz (1.7 MB, 131072 gaussians)` — matches the header's `n=131072` |
| `boot_gen.spz` | `Loaded boot_gen.spz (1.7 MB, 131072 gaussians)` |
| `tote_gen.spz` | `Loaded tote_gen.spz (1.6 MB, 131072 gaussians)` |
| `courtsneaker_gen.spz` | `Loaded courtsneaker_gen.spz (1.6 MB, 131072 gaussians)` |
| bundled `butterfly.spz` (v2, legacy gzip) | `Loaded butterfly.spz (3.9 MB, 177132 gaussians)` — no regression |
| first 1000 bytes of `handbag_gen.spz` | `[WARN] ... load failed for ...truncated.spz - gzip container is corrupt or truncated`; **no exception, process still alive** |
| header rewritten to version 9 | `[WARN] ... load failed for ...v9.spz - unsupported SPZ v9 (this build reads v1-v4)`; **no exception, process still alive** |
| protocol path (`displayxr-view://open?src=http%3A%2F%2Flocalhost%3A8123%2F...`, the exact crash repro) | `Scene loaded: ...spz (1.7 MB, 131072 gaussians)` — the run that used to die at `0xC0000094` |

Pixels: `xrCaptureAtlasDXR` (the `I` key) on the loaded handbag renders both views of the 2×1 atlas correctly, and butterfly likewise.

**Not verified here:** macOS / Linux / Android builds (left to CI — none of them has a local toolchain on this box), and no on-panel 3D eyeball.

Fixes the storefront undock path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZS571NBBnZ2n9d8CXtJwz
