### PR TITLE
feat: chain the silhouette content mask for XR_DXR_depth_budget v3 (#100)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISPLAYXR_EXTENSIONS_INCLUDE_DIR "${_dxr_ext_includes}" CACHE PATH
 FetchContent_Declare(
     displayxr_common
     GIT_REPOSITORY https://github.com/DisplayXR/displayxr-common.git
-    GIT_TAG v2.11.1
+    GIT_TAG v2.13.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(displayxr_common)

--- a/openxr_includes/openxr/XR_DXR_depth_budget.h
+++ b/openxr_includes/openxr/XR_DXR_depth_budget.h
@@ -63,7 +63,7 @@ extern "C" {
 #endif
 
 #define XR_DXR_depth_budget 1
-#define XR_DXR_depth_budget_SPEC_VERSION 2
+#define XR_DXR_depth_budget_SPEC_VERSION 3
 #define XR_DXR_DEPTH_BUDGET_EXTENSION_NAME "XR_DXR_depth_budget"
 
 // Reserved 1004999xxx range, next free block after view_rig (…140-142).
@@ -72,6 +72,8 @@ extern "C" {
 //! App-reported content bounds, narrowing the analysis ROI (v2).
 #define XR_TYPE_CONTENT_BOUNDS_DXR ((XrStructureType)1004999261)
 #define XR_TYPE_EVENT_DATA_REAR_DEPTH_BUDGET_STATE_CHANGED_DXR ((XrStructureType)1004999262)
+//! App-reported content occupancy mask (v3) - the silhouette, not a box.
+#define XR_TYPE_CONTENT_MASK_DXR ((XrStructureType)1004999263)
 
 /*!
  * @brief Why the runtime is handing out the budget it is handing out.
@@ -141,19 +143,37 @@ typedef struct XrRearDepthBudgetDXR {
  * conflict lives in the band around the silhouette rather than strictly under
  * it. @ref marginNormalized is dilation the app asks for ON TOP of the
  * runtime's own default.
+ *
+ * The runtime also CLAMPS the region to the frame's 3D display zones. Outside
+ * a 3D zone nothing is woven, so measuring the desktop there answers a question
+ * about pixels the content can never occlude.
  */
 typedef struct XrContentBoundsDXR {
     XrStructureType          type;   //!< Must be XR_TYPE_CONTENT_BOUNDS_DXR
     const void* XR_MAY_ALIAS next;
     /*!
-     * CANVAS-NORMALISED: offset/extent in [0,1], origin top-left (u right, v
-     * DOWN — the same convention as the display processor's background-preview
-     * canvas rect and XrViewDisplayRawDXR::canvasRectPx). The union over ALL
-     * views of the projected content AABB. An extent <= 0, or any non-finite
-     * component, means "unknown" and the runtime measures the whole canvas.
+     * WINDOW-NORMALISED: offset/extent in [0,1], origin top-left (u right, v
+     * DOWN). The frame these normalise to is the APP WINDOW'S CLIENT RECT —
+     * the frame of the display processor's background preview — and NEVER a
+     * display zone's `canvasRectPx`.
+     *
+     * The union over ALL views of the projected content AABB. An extent <= 0,
+     * or any non-finite component, means "unknown" and the runtime measures the
+     * whole window.
+     *
+     * **A zoned app must rebase.** With XR_DXR_display_zones the app projects
+     * in the ZONE's view, clamps to [0,1] of the zone, and then rebases through
+     * that zone's window rect before reporting — `dxr::ProjectAabbToWindowBounds`
+     * / `dxr::RebaseZoneBoundsToWindow` in `displayxr-common` do both halves.
+     * Chaining zone-normalised bounds as if they were window-normalised aims the
+     * analysis at the wrong part of the window, typically at a Local2D 2D band
+     * the content never covers. The runtime additionally clamps the region to
+     * the frame's 3D display zones, so that mistake degrades to a coarser
+     * measurement rather than a wrong one — but the clamp is a defence, not the
+     * contract.
      */
     XrRect2Df bounds;
-    //! Extra dilation the app wants, in canvas-normalised units. 0 = the runtime default alone.
+    //! Extra dilation the app wants, in window-normalised units. 0 = the runtime default alone.
     float marginNormalized;
 } XrContentBoundsDXR;
 
@@ -173,6 +193,36 @@ typedef struct XrEventDataRearDepthBudgetStateChangedDXR {
     XrRearDepthBudgetStateDXR previousState;
     XrRearDepthBudgetStateDXR newState;
 } XrEventDataRearDepthBudgetStateChangedDXR;
+
+/*!
+ * v3 INPUT (SPEC_VERSION 3): the app's content OCCUPANCY MASK for this frame - the
+ * union over ALL views of its rendered silhouette (the same artefact a transparent
+ * app derives from alpha for its click-through window region). Chain on
+ * XrFrameEndInfo::next, beside or instead of XrContentBoundsDXR.
+ *
+ * Grid: row-major, top-left origin, WINDOW-CLIENT-normalised extent - cell (x, y)
+ * covers [x/width, (x+1)/width) x [y/height, (y+1)/height) of the window client
+ * rect (the same frame as XrContentBoundsDXR; a zoned app writes its zone's
+ * silhouette into the window grid and leaves the rest 0). nonzero = content
+ * occupies the cell. The runtime copies the cells during xrEndFrame; the pointer
+ * need only stay valid until xrEndFrame returns.
+ *
+ * Precedence in the runtime, most specific first, each falling back to the next
+ * when absent, all-zero or stale (> 1 s): mask -> XrContentBoundsDXR -> the 3D
+ * display zones -> the whole canvas. The runtime resamples the mask onto its
+ * own analysis grid with an any-coverage filter, clamps it to the 3D zones and
+ * dilates it by the disparity band before measuring; only masked pixels count.
+ */
+typedef struct XrContentMaskDXR {
+    XrStructureType          type;   //!< Must be XR_TYPE_CONTENT_MASK_DXR
+    const void* XR_MAY_ALIAS next;
+    uint32_t                 width;        //!< 1..512 cells
+    uint32_t                 height;       //!< 1..512 cells
+    uint32_t                 strideBytes;  //!< >= width
+    const uint8_t*           cells;        //!< width x height bytes, nonzero = occupied
+    //! Extra dilation the app wants, in window-normalised units. 0 = the runtime default alone.
+    float                    marginNormalized;
+} XrContentMaskDXR;
 
 #ifdef __cplusplus
 }

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -31,6 +31,7 @@
 #include "view_rig_math.h"
 #include "clip_policy.h"   // dxr::ResolveClipPlanes / ChainRearDepthBudget / RearDepthBudgetStateName (#100)
 #include "content_bounds.h" // dxr::ProjectAabbToCanvasBounds / ChainContentBounds (#100 v2 ROI)
+#include "content_mask.h"   // dxr::ContentMaskFromCoverage / ChainContentMask (#100 v3 silhouette ROI)
 #include <openxr/XR_DXR_view_rig.h>
 #include <openxr/XR_DXR_depth_budget.h>
 
@@ -2040,6 +2041,13 @@ static void RenderThreadFunc(
                         // sentinel (0) unless a runtime that recognizes the struct fills
                         // it in, which is how "filled" is told from "not".
                         const bool hasDepthBudgetExt = XrDepthBudgetExtAvailable();
+                        // #100 v3: the silhouette content-mask ROI (XrContentMaskDXR) is a
+                        // v3-only addition to XR_DXR_depth_budget — gate on the RUNTIME's
+                        // reported extensionVersion, never on this app's vendored header,
+                        // so a v3-built binary never chains a struct a v2 runtime can't
+                        // parse (brief §6.1/6.2).
+                        const bool hasContentMaskV3 =
+                            hasDepthBudgetExt && XrDepthBudgetExtVersion() >= 3;
                         XrRearDepthBudgetDXR depthBudget{};
                         if (hasDepthBudgetExt) {
                             dxr::ChainRearDepthBudget(viewState, depthBudget);
@@ -2211,6 +2219,10 @@ static void RenderThreadFunc(
                         static XrContentBoundsDXR s_contentBoundsChain{};
                         XrRect2Df contentBoundsRect{};
                         bool haveContentBounds = false;
+                        // #100 v3: set true below (after the click-through silhouette for
+                        // this frame is available) when XrContentMaskDXR was actually
+                        // chained — read by the HUD "rear:" line further down.
+                        bool haveContentMask = false;
                         if (hasDepthBudgetExt && useRig && eyeCount > 0) {
                             float aabbMin[3], aabbMax[3];
                             bool aabbValid;
@@ -2545,6 +2557,66 @@ static void RenderThreadFunc(
                                                    chromeCount ? chrome : nullptr, chromeCount,
                                                    (lastV % cols) * renderW, (lastV / cols) * renderH,
                                                    eyeCount > 1);
+
+                                    // #100 v3: reduce the click-through silhouette g_punch just
+                                    // computed into a XR_DXR_depth_budget content-mask ROI
+                                    // (brief §6) — this app already derives exactly this
+                                    // artefact for SetWindowRgn, so no second alpha readback.
+                                    // Only when the RUNTIME has advertised v3 (hasContentMaskV3);
+                                    // a v2 runtime keeps the v2 content-bounds rect as its ROI.
+                                    // coverage() lags one update() call and returns nullptr
+                                    // until the first region has actually been applied — skip
+                                    // the mask this frame rather than chain stale/absent data;
+                                    // the v2 bounds chain above is untouched either way.
+                                    if (hasContentMaskV3) {
+                                        const uint8_t* cov = g_punch.coverage();
+                                        const uint32_t covW = g_punch.coverageWidth();
+                                        const uint32_t covH = g_punch.coverageHeight();
+                                        if (cov != nullptr && covW > 0 && covH > 0 &&
+                                            windowW > 0 && windowH > 0) {
+                                            // ~1/4 of the coverage raster, capped at the
+                                            // extension's recommended ceiling (content_mask.h) —
+                                            // finer buys nothing, the runtime's own disparity-band
+                                            // dilation erases sub-cell detail anyway.
+                                            uint32_t maskW = covW / 4;
+                                            uint32_t maskH = covH / 4;
+                                            if (maskW < 1) maskW = 1;
+                                            if (maskH < 1) maskH = 1;
+                                            if (maskW > dxr::kContentMaskRecommendedCells)
+                                                maskW = dxr::kContentMaskRecommendedCells;
+                                            if (maskH > dxr::kContentMaskRecommendedCells)
+                                                maskH = dxr::kContentMaskRecommendedCells;
+
+                                            // Static: ChainContentMask stores a pointer into this
+                                            // buffer that must stay valid through xrEndFrame further
+                                            // down this same frame; a function-local static (like
+                                            // s_contentBoundsChain above) avoids a dangling temporary
+                                            // without adding file-scope state.
+                                            static std::vector<uint8_t> s_contentMaskCells;
+                                            static XrContentMaskDXR s_contentMaskChain{};
+                                            // srcRectPx = nullptr: g_punch's coverage raster already
+                                            // covers the whole window client rect (no 3D zones in
+                                            // this app), matching ContentMaskFromCoverage's default.
+                                            if (dxr::ContentMaskFromCoverage(cov, covW, covH, covW,
+                                                    windowW, windowH, /*srcRectPx=*/nullptr,
+                                                    maskW, maskH, s_contentMaskCells) &&
+                                                dxr::ContentMaskCoverageCells(s_contentMaskCells) > 0) {
+                                                // Chain the mask FIRST, then let it point at
+                                                // whatever frameEndNext already carries (the v2
+                                                // content-bounds struct, when present) — bounds
+                                                // stays chained regardless (brief §6.4 "keep bounds
+                                                // always"); the runtime's own ROI precedence (mask,
+                                                // then bounds) doesn't depend on chain order.
+                                                XrFrameEndInfo maskChainProxy{};
+                                                maskChainProxy.next = frameEndNext;
+                                                if (dxr::ChainContentMask(maskChainProxy, s_contentMaskChain,
+                                                        s_contentMaskCells, maskW, maskH)) {
+                                                    frameEndNext = maskChainProxy.next;
+                                                    haveContentMask = true;
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             } else if (g_punch.shaped()) {
                                 g_punch.disable(hwnd);
@@ -2650,16 +2722,22 @@ static void RenderThreadFunc(
                                     const float rbFarOffsetVH = depthBudgetPtr ? depthBudgetPtr->farOffsetVH : 0.0f;
                                     const XrRearDepthBudgetStateDXR rbState = depthBudgetPtr
                                         ? depthBudgetPtr->state : XR_REAR_DEPTH_BUDGET_STATE_CLIPPED_NO_SOURCE_DXR;
-                                    wchar_t rbBuf[160];
+                                    wchar_t rbBuf[192];
+                                    // #100 v3: " mask" appended when XrContentMaskDXR was
+                                    // actually chained this frame (haveContentMask) — the
+                                    // silhouette ROI, not just the v2 bounds rect, reached
+                                    // the runtime.
                                     if (haveContentBounds) {
-                                        swprintf(rbBuf, 160, L"\nrear: %hs %.2fvH roi %.2f,%.2f-%.2f,%.2f",
+                                        swprintf(rbBuf, 192, L"\nrear: %hs %.2fvH roi %.2f,%.2f-%.2f,%.2f%hs",
                                             dxr::RearDepthBudgetStateName(rbState), rbFarOffsetVH,
                                             contentBoundsRect.offset.x, contentBoundsRect.offset.y,
                                             contentBoundsRect.offset.x + contentBoundsRect.extent.width,
-                                            contentBoundsRect.offset.y + contentBoundsRect.extent.height);
+                                            contentBoundsRect.offset.y + contentBoundsRect.extent.height,
+                                            haveContentMask ? " mask" : "");
                                     } else {
-                                        swprintf(rbBuf, 160, L"\nrear: %hs %.2fvH",
-                                            dxr::RearDepthBudgetStateName(rbState), rbFarOffsetVH);
+                                        swprintf(rbBuf, 192, L"\nrear: %hs %.2fvH%hs",
+                                            dxr::RearDepthBudgetStateName(rbState), rbFarOffsetVH,
+                                            haveContentMask ? " mask" : "");
                                     }
                                     stereoText += rbBuf;
                                 }

--- a/windows/xr_session.cpp
+++ b/windows/xr_session.cpp
@@ -25,6 +25,16 @@ static bool s_hasDepthBudgetExt = false;
 
 bool XrDepthBudgetExtAvailable() { return s_hasDepthBudgetExt; }
 
+// The runtime-reported extensionVersion (#100 v3 / brief §6): a v2 runtime
+// supports XrRearDepthBudgetDXR + XrContentBoundsDXR only, so the silhouette
+// content-mask path (XrContentMaskDXR) must gate on this being >= 3 rather
+// than on the app's own vendored header — an app built against the v3 header
+// against an older runtime must never chain a struct that runtime doesn't
+// know about. Stored next to s_hasDepthBudgetExt for the same reason.
+static uint32_t s_depthBudgetExtVersion = 0;
+
+uint32_t XrDepthBudgetExtVersion() { return s_depthBudgetExtVersion; }
+
 // INV-1.3 / runtime#715: 3D panel top-left in OS virtual-desktop pixels
 // (top-down, origin = primary monitor top-left), from
 // XrDisplayDesktopPositionDXR (XR_DXR_display_info spec v16). (0,0) =
@@ -104,6 +114,7 @@ bool InitializeOpenXR(XrSessionManager& xr) {
         }
         if (strcmp(ext.extensionName, XR_DXR_DEPTH_BUDGET_EXTENSION_NAME) == 0) {
             s_hasDepthBudgetExt = true;
+            s_depthBudgetExtVersion = ext.extensionVersion;
         }
     }
 
@@ -114,7 +125,8 @@ bool InitializeOpenXR(XrSessionManager& xr) {
     LOG_INFO("XR_DXR_atlas_capture: %s", xr.hasAtlasCaptureExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_view_rig: %s", s_hasViewRigExt ? "AVAILABLE" : "NOT FOUND");
     LOG_INFO("XR_DXR_mcp_tools: %s", xr.hasMcpToolsExt ? "AVAILABLE" : "NOT FOUND");
-    LOG_INFO("XR_DXR_depth_budget: %s", s_hasDepthBudgetExt ? "AVAILABLE" : "NOT FOUND");
+    LOG_INFO("XR_DXR_depth_budget: %s (v%u)", s_hasDepthBudgetExt ? "AVAILABLE" : "NOT FOUND",
+        s_depthBudgetExtVersion);
 
     if (!hasVulkan) {
         LOG_ERROR("XR_KHR_vulkan_enable2 extension not available");

--- a/windows/xr_session.h
+++ b/windows/xr_session.h
@@ -27,6 +27,14 @@ bool XrViewRigExtAvailable();
 // hand-rolled clip rule otherwise (dxr::ResolveClipPlanes(budget=nullptr, ...)).
 bool XrDepthBudgetExtAvailable();
 
+// The runtime's reported XR_DXR_depth_budget extensionVersion (#100 v3). A v2
+// runtime supports XrRearDepthBudgetDXR + XrContentBoundsDXR but NOT
+// XrContentMaskDXR — callers must gate the silhouette content-mask ROI on
+// this being >= 3, never on the app's own vendored header version, since an
+// app built against the v3 header can still run against an older runtime.
+// Returns 0 when the extension itself is unavailable.
+uint32_t XrDepthBudgetExtVersion();
+
 // INV-1.3 / runtime#715: 3D panel top-left in virtual-desktop pixels from
 // XrDisplayDesktopPositionDXR (display_info v16), filled by InitializeOpenXR.
 // (0,0) = primary/unknown (safe default, incl. on older runtimes). Demo-side


### PR DESCRIPTION
## Summary

Adds the v3 silhouette content-mask ROI to `XR_DXR_depth_budget` (design brief §6) on top of
v1.25.2's already-shipped v2 `XrContentBoundsDXR` support.

- Vendors `openxr_includes/openxr/XR_DXR_depth_budget.h` verbatim from
  `displayxr-runtime@feat/depth-budget-v3-content-mask` (`SPEC_VERSION 3`, adds
  `XrContentMaskDXR` / `XR_TYPE_CONTENT_MASK_DXR`).
- Bumps `common/CMakeLists.txt`'s displayxr-common pin `v2.11.1` → `v2.13.0`, which adds
  `common/content_mask.h` (`dxr::ContentMaskFromCoverage`, `ContentMaskCoverageCells`,
  `ChainContentMask`) and a `coverage()` accessor on `ClickThroughRegion`
  (`common/vk_clickthrough_region.h`). Diffed `v2.11.1..v2.13.0 --stat` — purely additive,
  no existing call sites this app uses were touched.

## Coverage source

This app already runs `dxr::ClickThroughRegion` (`g_punch`) every frame under Ctrl+T
transparent + borderless mode to build its `SetWindowRgn` click-through silhouette — that IS
the artefact v3 wants as its analysis ROI, so no second alpha readback is needed.
`g_punch.coverage()` / `coverageWidth()` / `coverageHeight()` (v2.13.0) feed straight into
`dxr::ContentMaskFromCoverage`.

## Wiring

- `windows/xr_session.{h,cpp}`: stores the runtime-reported `XR_DXR_depth_budget`
  `extensionVersion` (`XrDepthBudgetExtVersion()`) next to the existing enable flag. The mask
  path gates on this being `>= 3` — never on this app's own vendored header — so a v3-built
  binary run against a v2 (or absent) runtime never chains a struct that runtime can't parse.
- `windows/main.cpp`: right after `g_punch.update()` computes this frame's click-through
  coverage, reads `coverage()`/`coverageWidth()`/`coverageHeight()`, reduces to `<= 256x256`
  (~1/4 of the coverage raster, capped at `content_mask.h`'s recommended cell ceiling), and —
  only when `ContentMaskCoverageCells() > 0` — chains `XrContentMaskDXR` via
  `ChainContentMask` ahead of the existing v2 `XrContentBoundsDXR` (bounds stays chained
  regardless, per brief §6.4 "keep bounds always"). `coverage()` returning `nullptr` (no
  region applied yet, or standalone/opaque mode where the click-through path never runs) just
  skips the mask for that frame — the v2 bounds chain is untouched either way. The mask cells
  buffer is a function-local `static std::vector<uint8_t>` so the pointer `ChainContentMask`
  stores stays valid through `xrEndFrame` later in the same frame. The HUD `rear:` line
  appends ` mask` when the mask was actually chained this frame.

## Build / lint

- `scripts\build-with-deps.bat x64` (short 8.3 path, `cmd.exe //c`) — `=== DONE: ... ===`,
  no `error C`. Confirmed `displayxr-common` resolved at `v2.13.0` with `content_mask.h`
  present in `build/_deps/displayxr_common-src/common/`.
- `scripts/check_displayxr_app.py` on the worktree: 1 error / 0 warnings, identical to a
  fresh clone of `main` (pre-existing `linux/main.cpp` INV-5.9 vulkan_enable1 finding + the
  Android manifest INV-1.4 info line) — no new findings from this change.
- Windows-only change (`windows/`); `macos/`, `linux/`, `android/` untouched, so those legs
  keep compiling as-is.

## Not done here

Panel eyeball owed — needs a Leia SR display to confirm the runtime side actually narrows
the rear-depth analysis to the silhouette. **Requires runtime PR #1383** (the v3
`XR_DXR_depth_budget` runtime implementation) to be merged and released before the mask has
any effect; against an older/absent runtime this app degrades cleanly to the v2 bounds ROI
(or v1 whole-canvas, on an even older runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7EQer77eKb622ufZ9u7ZR
