### PR TITLE
fix(android): survive the recents freeform toggle — declare the multi-window config changes

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -115,11 +115,18 @@
             the head-tracking service handles all orientations; forcing portrait
             was our bug). configChanges keeps the NativeActivity alive across
             rotations (the surface resizes instead of the activity recreating).
+            screenLayout + smallestScreenSize also change when the task goes
+            FREEFORM (recents "freeform" button); without them Android relaunches
+            the activity, and the relaunch runs xrDestroySession while the main
+            thread is blocked in NativeActivity.onDestroy — a vendor-SDK shutdown
+            hang (CNSDK <= 0.10.66, LeiaInc/CNSDK#730) then wedges the app for
+            good. Declaring them (+ resizeableActivity) makes the toggle a resize.
         -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize|density|uiMode"
+            android:resizeableActivity="true"
             android:launchMode="singleTask">
             <meta-data
                 android:name="android.app.lib_name"


### PR DESCRIPTION
Same change as DisplayXR/displayxr-demo-modelviewer#120 (see that PR for the full diagnosis, backtrace and on-device verification).

`MainActivity` declares `screenLayout|smallestScreenSize|density|uiMode` in `configChanges` and `resizeableActivity="true"`, so the recents-card **freeform** toggle is a surface resize instead of an activity relaunch. The relaunch path hangs in `xrDestroySession → leia_core_release` on CNSDK ≤ 0.10.66 (upstream fix LeiaInc/CNSDK#730), which is why "nothing happens" when tapping the freeform icon.

**Verified on device: modelviewer only** (identical manifest shape). This repo's APK was not rebuilt/tested; the change is manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)