### PR TITLE
feat(android): adopt the DisplayXR client wake library; delete our own

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -71,16 +71,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-
-      # The wake library is a release asset on the runtime repo, not a Maven artifact
-      # (the org's GitHub Packages budget is a $0 hard stop). Gradle deliberately does
-      # NOT download it during configuration -- a configure phase that reaches the
-      # network breaks offline builds -- so it is fetched here, before the build. The
-      # script needs no credential: the runtime repo is public, and this job's
-      # GITHUB_TOKEN is not a credential for it anyway.
-      - name: Fetch the DisplayXR client wake library
-        if: needs.DetectChanges.outputs.docs_only != 'true'
-        run: ./android/fetch-client-aar.sh
       - name: Doc-only short-circuit
         if: needs.DetectChanges.outputs.docs_only == 'true'
         run: echo "docs_only=true; build steps will skip and report success."
@@ -111,6 +101,16 @@ jobs:
           echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
           echo "ANDROID_KEYSTORE_FILE=$RUNNER_TEMP/release.jks" >> "$GITHUB_ENV"
 
+
+      # The wake library is a release asset on the runtime repo, not a Maven artifact
+      # (the org's GitHub Packages budget is a $0 hard stop). Gradle deliberately does
+      # NOT download it during configuration -- a configure phase that reaches the
+      # network breaks offline builds -- so it is fetched here, before the build. The
+      # script needs no credential: the runtime repo is public, and this job's
+      # GITHUB_TOKEN is not a credential for it anyway.
+      - name: Fetch the DisplayXR client wake library
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: ./android/fetch-client-aar.sh
       - name: Build release APK
         if: needs.DetectChanges.outputs.docs_only != 'true'
         env:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -71,6 +71,16 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+
+      # The wake library is a release asset on the runtime repo, not a Maven artifact
+      # (the org's GitHub Packages budget is a $0 hard stop). Gradle deliberately does
+      # NOT download it during configuration -- a configure phase that reaches the
+      # network breaks offline builds -- so it is fetched here, before the build. The
+      # script needs no credential: the runtime repo is public, and this job's
+      # GITHUB_TOKEN is not a credential for it anyway.
+      - name: Fetch the DisplayXR client wake library
+        if: needs.DetectChanges.outputs.docs_only != 'true'
+        run: ./android/fetch-client-aar.sh
       - name: Doc-only short-circuit
         if: needs.DetectChanges.outputs.docs_only == 'true'
         run: echo "docs_only=true; build steps will skip and report success."

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ local.properties
 
 # Claude Code local worktrees / scratch
 .claude/
+
+# Fetched by android/fetch-client-aar.sh from the pinned runtime release.
+# A binary that is already published elsewhere must not be vendored here: it would
+# drift from dxrClientRuntimeTag silently, which is the whole failure this replaces.
+android/libs/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -100,7 +100,63 @@ android {
     }
 }
 
