### PR TITLE
fix(spz): honour the header's coordinate system (v3/v4 files loaded upside down)

### DIFF
--- a/3dgs_common/gs_spz_loader.cpp
+++ b/3dgs_common/gs_spz_loader.cpp
@@ -27,6 +27,40 @@
  * spz the inflated buffer would send it down the NGSP path and it would reject
  * the version as < 4). Hence the "gunzip, look, then choose which buffer to
  * pass" shape below.
+ *
+ * ── Coordinate systems ──────────────────────────────────────────────────────
+ *
+ * THE SPZ CONTAINER DOES NOT RECORD ITS COORDINATE SYSTEM. Neither header
+ * carries the field: in the 32-byte `NgspFileHeader` the byte at offset 15 —
+ * the one a legacy 16-byte read shows as "reserved" — is `numStreams` (5 for a
+ * degree-0 file: positions, alphas, colors, scales, rotations). Upstream's only
+ * coordinate metadata is an optional *extension* block gated behind
+ * `SPZ_BUILD_EXTENSIONS`, which is compiled out here (and whose header isn't
+ * even in the tree at our pinned rev); the storefront's files carry
+ * `flags = 0`, i.e. no extensions. So the source system is a POLICY CHOICE the
+ * loader has to make, not something it can read.
+ *
+ * Upstream picks one unconditionally — `unpackGaussians()` ends in
+ * `convertCoordinates(CoordinateSystem::RUB, o.to)`, i.e. "the bytes are RUB".
+ * That is right for files the Niantic writer produced (v1-v3 in practice) and
+ * WRONG for every v4 file in the wild, because the only v4 writer anyone uses,
+ * `@playcanvas/splat-transform`, bakes the cloud into PLY space
+ * (`Transform.PLY`) and then calls `saveSpz` with `from = UNSPECIFIED` — an
+ * identity converter — so the on-disk bytes are RDF, not RUB. Its own source
+ * says so: "splat-transform stores SPZ with no coordinate conversion: data is
+ * baked to PLY/RDF space before saving … the format carries no coordinate
+ * metadata". Asking spz for `to = RUB` then applies RUB->RUB (nothing) and the
+ * scene renders upside down (RDF vs RUB differ by 180 deg about X).
+ *
+ * Hence `SpzSourceSystem()` below: legacy containers (v1-v3) are RUB, NGSP
+ * containers (v4+) are RDF. That is the generation split between the two
+ * writers, and it reproduces what the web viewers show — the storefront's
+ * Spark page loads the SAME cloud as `.sog` (splat-transform bakes `.sog` to
+ * `Transform.PLY` too) and rights it with `mesh.quaternion.set(1,0,0,0)`, a
+ * 180 deg rotation about X, which is exactly RDF -> RUB.
+ *
+ * `DXR_SPZ_COORD_SYSTEM=rub|rdf` overrides the choice for a file that breaks
+ * the rule (a raw-NGSP v4 straight out of Niantic's own writer would be RUB).
  */
 
 #include "gs_spz_loader.h"
@@ -38,6 +72,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
@@ -132,6 +167,33 @@ bool PeekSpzHeader(const uint8_t* data, size_t size,
     return true;
 }
 
+//! Printable name for the systems this loader can pick between.
+const char* CoordSystemName(spz::CoordinateSystem cs) {
+    switch (cs) {
+        case spz::CoordinateSystem::RUB: return "RUB (+X right, +Y up, +Z back)";
+        case spz::CoordinateSystem::RDF: return "RDF (+X right, +Y down, +Z front)";
+        default:                         return "UNSPECIFIED";
+    }
+}
+
+//! Which coordinate system the on-disk bytes are in. See the coordinate-systems
+//! section of the file header comment — the container never says, so this is the
+//! loader's policy: legacy containers come from Niantic's writer (RUB), NGSP
+//! containers come from @playcanvas/splat-transform (RDF/PLY space).
+//!
+//! `DXR_SPZ_COORD_SYSTEM=rub|rdf` overrides it for a file that breaks the rule.
+spz::CoordinateSystem SpzSourceSystem(uint32_t version) {
+    if (const char* env = std::getenv("DXR_SPZ_COORD_SYSTEM")) {
+        if (env[0] == 'r' || env[0] == 'R') {
+            if (env[1] == 'u' || env[1] == 'U') return spz::CoordinateSystem::RUB;
+            if (env[1] == 'd' || env[1] == 'D') return spz::CoordinateSystem::RDF;
+        }
+        fprintf(stderr, "ParseSpzFile: ignoring DXR_SPZ_COORD_SYSTEM='%s' (expected rub or rdf)\n",
+                env);
+    }
+    return version >= 4 ? spz::CoordinateSystem::RDF : spz::CoordinateSystem::RUB;
+}
+
 }  // namespace
 
 bool ParseSpzFile(const std::string& path, std::vector<GsVertex>& vertices, SpzFileInfo* info)