+// ---------------------------------------------------------------------------
+// DisplayXR client wake library.
+//
+// WHY THIS APP NEEDS IT. On some OEM Android builds a client cannot reach the
+// runtime at all until the runtime has been started once: the vendor's
+// AutoLaunchManagerService refuses "related start" of another package's
+// components, and the Khronos loader's broker lookup is a ContentProvider start.
+// Measured on a Lume Phone (runtime#1453): 12 broker queries, 6
+// `Provider RelatedStart BlockResult = true`, the broker answered 0 times, and
+// the app fell through to "open the DisplayXR app once". With the runtime
+// pre-started by an activity the same launch takes 1 query, 0 blocks, and
+// xrCreateInstance returns XR_SUCCESS.
+//
+// This app used to carry its own wakeRuntime() -- as all five demos did, all
+// using startService, all swallowing the exception, so a wake that never worked
+// looked like it did. The library replaces that with one implementation that
+// ships with the runtime.
+//
+// It is an AAR because its MANIFEST is load-bearing: the <queries> entries
+// (without which Android 11+ package visibility hides the runtime) and the
+// androidx.startup provider registration that makes the wake automatic. Source
+// copies would have to replicate both by hand.
+//
+// Resolution order, most specific first:
+//   1. -PdxrClientAar=<path>  or  DXR_CLIENT_AAR=<path>   -- dev loop against a
+//      runtime checkout: src/xrt/targets/displayxr_client/build/outputs/aar/…
+//   2. android/libs/DisplayXR-Client-*.aar                -- fetched by
+//      ./android/fetch-client-aar.sh, which pulls the asset from the pinned
+//      runtime release below.
+// Deliberately NO download at configuration time: a Gradle configure phase that
+// reaches the network fails in offline builds and in CI without a token.
+ext.dxrClientRuntimeTag = 'v2.16.28'
+
+def resolveDxrClientAar = {
+    def explicit = project.findProperty('dxrClientAar') ?: System.getenv('DXR_CLIENT_AAR')
+    if (explicit) {
+        def f = file(explicit)
+        if (!f.exists()) throw new GradleException("DXR_CLIENT_AAR points at a missing file: $f")
+        return f
+    }
+    def libs = file('libs')
+    def found = libs.exists() ? libs.listFiles({ d, n -> n.startsWith('DisplayXR-Client-') && n.endsWith('.aar') } as FilenameFilter) : null
+    if (found != null && found.length > 0) return found.sort { it.name }.last()
+    throw new GradleException(
+        "DisplayXR client wake library not found.\n" +
+        "  Fetch the pinned release asset:  ./android/fetch-client-aar.sh\n" +
+        "  or point at a local runtime build: -PdxrClientAar=<runtime>/src/xrt/targets/displayxr_client/build/outputs/aar/displayxr_client-release.aar")
+}
+
 dependencies {
+
+    implementation files(resolveDxrClientAar())
+    // MUST be declared here. An AAR consumed through files() carries no POM, so
+    // none of its transitive dependencies come with it -- and androidx.startup is
+    // what instantiates the library's initializer. Omit this and the provider class
+    // is simply absent at runtime: no crash, no log, the wake just never happens.
+    implementation 'androidx.startup:startup-runtime:1.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     // Khronos OpenXR loader for Android — bundles libopenxr_loader.so +

--- a/android/fetch-client-aar.sh
+++ b/android/fetch-client-aar.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Fetch the DisplayXR client wake library AAR pinned by android/build.gradle.
+#
+# The library ships as a release asset on the runtime repo (no Maven: the org's
+# GitHub Packages budget is pinned at $0 with a hard stop, so publishing there
+# would break every workflow in the org, not just this one).
+#
+#   ./android/fetch-client-aar.sh            # the pinned tag
+#   ./android/fetch-client-aar.sh v2.16.29   # a specific tag
+set -euo pipefail
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TAG="${1:-$(grep -oE "dxrClientRuntimeTag *= *'[^']+'" "$HERE/build.gradle" | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+")}"
+[ -n "$TAG" ] || { echo "Could not read dxrClientRuntimeTag from build.gradle" >&2; exit 1; }
+mkdir -p "$HERE/libs"
+# Remove older copies so the gradle resolver cannot pick a stale one.
+rm -f "$HERE"/libs/DisplayXR-Client-*.aar
+
+VER="${TAG#v}"
+ASSET="DisplayXR-Client-${VER}.aar"
+
+# gh when it is available and authenticated; otherwise a plain HTTPS download.
+# The runtime repo is PUBLIC, so its release assets need no credential -- and CI
+# here has only this repo's GITHUB_TOKEN, which is not a credential for another
+# repository. Requiring gh auth would make the fallback path the common one.
+if command -v gh >/dev/null && gh auth status >/dev/null 2>&1 \
+   && gh release download "$TAG" -R DisplayXR/displayxr-runtime -p "$ASSET" -D "$HERE/libs" 2>/dev/null; then
+    echo "fetched $ASSET via gh"
+else
+    URL="https://github.com/DisplayXR/displayxr-runtime/releases/download/${TAG}/${ASSET}"
+    echo "fetching $URL"
+    curl -fsSL --retry 3 -o "$HERE/libs/$ASSET" "$URL" \
+      || { echo "Could not download $ASSET from $TAG." >&2
+           echo "  Check that the release exists and carries that asset:" >&2
+           echo "    gh release view $TAG -R DisplayXR/displayxr-runtime" >&2
+           rm -f "$HERE/libs/$ASSET"; exit 1; }
+fi
+# An HTML error page saved as a .aar is the classic silent failure here: gradle
+# would then fail with an unhelpful zip error far from the cause.
+unzip -l "$HERE/libs/$ASSET" >/dev/null 2>&1 \
+  || { echo "$ASSET is not a valid archive -- the download returned something else." >&2
+       rm -f "$HERE/libs/$ASSET"; exit 1; }
+ls -la "$HERE/libs"

--- a/android/src/main/java/com/displayxr/gausssplat_vk_android/MainActivity.kt
+++ b/android/src/main/java/com/displayxr/gausssplat_vk_android/MainActivity.kt
@@ -155,29 +155,23 @@ class MainActivity : NativeActivity() {
         }
     }
 
-    // Wake the DisplayXR runtime package before xrCreateInstance. After a
-    // force-stop / fresh install the runtime is in Android's "stopped" state,
-    // so the OpenXR loader's broker lookup excludes it → XR_ERROR_RUNTIME_
-    // UNAVAILABLE on a cold tap. Sending an explicit intent with
-    // FLAG_INCLUDE_STOPPED_PACKAGES clears the stopped flag so the broker
-    // becomes discoverable. (Test-harness convenience — real apps assume the
-    // runtime was already launched once.)
-    private fun wakeRuntime() {
-        try {
-            val intent = Intent("org.khronos.openxr.OpenXRRuntimeService").apply {
-                `package` = "org.freedesktop.monado.openxr_runtime.out_of_process"
-                addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-            }
-            startService(intent)
-        } catch (_: Throwable) {
-            // Best-effort; the native side retries xrCreateInstance.
-        }
-    }
+    // The runtime wake used to live here, as a private wakeRuntime() using
+    // startService with a silent catch. It never worked: startService is refused
+    // from a background context by Android 8+ limits, and on OEM builds that block
+    // "related start" of another package's components no service API works at all --
+    // but the swallowed exception made it look like it did. All five demos shipped
+    // that same code, which is why it stayed invisible for so long.
+    //
+    // It is now the displayxr_client library, which ships with the runtime and starts
+    // the runtime's no-display WakeActivity -- the one gesture those OEM policies
+    // permit. The library registers itself through androidx.startup, so there is
+    // deliberately NOTHING to call from here: adding a call site back is how the five
+    // copies happened. See runtime#1453 / #1454.
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Do NOT lock orientation — let all four orientations through.
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
-        wakeRuntime()
         super.onCreate(savedInstanceState)
         pushRotation()
         (getSystemService(Context.DISPLAY_SERVICE) as DisplayManager)


### PR DESCRIPTION
This app carried its own `wakeRuntime()`: `startService` wrapped in a silent `catch (_: Throwable)`. **It never worked.** `startService` is refused from a background context by Android 8+ limits, and on OEM builds that block "related start" of another package's components no service API works at all — the swallowed exception just made it look like it did. All five demos shipped that same code.

Replaced by the `displayxr_client` library, which ships with the runtime as a release asset. Part of the rollout tracked in [runtime#1462](https://github.com/DisplayXR/displayxr-runtime/issues/1462); `displayxr-demo-modelviewer` was the first adopter and is the worked example.

## Measured on a Lume Phone

Same runtime build, cold launch, runtime force-stopped:

| | broker queries | `Provider RelatedStart BlockResult = true` | broker answered | result |
|---|---|---|---|---|
| hand-rolled wake | 12 | 6 | **0** | `XR_ERROR_RUNTIME_UNAVAILABLE` |
| library | 1 | **0** | 1 | `xrCreateInstance -> XR_SUCCESS` |

That A/B also settled the root cause: it is **not** `FLAG_STOPPED`. The vendor's `AutoLaunchManagerService` blocks related start of the broker **ContentProvider** itself. Pre-starting the runtime with an activity — the one gesture those policies permit — means the provider needs no start, so there is nothing left to block.

## There is deliberately nothing to call

The library registers through `androidx.startup`, so `onCreate` has no wake call any more. Re-adding a call site is how five hand-rolled copies happened; the comment left in `MainActivity` says so.

## Two consumption traps, both silent

Documented at the call site because neither produces an error:

- **`androidx.startup` must be declared by this app.** An AAR consumed through `files()` carries no POM, so no transitive dependency comes with it — and `androidx.startup` is what instantiates the initializer. Omit it and the provider class is simply absent at runtime: no crash, no log, no wake.
- **Nothing reaches the network at configuration time.** The AAR resolves from `-PdxrClientAar` / `DXR_CLIENT_AAR` (dev loop against a runtime checkout) or `android/libs/`, populated by `./android/fetch-client-aar.sh` in a CI step before the build. That script needs no credential — the runtime repo is public — and it rejects a download that is not a valid archive, because an HTML error page saved as a `.aar` otherwise fails much later with an unhelpful zip error.

## Verified here

The APK builds, and `aapt2` confirms the library's `<queries>`, the `InitializationProvider` under this app's own authority, and the `RuntimeWakeInitializer` meta-data are merged into its manifest.

Requires runtime **v2.16.28** or later — the release carrying `DisplayXR-Client-*.aar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1B9cNKHwa2SJo9aKkSDEZ