@@ -178,13 +240,14 @@ bool ParseSpzFile(const std::string& path, std::vector<GsVertex>& vertices, SpzF
     fi.numPoints = (int)headerPoints;
     fi.shDegree = (int)headerShDegree;
 
-    // EXPERIMENT: was RDF (Y-down, Z-forward = COLMAP/gsplat-trainer PLY convention).
-    // Trying RUB (Y-up, Z-back = OpenGL / OpenXR / SPZ-native) to see if the
-    // scene matches SuperSplat's orientation without needing a 180° yaw fix.
+    // Ask spz for its own storage convention (RUB) and do NOT let it convert:
+    // `unpackGaussians` would convert FROM an assumed RUB, and for a v4 file
+    // that assumption is the bug. The real source system is decided below and
+    // applied explicitly, so the conversion reads the way it means.
     spz::GaussianCloud cloud;
     try {
         spz::UnpackOptions options;
-        options.to = spz::CoordinateSystem::RUB;
+        options.to = spz::CoordinateSystem::RUB;  // RUB -> RUB, a no-op
         cloud = spz::loadSpz(payload, payloadSize, options);
     } catch (const std::exception& e) {
         fi.error = std::string("spz loader threw: ") + e.what();
@@ -231,8 +294,24 @@ bool ParseSpzFile(const std::string& path, std::vector<GsVertex>& vertices, SpzF
         return false;
     }
 
-    printf("ParseSpzFile: loading %u gaussians from %s (spzVersion=%d, shDegree=%d)\n",
-           numPoints, path.c_str(), fi.version, cloud.shDegree);
+    // The container never declares its coordinate system (see the file header
+    // comment), so name the one we assumed — a scene that comes out upside down
+    // is then one grep away from its cause, and DXR_SPZ_COORD_SYSTEM is the fix.
+    // Convert here, once per load, on the whole cloud: spz's own converter also
+    // handles the rotations, scales and SH bands, which a hand-rolled position
+    // flip in the vertex loop below would silently get wrong.
+    const spz::CoordinateSystem sourceSystem = SpzSourceSystem(version);
+    fi.sourceSystem = CoordSystemName(sourceSystem);
+    if (sourceSystem != spz::CoordinateSystem::RUB) {
+        cloud.convertCoordinates(sourceSystem, spz::CoordinateSystem::RUB);
+    }
+
+    printf("ParseSpzFile: loading %u gaussians from %s (spzVersion=%d, shDegree=%d, "
+           "source coords=%s -> RUB)\n",
+           numPoints, path.c_str(), fi.version, cloud.shDegree, fi.sourceSystem.c_str());
+    // stdout is block-buffered when redirected, and a viewer is usually ended by
+    // a kill, not a clean exit — an unflushed line is a line nobody ever sees.
+    fflush(stdout);
 
     // SH floats per point (beyond DC, which is stored in cloud.colors). Degree 4
     // is accepted but only its first 45 floats (bands 1–3) fit GsVertex; the

--- a/3dgs_common/gs_spz_loader.h
+++ b/3dgs_common/gs_spz_loader.h
@@ -23,10 +23,19 @@ struct SpzFileInfo {
     int         numPoints = 0;  //!< gaussians the header claims (0 when unknown)
     int         shDegree  = 0;  //!< spherical-harmonics degree the header claims
     std::string error;          //!< one-line failure reason, empty on success
+    //! Coordinate system the loader ASSUMED the on-disk bytes were in before
+    //! converting them to the app's canonical RUB. The SPZ container records no
+    //! such field, so this is the loader's policy choice, not a header read —
+    //! see the coordinate-systems section of gs_spz_loader.cpp's file comment.
+    std::string sourceSystem;
 };
 
 // Parse a Niantic SPZ file and return GPU-ready vertices.
-// Converts from SPZ's RUB coordinate system to PLY's RDF convention.
+// Converts the cloud into the app's canonical RUB (+X right, +Y up, +Z back).
+// The container carries no coordinate-system field, so the source system is
+// inferred from the container generation — legacy v1-v3 are RUB (Niantic's
+// writer), NGSP v4+ are RDF (@playcanvas/splat-transform bakes PLY space) —
+// and `DXR_SPZ_COORD_SYSTEM=rub|rdf` overrides that. See gs_spz_loader.cpp.
 // Applies: sigmoid(opacity), exp(scale), normalize(rotation), SH mapping.
 // Returns true on success. On failure, vertices is empty and, when `info` is
 // non-null, info->error carries a one-line reason naming the SPZ version.


### PR DESCRIPTION
The storefront's SPZ v4 splats (`gen/handbag_gen.spz`, `boot_gen.spz`, `tote_gen.spz`, all from `@playcanvas/splat-transform` 3.3.3) loaded **upside down** in this viewer — handles down, sole up — while the bundled `butterfly.spz` (v2) was upright and the same cloud renders upright on the web page as `.sog` via Spark.

## Root cause

**The SPZ container does not record its coordinate system.** The suspicion was that the v4 header's byte 15 (`… flags=0 reserved=5` on a legacy 16-byte read) was a `CoordinateSystem` field. It isn't. In upstream's 32-byte `NgspFileHeader` that byte is `numStreams`, and it reads **5** because a degree-0 file has five ZSTD streams — upstream's own log line on these files agrees:

```
[SPZ] loadSpzPacked (NGSP): version=4, numPoints=131072, shDegree=0, numStreams=5, tocByteOffset=32
```

Upstream's only coordinate metadata is an optional **extension block** gated behind `SPZ_BUILD_EXTENSIONS` — compiled out here, and `splat-extensions.h` isn't even in the tree at our pinned rev (`affd0ece`). These files carry `flags = 0`, so no extensions. `unpackGaussians()` therefore falls to its unconditional

```cpp
result.convertCoordinates(CoordinateSystem::RUB, o.to);   // "the bytes are RUB"
```

and the loader's `options.to = RUB` made that a **no-op**.

That assumption is right for Niantic's writer and wrong for `@playcanvas/splat-transform`, which bakes the cloud into `Transform.PLY` (`fromEulers(0, 0, 180)`) and then calls `saveSpz` with `from = CoordinateSystem::UNSPECIFIED` — an identity converter — so the on-disk bytes are **RDF**, not RUB. Its own source says so:

> splat-transform stores SPZ with no coordinate conversion: data is baked to PLY/RDF space before saving and written with `from: UNSPECIFIED` (the spz spec's default — the format carries no coordinate metadata) …

`RDF (6)` and `RUB (4)` differ by 180° about X (`flipP = (1, -1, -1)`) — exactly the flip that was showing. Decoding the positions out of `handbag_gen.spz` confirms it independently: the raw cloud is Y-down (the bag is upright only with Y negated).

## The fix

The source system is a **policy choice**, not a header read, so it is picked by container generation:

| container | writer in practice | assumed source |
|---|---|---|
| legacy gzip, v1–v3 | Niantic `saveSpz` | `RUB` — unchanged, `butterfly.spz` stays upright |
| NGSP/ZSTD, v4+ | `@playcanvas/splat-transform` | `RDF` → converted to `RUB` |

That reproduces what the web viewers show: the page loads the **same cloud** as `.sog` (`writeSogSource` bakes to `Transform.PLY` too) and rights it with `mesh.quaternion.set(1, 0, 0, 0)` — a 180° rotation about X, i.e. exactly RDF → RUB.

The conversion runs once per load through spz's own `GaussianCloud::convertCoordinates`, so rotations, scales and SH bands move with the positions; a hand-rolled position flip in the vertex loop would have left the quaternions behind. **There was no post-load flip to remove** — the loader's only other coordinate statement was the `options.to` it already passed.

The chosen system is named in the load log (flushed — a viewer is usually ended by a kill, and an unflushed line is a line nobody sees) and carried on `SpzFileInfo::sourceSystem`. `DXR_SPZ_COORD_SYSTEM=rub|rdf` overrides it for a file that breaks the rule — a raw-NGSP v4 straight out of Niantic's own writer would be RUB.

```
ParseSpzFile: loading 131072 gaussians from …/handbag_gen.spz (spzVersion=4, shDegree=0, source coords=RDF (+X right, +Y down, +Z front) -> RUB)
ParseSpzFile: loading 177132 gaussians from …/butterfly.spz  (spzVersion=2, shDegree=3, source coords=RUB (+X right, +Y up, +Z back) -> RUB)
```

## Verification (Leia SR panel, viewer's own `I`-key atlas capture)

| scene | capture | result |
|---|---|---|
| `handbag_gen.spz` **before** | `handbag_gen-2_atlas_2_2x1.png` | upside down — handles hanging down, feet up |
| `handbag_gen.spz` **after** | `handbag_gen-4_atlas_2_2x1.png` | upright, handles up, gold feet down, turn-lock clasp — matches `thumbs/handbag_gen.png` |
| `boot_gen.spz` after | `boot_gen-2_atlas_2_2x1.png` | upright, sole down, opening up |
| `tote_gen.spz` after | `tote_gen-2_atlas_2_2x1.png` | upright, straps up |
| `butterfly.spz` before | `butterfly-3_atlas_2_2x1.png` | upright |
| `butterfly.spz` after | `butterfly-5_atlas_2_2x1.png` | upright — **unchanged** |

Butterfly A/B is below the noise: pre-fix vs post-fix mean abs diff **5.2**, same-binary run-to-run noise floor **3.8**, and a vertical flip would be **19.1**. (The residual is eye-tracked viewer-pose jitter between runs.)

Pick/recenter still works on the converted cloud — a double-click at the window centre logs `Focus on splat (0.114, 0.055, 0.361)`. It needed no change: `pickGaussian` reads `pickData_`, built from the already-converted vertices. Neither did `display3d_view` — there is no `vulkan_flip_y` parameter in this repo; the Vulkan Y-down flip lives at the raster stage in `preprocess.comp` (W7 / #396) and is coordinate-convention-agnostic.

Also ran `--transparent --rect=300,300,900,900 handbag_gen.spz` once: window came up at the requested rect and wove (`weave: target=900x900 vp=(0,0 900x900) view=450x450`), no viewer left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZS571NBBnZ2n9d8CXtJwz
